### PR TITLE
grcqt: Add double click to add block and simplify tests

### DIFF
--- a/grc/gui_qt/Utils.py
+++ b/grc/gui_qt/Utils.py
@@ -1,6 +1,7 @@
 import cairo
 
 import logging
+from pathlib import Path
 
 from qtpy import QtGui, QtCore, QtWidgets, QtSvg
 
@@ -8,6 +9,7 @@ from . import Constants
 from .components.canvas.colors import FLOWGRAPH_BACKGROUND_COLOR
 
 log = logging.getLogger(__name__)
+
 
 def get_rotated_coordinate(coor, rotation):
     """
@@ -21,35 +23,40 @@ def get_rotated_coordinate(coor, rotation):
     # handles negative angles
     rotation = (rotation + 360) % 360
     if rotation not in Constants.POSSIBLE_ROTATIONS:
-        raise ValueError('unusable rotation angle "%s"'%str(rotation))
+        raise ValueError('unusable rotation angle "%s"' % str(rotation))
     # determine the number of degrees to rotate
     cos_r, sin_r = {
-        0: (1, 0), 90: (0, 1), 180: (-1, 0), 270: (0, -1),
+        0: (1, 0),
+        90: (0, 1),
+        180: (-1, 0),
+        270: (0, -1),
     }[rotation]
     x, y = coor
     return x * cos_r + y * sin_r, -x * sin_r + y * cos_r
 
+
 def make_screenshot(fg_view, file_path, transparent_bg=False):
     if not file_path:
         return
-    if file_path.endswith(".png"):
+    file_path = Path(file_path)
+    if file_path.suffix == ".png":
         rect = fg_view.viewport().rect()
 
         pixmap = QtGui.QPixmap(rect.size())
         painter = QtGui.QPainter(pixmap)
 
         fg_view.render(painter, QtCore.QRectF(pixmap.rect()), rect)
-        pixmap.save(file_path,"PNG")
+        pixmap.save(str(file_path), "PNG")
         painter.end()
-    elif file_path.endswith(".svg"):
+    elif file_path.suffix == ".svg":
         rect = fg_view.viewport().rect()
 
         generator = QtSvg.QSvgGenerator()
-        generator.setFileName(file_path)
+        generator.setFileName(str(file_path))
         generator.setSize(rect.size())
         painter = QtGui.QPainter(generator)
         fg_view.render(painter)
         painter.end()
-    elif file_path.endswith(".pdf"):
+    elif file_path.suffix == ".pdf":
         log.warning("PDF screen capture not implemented")
-        return # TODO
+        return  # TODO

--- a/grc/gui_qt/components/block_library.py
+++ b/grc/gui_qt/components/block_library.py
@@ -33,30 +33,24 @@ from .. import base
 # Logging
 log = logging.getLogger(__name__)
 
+
 class BlockSearchBar(QtWidgets.QLineEdit):
     def __init__(self, parent):
         QtWidgets.QLineEdit.__init__(self)
         self.parent = parent
-        self.setObjectName('block_library::search_bar')
-        self.returnPressed.connect(self.add_block)
+        self.setObjectName("block_library::search_bar")
+        self.returnPressed.connect(self.on_return_pressed)
 
-    def add_block(self):
+    def on_return_pressed(self):
         label = self.text()
         if label in self.parent._block_tree_flat:
-            fg = self.parent.app.MainWindow.currentFlowgraph
             block_key = self.parent._block_tree_flat[label].key
-            id = fg._get_unique_id(block_key)
-
-            block = fg.new_block(block_key)
-            block.params['id'].set_value(id)
-            fg.addItem(block)
-            block.moveToTop()
-            fg.update()
-            # TODO: Move it to the middle of the view
-            self.setText('')
+            self.parent.add_block(block_key)
+            self.setText("")
             self.parent.populate_tree(self.parent._block_tree)
         else:
-            log.info(f'No block named {label}')
+            log.info(f"No block named {label}")
+
 
 def get_items(model):
     items = []
@@ -65,14 +59,19 @@ def get_items(model):
         items.append(model.data(index))
     return items
 
+
 class LibraryView(QtWidgets.QTreeView):
     # TODO: Use selectionChanged() or something instead
     # so we can use arrow keys too
     def updateDocTab(self):
         label = self.model().data(self.currentIndex())
         if label in self.parent().parent()._block_tree_flat:
-            prefix = str(self.parent().parent().app.platform.config.wiki_block_docs_url_prefix)
-            self.parent().parent().app.WikiTab.setURL(QUrl(prefix + label.replace(" ", "_")))
+            prefix = str(
+                self.parent().parent().app.platform.config.wiki_block_docs_url_prefix
+            )
+            self.parent().parent().app.WikiTab.setURL(
+                QUrl(prefix + label.replace(" ", "_"))
+            )
 
     def handle_clicked(self):
         if self.isExpanded(self.currentIndex()):
@@ -80,14 +79,14 @@ class LibraryView(QtWidgets.QTreeView):
         else:
             self.expand(self.currentIndex())
 
-class BlockLibrary(QtWidgets.QDockWidget, base.Component):
 
+class BlockLibrary(QtWidgets.QDockWidget, base.Component):
     def __init__(self):
         QtWidgets.QDockWidget.__init__(self)
         base.Component.__init__(self)
 
-        self.setObjectName('block_library')
-        self.setWindowTitle('Block Library')
+        self.setObjectName("block_library")
+        self.setWindowTitle("Block Library")
 
         # TODO: Pull from preferences and revert to default if not found?
         self.resize(400, 300)
@@ -97,11 +96,11 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
 
         # Create the layout widget
         container = QtWidgets.QWidget(self)
-        container.setObjectName('block_library::container')
+        container.setObjectName("block_library::container")
         self._container = container
 
         layout = QtWidgets.QVBoxLayout(container)
-        layout.setObjectName('block_library::layout')
+        layout.setObjectName("block_library::layout")
         layout.setSpacing(0)
         layout.setContentsMargins(5, 0, 5, 5)
         self._layout = layout
@@ -110,23 +109,24 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
         self._model = QtGui.QStandardItemModel()
 
         library = LibraryView(container)
-        library.setObjectName('block_library::library')
+        library.setObjectName("block_library::library")
         library.setModel(self._model)
         library.setDragEnabled(True)
         library.setDragDropMode(QtWidgets.QAbstractItemView.DragOnly)
-        #library.setColumnCount(1)
+        # library.setColumnCount(1)
         library.setHeaderHidden(True)
         # Expand categories with a single click
         library.clicked.connect(library.handle_clicked)
         library.selectionModel().selectionChanged.connect(library.updateDocTab)
-        #library.headerItem().setText(0, "Blocks")
+        library.doubleClicked.connect(
+            lambda block: self.add_block(block.data(QtCore.Qt.UserRole))
+        )
+        # library.headerItem().setText(0, "Blocks")
         self._library = library
 
         search_bar = BlockSearchBar(self)
         search_bar.setPlaceholderText("Find a block")
         self._search_bar = search_bar
-
-
 
         # Add widgets to the component
         layout.addWidget(search_bar)
@@ -137,9 +137,9 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
 
         ### Translation support
 
-        #self.setWindowTitle(_translate("blockLibraryDock", "Library", None))
-        #library.headerItem().setText(0, _translate("blockLibraryDock", "Blocks", None))
-        #QtCore.QMetaObject.connectSlotsByName(blockLibraryDock)
+        # self.setWindowTitle(_translate("blockLibraryDock", "Library", None))
+        # library.headerItem().setText(0, _translate("blockLibraryDock", "Blocks", None))
+        # QtCore.QMetaObject.connectSlotsByName(blockLibraryDock)
 
         ### Loading blocks
 
@@ -154,7 +154,11 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
         completer.setFilterMode(QtCore.Qt.MatchContains)
         self._search_bar.setCompleter(completer)
 
-        self._search_bar.textChanged.connect(lambda x: self.populate_tree(self._block_tree, get_items(completer.completionModel())))
+        self._search_bar.textChanged.connect(
+            lambda x: self.populate_tree(
+                self._block_tree, get_items(completer.completionModel())
+            )
+        )
 
         # TODO: Move to the base controller and set actions as class attributes
         # Automatically create the actions, menus and toolbars.
@@ -170,14 +174,15 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
         # Register the dock widget through the AppController.
         # The AppController then tries to find a saved dock location from the preferences
         # before calling the MainWindow Controller to add the widget.
-        self.app.registerDockWidget(self, location=self.settings.window.BLOCK_LIBRARY_DOCK_LOCATION)
+        self.app.registerDockWidget(
+            self, location=self.settings.window.BLOCK_LIBRARY_DOCK_LOCATION
+        )
 
         # Register the menus
-        #self.app.registerMenu(self.menus["library"])
+        # self.app.registerMenu(self.menus["library"])
 
     def createActions(self, actions):
         pass
-
 
     def createMenus(self, actions, menus):
         pass
@@ -186,7 +191,7 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
         pass
 
     def load_blocks(self):
-        ''' Load the block tree from the platform and populate the widget. '''
+        """Load the block tree from the platform and populate the widget."""
         # Loop through all of the blocks and create the nested hierarchy (this can be unlimited nesting)
         # This takes advantage of Python's use of references to move through the nested layers
 
@@ -195,9 +200,9 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
         for block in six.itervalues(self.app.platform.blocks):
             if block.category:
                 # Blocks with None category should be left out for whatever reason (e.g. not installed)
-                #print(block.category) # in list form, e.g. ['Core', 'Digital Television', 'ATSC']
-                #print(block.label) # label GRC uses to name block
-                #print(block.key) # actual block name (i.e. class name)
+                # print(block.category) # in list form, e.g. ['Core', 'Digital Television', 'ATSC']
+                # print(block.label) # label GRC uses to name block
+                # print(block.key) # actual block name (i.e. class name)
 
                 # Create a copy of the category list so things can be removed without changing the original list
                 category = block.category[:]
@@ -219,8 +224,16 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
         # Save a reference to the block tree in case it is needed later
         self._block_tree = block_tree
 
+    def add_block(self, block_key):
+        """Add a block by its key."""
+        if block_key is None:
+            return
+
+        fg = self.app.MainWindow.currentFlowgraph
+        fg.add_block(block_key)
+
     def populate_tree(self, block_tree, v_blocks=None):
-        ''' Populate the item model and tree view with the hierarchical block tree. '''
+        """Populate the item model and tree view with the hierarchical block tree."""
         # Recursive method of populating the QStandardItemModel
         # Since the _model.invisibleRootItem is the initial parent, this will populate
         # the model which is used for the TreeView.
@@ -231,14 +244,16 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
             for name, obj in sorted(blocks.items()):
                 child_item = QtGui.QStandardItem()
                 child_item.setEditable(False)
-                if type(obj) is dict: # It's a category
+                if type(obj) is dict:  # It's a category
                     child_item.setText(name)
-                    child_item.setDragEnabled(False) # categories should not be draggable
+                    child_item.setDragEnabled(
+                        False
+                    )  # categories should not be draggable
                     if not _populate(obj, child_item):
                         continue
                     else:
                         found = True
-                else: # It's a block
+                else:  # It's a block
                     if v_blocks and not name in v_blocks:
                         continue
                     else:
@@ -246,13 +261,18 @@ class BlockLibrary(QtWidgets.QDockWidget, base.Component):
                     child_item.setText(obj.label)
                     child_item.setDragEnabled(True)
                     child_item.setSelectable(True)
-                    child_item.setData(QtCore.QVariant(obj.key), role=QtCore.Qt.UserRole,)
+                    child_item.setData(
+                        QtCore.QVariant(obj.key),
+                        role=QtCore.Qt.UserRole,
+                    )
                 parent.appendRow(child_item)
             return found
 
         # Call the nested function recursively to populate the block tree
         log.debug("Populating the treeview")
         _populate(block_tree, self._model.invisibleRootItem())
-        self._library.expand(self._model.item(0,0).index()) # TODO: Should be togglable in prefs
+        self._library.expand(
+            self._model.item(0, 0).index()
+        )  # TODO: Should be togglable in prefs
         if v_blocks:
             self._library.expandAll()

--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -12,8 +12,8 @@ from ....core.blocks.block import Block as CoreBlock
 log = logging.getLogger(__name__)
 
 LONG_VALUE = 20  # maximum length of a param string.
-                 # if exceeded, '...' will be displayed
-'''
+# if exceeded, '...' will be displayed
+"""
 class ParameterEdit(QtWidgets.QWidget):
     def __init__(self, label, value):
         super().__init__()
@@ -21,9 +21,10 @@ class ParameterEdit(QtWidgets.QWidget):
         self.layout.addWidget(QtWidgets.QLabel(label))
         edit = QtWidgets.QLineEdit(value)
         self.layout.addWidget(edit)
-'''
+"""
 
-#TODO: Move this to a separate file
+
+# TODO: Move this to a separate file
 class PropsDialog(QtWidgets.QDialog):
     def __init__(self, parent_block):
         super().__init__()
@@ -44,7 +45,6 @@ class PropsDialog(QtWidgets.QDialog):
                 yield cat
                 seen.add(cat)
 
-
         self.edit_params = []
 
         self.tabs = QtWidgets.QTabWidget()
@@ -55,7 +55,7 @@ class PropsDialog(QtWidgets.QDialog):
             qvb.setHorizontalSpacing(20)
             i = 0
             for param in self._block.params.values():
-                if param.category == cat and param.hide != 'all':
+                if param.category == cat and param.hide != "all":
                     qvb.addWidget(QtWidgets.QLabel(param.name), i, 0)
                     if param.dtype == "enum" or param.options:
                         dropdown = QtWidgets.QComboBox()
@@ -66,20 +66,28 @@ class PropsDialog(QtWidgets.QDialog):
                         qvb.addWidget(dropdown, i, 1)
                         self.edit_params.append(dropdown)
                         if param.dtype == "enum":
-                            dropdown.setCurrentIndex(dropdown.param_values.index(param.get_value()))
+                            dropdown.setCurrentIndex(
+                                dropdown.param_values.index(param.get_value())
+                            )
                         else:
                             dropdown.setEditable(True)
-                            value_label = param.options[param.value] if param.value in param.options else param.value
+                            value_label = (
+                                param.options[param.value]
+                                if param.value in param.options
+                                else param.value
+                            )
                             dropdown.setCurrentText(value_label)
                     else:
                         line_edit = QtWidgets.QLineEdit(param.value)
                         line_edit.param = param
-                        if f'dtype_{param.dtype}' in colors.LIGHT_THEME_STYLES:
-                            line_edit.setStyleSheet(colors.LIGHT_THEME_STYLES[f'dtype_{param.dtype}'])
+                        if f"dtype_{param.dtype}" in colors.LIGHT_THEME_STYLES:
+                            line_edit.setStyleSheet(
+                                colors.LIGHT_THEME_STYLES[f"dtype_{param.dtype}"]
+                            )
                         qvb.addWidget(line_edit, i, 1)
                         self.edit_params.append(line_edit)
                     qvb.addWidget(QtWidgets.QLabel("unit"), i, 2)
-                i+=1
+                i += 1
             tab = QtWidgets.QWidget()
             tab.setLayout(qvb)
             self.tabs.addTab(tab, cat)
@@ -101,7 +109,7 @@ class PropsDialog(QtWidgets.QDialog):
         for par in self.edit_params:
             if isinstance(par, QtWidgets.QLineEdit):
                 par.param.set_value(par.text())
-            else: # Dropdown/ComboBox
+            else:  # Dropdown/ComboBox
                 for key, val in par.param.options.items():
                     if val == par.currentText():
                         par.param.set_value(key)
@@ -110,8 +118,8 @@ class PropsDialog(QtWidgets.QDialog):
         self._block.create_shapes_and_labels()
         self._block.parent.blockPropsChange.emit(self._block)
 
-class Block(QtWidgets.QGraphicsItem, CoreBlock):
 
+class Block(QtWidgets.QGraphicsItem, CoreBlock):
     @classmethod
     def make_cls_with_base(cls, super_cls):
         name = super_cls.__name__
@@ -121,7 +129,7 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
 
     def create_shapes_and_labels(self):
         self.prepareGeometryChange()
-        font = QtGui.QFont('Helvetica', 10)
+        font = QtGui.QFont("Helvetica", 10)
         font.setBold(True)
 
         # figure out height of block based on how many params there are
@@ -129,27 +137,38 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
 
         for key, item in self.params.items():
             value = item.value
-            if value is not None and item.hide == 'none':
-                i+= 20
+            if value is not None and item.hide == "none":
+                i += 20
 
         self.height = i
 
         def get_min_height_for_ports(ports):
-            min_height = 2 * Constants.PORT_BORDER_SEPARATION + len(ports) * Constants.PORT_SEPARATION
+            min_height = (
+                2 * Constants.PORT_BORDER_SEPARATION
+                + len(ports) * Constants.PORT_SEPARATION
+            )
             # If any of the ports are bus ports - make the min height larger
-            if any([p.dtype == 'bus' for p in ports]):
-                min_height = 2 * Constants.PORT_BORDER_SEPARATION + sum(
-                    port.height + Constants.PORT_SPACING for port in ports if port.dtype == 'bus'
-                    ) - Constants.PORT_SPACING
+            if any([p.dtype == "bus" for p in ports]):
+                min_height = (
+                    2 * Constants.PORT_BORDER_SEPARATION
+                    + sum(
+                        port.height + Constants.PORT_SPACING
+                        for port in ports
+                        if port.dtype == "bus"
+                    )
+                    - Constants.PORT_SPACING
+                )
 
             else:
                 if ports:
                     min_height -= ports[-1].height
             return min_height
 
-        self.height = max(self.height,
-                     get_min_height_for_ports(self.active_sinks),
-                     get_min_height_for_ports(self.active_sources))
+        self.height = max(
+            self.height,
+            get_min_height_for_ports(self.active_sinks),
+            get_min_height_for_ports(self.active_sources),
+        )
         # figure out width of block based on widest line of text
         fm = QtGui.QFontMetrics(font)
         largest_width = fm.width(self.label)
@@ -157,38 +176,53 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
             name = item.name
             value = item.value
             value_label = item.options[value] if value in item.options else value
-            if value is not None and item.hide == 'none':
+            if value is not None and item.hide == "none":
                 full_line = name + ": " + value_label
-                '''
+                """
                 if len(value) > LONG_VALUE:
                     value = value[:LONG_VALUE-3] + '...'
-                '''
+                """
                 if fm.width(full_line) > largest_width:
                     largest_width = fm.width(full_line)
         self.width = largest_width + 15
 
-        bussified = self.current_bus_structure['source'], self.current_bus_structure['sink']
-        for ports, has_busses in zip((self.active_sources, self.active_sinks), bussified):
+        bussified = (
+            self.current_bus_structure["source"],
+            self.current_bus_structure["sink"],
+        )
+        for ports, has_busses in zip(
+            (self.active_sources, self.active_sinks), bussified
+        ):
             if not ports:
                 continue
-            port_separation = Constants.PORT_SEPARATION if not has_busses else ports[0].height + Constants.PORT_SPACING
-            offset = (self.height - (len(ports) - 1) * port_separation - ports[0].height) / 2
+            port_separation = (
+                Constants.PORT_SEPARATION
+                if not has_busses
+                else ports[0].height + Constants.PORT_SPACING
+            )
+            offset = (
+                self.height - (len(ports) - 1) * port_separation - ports[0].height
+            ) / 2
             for port in ports:
                 if port._dir == "sink":
                     port.setPos(-15, offset)
                 else:
                     port.setPos(self.width, offset)
                 port.create_shapes_and_labels()
-                '''
+                """
                 port.coordinate = {
                     0: (+self.width, offset),
                     90: (offset, -port.width),
                     180: (-port.width, offset),
                     270: (offset, +self.width),
                 }[port.connector_direction]
-                '''
+                """
 
-                offset += Constants.PORT_SEPARATION if not has_busses else port.height + Constants.PORT_SPACING
+                offset += (
+                    Constants.PORT_SEPARATION
+                    if not has_busses
+                    else port.height + Constants.PORT_SPACING
+                )
 
         self._update_colors()
         self.create_port_labels()
@@ -199,14 +233,13 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
             max_width = 0
             for port in ports:
                 port.create_shapes_and_labels()
-                #max_width = max(max_width, port.width_with_label)
-            #for port in ports:
+                # max_width = max(max_width, port.width_with_label)
+            # for port in ports:
             #    port.width = max_width
 
-
-    #def __init__(self, block_key, block_label, attrib, params, parent):
+    # def __init__(self, block_key, block_label, attrib, params, parent):
     def __init__(self, parent, **n):
-        #super(self.__class__, self).__init__(parent, **n)
+        # super(self.__class__, self).__init__(parent, **n)
         CoreBlock.__init__(self, parent)
         QtWidgets.QGraphicsItem.__init__(self)
 
@@ -215,24 +248,29 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
         for source in self.sources:
             source.setParentItem(self)
 
-        self.width = 300 # default shouldnt matter, it will change immedaitely after the first paint
-        #self.block_key = block_key
-        #self.block_label = block_label
+        self.width = 300  # default shouldnt matter, it will change immedaitely after the first paint
+        # self.block_key = block_key
+        # self.block_label = block_label
         self.block_label = self.key
 
-        if 'coordinate' not in self.states.keys():
-            self.states['coordinate'] = (500, 300)
-            self.setPos(QtCore.QPointF(self.states['coordinate'][0], self.states['coordinate'][1]))
-        if 'rotation' not in self.states.keys():
-            self.states['rotation'] = 0.0
+        if "coordinate" not in self.states.keys():
+            self.states["coordinate"] = (500, 300)
+            self.setPos(
+                QtCore.QPointF(
+                    self.states["coordinate"][0], self.states["coordinate"][1]
+                )
+            )
+        if "rotation" not in self.states.keys():
+            self.states["rotation"] = 0.0
 
         self.create_shapes_and_labels()
 
         self.moving = False
         self.oldPos = (self.x(), self.y())
         self.newPos = (self.x(), self.y())
-        self.states['coordinate'] = (self.x(), self.y())
+        self.states["coordinate"] = (self.x(), self.y())
         self.oldData = None
+        self.props_dialog = None
 
         self.setFlag(QtWidgets.QGraphicsItem.ItemIsMovable)
         self.setFlag(QtWidgets.QGraphicsItem.ItemIsSelectable)
@@ -246,9 +284,9 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
             """
             if self.is_dummy_block:
                 return colors.MISSING_BLOCK_BACKGROUND_COLOR
-            if self.state == 'bypassed':
+            if self.state == "bypassed":
                 return colors.BLOCK_BYPASSED_COLOR
-            if self.state == 'enabled':
+            if self.state == "enabled":
                 if self.deprecated:
                     return colors.BLOCK_DEPRECATED_BACKGROUND_COLOR
                 return colors.BLOCK_ENABLED_COLOR
@@ -262,20 +300,20 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
                 return colors.MISSING_BLOCK_BORDER_COLOR
             if self.deprecated:
                 return colors.BLOCK_DEPRECATED_BORDER_COLOR
-            if self.state == 'enabled':
+            if self.state == "enabled":
                 return colors.BORDER_COLOR
             return colors.BORDER_COLOR_DISABLED
 
         self._bg_color = get_bg()
-        #self._font_color[-1] = 1.0 if self.state == 'enabled' else 0.4
+        # self._font_color[-1] = 1.0 if self.state == 'enabled' else 0.4
         self._border_color = get_border()
 
     def paint(self, painter, option, widget):
-        x,y = (self.x(), self.y())
-        self.states['coordinate'] = (self.x(), self.y())
+        x, y = (self.x(), self.y())
+        self.states["coordinate"] = (self.x(), self.y())
         # Set font
-        font = QtGui.QFont('Helvetica', 10)
-        #font.setStretch(70) # makes it more condensed
+        font = QtGui.QFont("Helvetica", 10)
+        # font.setStretch(70) # makes it more condensed
         font.setBold(True)
 
         painter.setRenderHint(QtGui.QPainter.Antialiasing)
@@ -302,15 +340,19 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
             painter.setPen(Qt.black)
         else:
             painter.setPen(Qt.red)
-        painter.drawText(QtCore.QRectF(0, 0 - self.height/2 + 15, self.width, self.height), Qt.AlignCenter, self.label)  # NOTE the 3rd/4th arg in  QRectF seems to set the bounding box of the text, so if there is ever any clipping, thats why
+        painter.drawText(
+            QtCore.QRectF(0, 0 - self.height / 2 + 15, self.width, self.height),
+            Qt.AlignCenter,
+            self.label,
+        )  # NOTE the 3rd/4th arg in  QRectF seems to set the bounding box of the text, so if there is ever any clipping, thats why
 
         # Draw param text
-        y_offset = 30 # params start 30 down from the top of the box
+        y_offset = 30  # params start 30 down from the top of the box
         for key, item in self.params.items():
             name = item.name
             value = item.value
             value_label = item.options[value] if value in item.options else value
-            if value is not None and item.hide == 'none':
+            if value is not None and item.hide == "none":
                 if item.is_valid():
                     painter.setPen(QtGui.QPen(1))
                 else:
@@ -318,29 +360,41 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
 
                 font.setBold(True)
                 painter.setFont(font)
-                painter.drawText(QtCore.QRectF(7.5, 0 + y_offset, self.width, self.height), Qt.AlignLeft, name + ': ')
+                painter.drawText(
+                    QtCore.QRectF(7.5, 0 + y_offset, self.width, self.height),
+                    Qt.AlignLeft,
+                    name + ": ",
+                )
                 fm = QtGui.QFontMetrics(font)
                 font.setBold(False)
                 painter.setFont(font)
-                painter.drawText(QtCore.QRectF(7.5 + fm.width(name + ": "), 0 + y_offset, self.width, self.height), Qt.AlignLeft, value_label)
+                painter.drawText(
+                    QtCore.QRectF(
+                        7.5 + fm.width(name + ": "),
+                        0 + y_offset,
+                        self.width,
+                        self.height,
+                    ),
+                    Qt.AlignLeft,
+                    value_label,
+                )
                 y_offset += 20
 
-
-
-
-    def boundingRect(self): # required to have
-        return QtCore.QRectF(-2.5, -2.5, self.width+5, self.height+5) # margin to avoid artifacts
+    def boundingRect(self):  # required to have
+        return QtCore.QRectF(
+            -2.5, -2.5, self.width + 5, self.height + 5
+        )  # margin to avoid artifacts
 
     def registerMoveStarting(self):
         self.moving = True
-        self.oldPos = self.states['coordinate']
+        self.oldPos = self.states["coordinate"]
 
     def setStates(self, states):
         for k, v in states.items():
             self.states[k] = v
 
-        self.setPos(self.states['coordinate'][0], self.states['coordinate'][1])
-        self.setRotation(self.states['rotation'])
+        self.setPos(self.states["coordinate"][0], self.states["coordinate"][1])
+        self.setRotation(self.states["rotation"])
 
     def mouseReleaseEvent(self, e):
         super(self.__class__, self).mouseReleaseEvent(e)
@@ -348,7 +402,7 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
     def mousePressEvent(self, e):
         log.debug(f"{self} clicked")
         try:
-            #self.parent.app.DocumentationTab.setText(self.documentation[self.key])
+            # self.parent.app.DocumentationTab.setText(self.documentation[self.key])
             prefix = str(self.parent.app.platform.Config.wiki_block_docs_url_prefix)
             self.parent.app.WikiTab.setURL(QUrl(prefix + self.label.replace(" ", "_")))
         except KeyError:
@@ -362,17 +416,19 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
         super(self.__class__, self).mouseDoubleClickEvent(e)
         self.props_dialog = PropsDialog(self)
         self.props_dialog.show()
-        '''
+        """
         if props.exec():
             log.debug(f"Pressed Ok on block {self.name}'s PropsDialog")
         else:
             log.debug(f"Pressed Cancel on block {self.name}'s PropsDialog")
-        '''
+        """
 
     def import_data(self, name, states, parameters, **_):
         CoreBlock.import_data(self, name, states, parameters, **_)
-        self.states['coordinate'] = QtCore.QPointF(states['coordinate'][0], states['coordinate'][1])
-        self.setPos(self.states['coordinate'])
+        self.states["coordinate"] = QtCore.QPointF(
+            states["coordinate"][0], states["coordinate"][1]
+        )
+        self.setPos(self.states["coordinate"])
         self.rewrite()
         self.create_shapes_and_labels()
 
@@ -385,4 +441,4 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
         self.setZValue(self.parent.getMaxZValue() + 1)
 
     def center(self):
-        return QtCore.QPointF(self.x() + self.width/2, self.y() + self.height/2)
+        return QtCore.QPointF(self.x() + self.width / 2, self.y() + self.height / 2)

--- a/grc/gui_qt/components/flowgraph.py
+++ b/grc/gui_qt/components/flowgraph.py
@@ -60,9 +60,9 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         self.setParent(view)
         self.parent = self.platform
         CoreFlowgraph.__init__(self, self.platform)
-        self.isPanning    = False
+        self.isPanning = False
         self.mousePressed = False
-        
+
         self.newConnection = None
         self.startPort = None
         self._elements_to_draw = []
@@ -78,20 +78,20 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
     def update(self):
         """
         Call the top level rewrite and validate.
-        Call the top level create labels and shapes.  
+        Call the top level create labels and shapes.
         """
         self.rewrite()
         self.validate()
         for block in self.blocks:
             block.create_shapes_and_labels()
         self.update_elements_to_draw()
-        #self.create_labels()
-        #self.create_shapes()
-    
+        # self.create_labels()
+        # self.create_shapes()
+
     def update_elements_to_draw(self):
-        #hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
+        # hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
         hide_disabled_blocks = False
-        #hide_variables = Actions.TOGGLE_HIDE_VARIABLES.get_active()
+        # hide_variables = Actions.TOGGLE_HIDE_VARIABLES.get_active()
         hide_variables = False
 
         def draw_order(elem):
@@ -136,8 +136,8 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
                 item[Qt.ItemDataRole(key)] = value
             data.append(item)
         return data
-    
-    def _get_unique_id(self, base_id=''):
+
+    def _get_unique_id(self, base_id=""):
         """
         Get a unique id starting with the base id.
 
@@ -149,7 +149,7 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         """
         block_ids = set(b.name for b in self.blocks)
         for index in count():
-            block_id = '{}_{}'.format(base_id, index)
+            block_id = "{}_{}".format(base_id, index)
             if block_id not in block_ids:
                 break
         return block_id
@@ -158,45 +158,57 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         QtWidgets.QGraphicsScene.dropEvent(self, event)
         if event.mimeData().hasUrls:
             data = event.mimeData()
-            if data.hasFormat('application/x-qabstractitemmodeldatalist'):
-                bytearray = data.data('application/x-qabstractitemmodeldatalist')
+            if data.hasFormat("application/x-qabstractitemmodeldatalist"):
+                bytearray = data.data("application/x-qabstractitemmodeldatalist")
                 data_items = self.decode_data(bytearray)
 
                 # Find block in tree so that we can pull out label
                 block_key = data_items[0][QtCore.Qt.UserRole].value()
-                block = self.platform.blocks[block_key]
 
                 # Add block of this key at the cursor position
                 cursor_pos = event.scenePos()
+                pos = (cursor_pos.x(), cursor_pos.y())
 
-                # Pull out its params (keep in mind we still havent added the dialog box that lets you change param values so this is more for show)
-                params = []
-                for p in block.parameters_data: # block.parameters_data is a list of dicts, one per param
-                    if 'label' in p: # for now let's just show it as long as it has a label
-                        key = p['label']
-                        value = p.get('default', '') # just show default value for now
-                        params.append((key, value))
-
-                # Tell the block where to show up on the canvas
-                attrib = {'_coordinate':(cursor_pos.x(), cursor_pos.y())}
-
-                id = self._get_unique_id(block_key)
-                
-                block = self.new_block(block_key, attrib=attrib)
-                block.states['coordinate'] = (cursor_pos.x(), cursor_pos.y())
-                block.setPos(cursor_pos.x(), cursor_pos.y())
-                block.params['id'].set_value(id)
-                self.addItem(block)
-                block.moveToTop()
-                self.update()
-                self.newElement.emit(block)
+                self.add_block(block_key, pos)
 
                 event.setDropAction(Qt.CopyAction)
                 event.accept()
             else:
-                return QtGui.QStandardItemModel.dropMimeData(self, data, action, row, column, parent)
+                return QtGui.QStandardItemModel.dropMimeData(
+                    self, data, action, row, column, parent
+                )
         else:
             event.ignore()
+
+    def add_block(self, block_key, pos=(0, 0)):
+        print(f"{block_key=}")
+        block = self.platform.blocks[block_key]
+
+        # Pull out its params (keep in mind we still havent added the dialog box that lets you change param values so this is more for show)
+        params = []
+        for (
+            p
+        ) in (
+            block.parameters_data
+        ):  # block.parameters_data is a list of dicts, one per param
+            if "label" in p:  # for now let's just show it as long as it has a label
+                key = p["label"]
+                value = p.get("default", "")  # just show default value for now
+                params.append((key, value))
+
+        id = self._get_unique_id(block_key)
+
+        # Tell the block where to show up on the canvas
+        attrib = {"_coordinate": pos}
+
+        block = self.new_block(block_key, attrib=attrib)
+        block.states["coordinate"] = pos
+        block.setPos(*pos)
+        block.params["id"].set_value(id)
+        self.addItem(block)
+        block.moveToTop()
+        self.update()
+        self.newElement.emit(block)
 
     def selected_blocks(self):
         blocks = []
@@ -233,32 +245,31 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         selected_blocks = self.selected_blocks()
         if not any(selected_blocks):
             return False
-        #initialize min and max coordinates
-        min_x, min_y = max_x, max_y = selected_blocks[0].x(),selected_blocks[0].y()
+        # initialize min and max coordinates
+        min_x, min_y = max_x, max_y = selected_blocks[0].x(), selected_blocks[0].y()
         # rotate each selected block, and find min/max coordinate
         for selected_block in selected_blocks:
             selected_block.rotate(rotation)
-            #update the min/max coordinate
-            x, y = selected_block.x(),selected_block.y()
+            # update the min/max coordinate
+            x, y = selected_block.x(), selected_block.y()
             min_x, min_y = min(min_x, x), min(min_y, y)
             max_x, max_y = max(max_x, x), max(max_y, y)
-        #calculate center point of selected blocks
-        ctr_x, ctr_y = (max_x + min_x)/2, (max_y + min_y)/2
-        #rotate the blocks around the center point
+        # calculate center point of selected blocks
+        ctr_x, ctr_y = (max_x + min_x) / 2, (max_y + min_y) / 2
+        # rotate the blocks around the center point
         for selected_block in selected_blocks:
-            x, y = selected_block.x(),selected_block.y()
+            x, y = selected_block.x(), selected_block.y()
             x, y = Utils.get_rotated_coordinate((x - ctr_x, y - ctr_y), rotation)
             selected_block.setPos(x + ctr_x, y + ctr_y)
         return True
 
-
-    def mousePressEvent(self,  event):
+    def mousePressEvent(self, event):
         item = self.itemAt(event.scenePos(), QtGui.QTransform())
         selected = self.selectedItems()
         self.movingThings = False
         if item:
             if item.is_block:
-                self.movingThings = True 
+                self.movingThings = True
         self.clickPos = event.scenePos()
         conn_made = False
         if item:
@@ -282,7 +293,9 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
                 if not conn_made:
                     self.startPort = item
                     if item.is_source:
-                        self.newConnection = ConnectionArrow(self, item.connection_point, event.scenePos())
+                        self.newConnection = ConnectionArrow(
+                            self, item.connection_point, event.scenePos()
+                        )
                         self.newConnection.setPen(QtGui.QPen(1))
                         self.addItem(self.newConnection)
         if event.button() == Qt.LeftButton:
@@ -298,13 +311,19 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
             newPos = event.pos()
             diff = newPos - self.dragPos
             self.dragPos = newPos
-            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - diff.x())
-            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - diff.y())
+            self.horizontalScrollBar().setValue(
+                self.horizontalScrollBar().value() - diff.x()
+            )
+            self.verticalScrollBar().setValue(
+                self.verticalScrollBar().value() - diff.y()
+            )
             event.accept()
         else:
-            itemUnderMouse = self.itemAt(event.pos(), QtGui.QTransform()) # the 2nd arg lets you transform some items and ignore others
-            if  itemUnderMouse is not None:
-                #~ print itemUnderMouse
+            itemUnderMouse = self.itemAt(
+                event.pos(), QtGui.QTransform()
+            )  # the 2nd arg lets you transform some items and ignore others
+            if itemUnderMouse is not None:
+                # ~ print itemUnderMouse
                 pass
 
             super(Flowgraph, self).mouseMoveEvent(event)
@@ -325,7 +344,7 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
             if self.clickPos != event.scenePos():
                 if self.movingThings:
                     self.itemMoved.emit(event.scenePos() - self.clickPos)
-        '''
+        """
         if event.button() == Qt.LeftButton:
             if event.modifiers() & Qt.ControlModifier:
                 #self.setCursor(Qt.OpenHandCursor)
@@ -334,32 +353,31 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
                 self.isPanning = False
                 #self.setCursor(Qt.ArrowCursor)
             self.mousePressed = False
-        '''
+        """
         super(Flowgraph, self).mouseReleaseEvent(event)
 
-    def mouseDoubleClickEvent(self, event): # Will be used to open up dialog box of a block
+    def mouseDoubleClickEvent(
+        self, event
+    ):  # Will be used to open up dialog box of a block
         super(Flowgraph, self).mouseDoubleClickEvent(event)
-
-
 
     def createActions(self, actions):
         log.debug("Creating actions")
 
-        '''
+        """
         # File Actions
         actions['save'] = Action(Icons("document-save"), _("save"), self,
                                 shortcut=Keys.New, statusTip=_("save-tooltip"))
 
         actions['clear'] = Action(Icons("document-close"), _("clear"), self,
                                          shortcut=Keys.Open, statusTip=_("clear-tooltip"))
-        '''
+        """
 
     def createMenus(self, actions, menus):
         log.debug("Creating menus")
 
     def createToolbars(self, actions, toolbars):
         log.debug("Creating toolbars")
-
 
     def import_data(self, data):
         super(Flowgraph, self).import_data(data)
@@ -369,19 +387,19 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
     def getMaxZValue(self):
         z_values = []
         for block in self.blocks:
-             z_values.append(block.zValue())
+            z_values.append(block.zValue())
         return max(z_values)
 
     def remove_element(self, element):
         self.removeItem(element)
         super(Flowgraph, self).remove_element(element)
-    
+
     def add_element(self, element):
         super(Flowgraph, self).add_element(element)
         self.addItem(element)
 
     def get_extents(self):
-        #show_comments = Actions.TOGGLE_SHOW_BLOCK_COMMENTS.get_active()
+        # show_comments = Actions.TOGGLE_SHOW_BLOCK_COMMENTS.get_active()
         show_comments = True
 
         def sub_extents():
@@ -393,10 +411,9 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         extent = 10000000, 10000000, 0, 0
         cmps = (min, min, max, max)
         for sub_extent in sub_extents():
-            extent = [cmp(xy, e_xy)
-                      for cmp, xy, e_xy in zip(cmps, extent, sub_extent)]
+            extent = [cmp(xy, e_xy) for cmp, xy, e_xy in zip(cmps, extent, sub_extent)]
         return tuple(extent)
-    
+
     def copy_to_clipboard(self):
         """
         Copy the selected blocks and connections into the clipboard.
@@ -409,23 +426,25 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         if not blocks:
             return None
         # calc x and y min
-        x_min, y_min = blocks[0].states['coordinate']
+        x_min, y_min = blocks[0].states["coordinate"]
         for block in blocks:
-            x, y = block.states['coordinate']
+            x, y = block.states["coordinate"]
             x_min = min(x, x_min)
             y_min = min(y, y_min)
         # get connections between selected blocks
-        connections = list(filter(
-            lambda c: c.source_block in blocks and c.sink_block in blocks,
-            self.connections,
-        ))
+        connections = list(
+            filter(
+                lambda c: c.source_block in blocks and c.sink_block in blocks,
+                self.connections,
+            )
+        )
         clipboard = (
             (x_min, y_min),
             [block.export_data() for block in blocks],
             [connection.export_data() for connection in connections],
         )
         return clipboard
-    
+
     def paste_from_clipboard(self, clipboard):
         """
         Paste the blocks and connections from the clipboard.
@@ -435,7 +454,7 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         """
         self.clearSelection()
         (x_min, y_min), blocks_n, connections_n = clipboard
-        '''
+        """
         # recalc the position
         scroll_pane = self.drawing_area.get_parent().get_parent()
         h_adj = scroll_pane.get_hadjustment()
@@ -445,21 +464,21 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
 
         if len(self.get_elements()) <= 1:
             x_off, y_off = 0, 0
-        '''
+        """
         x_off, y_off = 10, 10
 
         # create blocks
         pasted_blocks = {}
         for block_n in blocks_n:
-            block_key = block_n.get('id')
-            if block_key == 'options':
+            block_key = block_n.get("id")
+            if block_key == "options":
                 continue
 
-            block_name = block_n.get('name')
+            block_name = block_n.get("name")
             # Verify whether a block with this name exists before adding it
             if block_name in (blk.name for blk in self.blocks):
                 block_n = block_n.copy()
-                block_n['name'] = self._get_unique_id(block_name)
+                block_n["name"] = self._get_unique_id(block_name)
 
             block = self.new_block(block_key)
             if not block:
@@ -472,7 +491,7 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
             self.addItem(block)
             block.moveToTop()
             block.setSelected(True)
-            '''
+            """
             while any(Utils.align_to_grid(block.states['coordinate']) == Utils.align_to_grid(other.states['coordinate'])
                       for other in self.blocks if other is not block):
                 block.moveBy(Constants.CANVAS_GRID_SIZE,
@@ -480,7 +499,7 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
                 # shift all following blocks
                 x_off += Constants.CANVAS_GRID_SIZE
                 y_off += Constants.CANVAS_GRID_SIZE
-            '''
+            """
 
         # update before creating connections
         self.update()
@@ -492,18 +511,20 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
             connection.setSelected(True)
 
 
-class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Component so it can see platform
+class FlowgraphView(
+    QtWidgets.QGraphicsView, base.Component
+):  # added base.Component so it can see platform
     def __init__(self, parent, filename=None):
         super(FlowgraphView, self).__init__()
         self.setParent(parent)
-        self.setAlignment(Qt.AlignLeft|Qt.AlignTop)
+        self.setAlignment(Qt.AlignLeft | Qt.AlignTop)
 
         self.flowgraph = Flowgraph(self)
 
         self.scalefactor = 0.8
         self.scale(self.scalefactor, self.scalefactor)
 
-        self.setSceneRect(0,0,DEFAULT_MAX_X, DEFAULT_MAX_Y)
+        self.setSceneRect(0, 0, DEFAULT_MAX_X, DEFAULT_MAX_Y)
         if filename is not None:
             self.readFile(filename)
         else:
@@ -513,15 +534,14 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
         self.fitInView(self.flowgraph.sceneRect(), QtCore.Qt.KeepAspectRatio)
         self.setBackgroundBrush(QtGui.QBrush(QtGui.QColor(25, 35, 45)))
 
-        self.isPanning    = False
+        self.isPanning = False
         self.mousePressed = False
 
         self.saved = False
 
         self.setDragMode(self.RubberBandDrag)
 
-
-        '''
+        """
         QGraphicsView.__init__(self, flow_graph, parent)
         self._flow_graph = flow_graph
 
@@ -537,25 +557,22 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
         #ToDo: Better put this in Block()
         #self.setContextMenuPolicy(Qt.ActionsContextMenu)
         #self.addActions(parent.main_window.menuEdit.actions())
-        '''
-
+        """
 
     def createActions(self, actions):
         log.debug("Creating actions")
 
-        '''
+        """
         # File Actions
         actions['save'] = Action(Icons("document-save"), _("save"), self,
                                 shortcut=Keys.New, statusTip=_("save-tooltip"))
 
         actions['clear'] = Action(Icons("document-close"), _("clear"), self,
                                          shortcut=Keys.Open, statusTip=_("clear-tooltip"))
-        '''
-
-    
+        """
 
     def contextMenuEvent(self, event):
-        contextMenu = self._app().MainWindow.menus['edit']
+        contextMenu = self._app().MainWindow.menus["edit"]
         contextMenu.exec_(self.mapToGlobal(event.pos()))
 
     def createMenus(self, actions, menus):
@@ -569,15 +586,15 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
         root = tree.getroot()
         blocks = {}
 
-        for xml_block in tree.findall('block'):
+        for xml_block in tree.findall("block"):
             attrib = {}
             params = []
-            block_key = xml_block.find('key').text
+            block_key = xml_block.find("key").text
 
-            for param in xml_block.findall('param'):
-                key = param.find('key').text
-                value = param.find('value').text
-                if key.startswith('_'):
+            for param in xml_block.findall("param"):
+                key = param.find("key").text
+                value = param.find("value").text
+                if key.startswith("_"):
                     attrib[key] = literal_eval(value)
                 else:
                     params.append((key, value))
@@ -593,14 +610,14 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
                 log.warning("Block '{}' was not found".format(block_key))
 
         # This part no longer works now that we are using a Scene with GraphicsItems, but I'm sure there's still some way to do it
-        #bounds = self.scene.itemsBoundingRect()
-        #self.setSceneRect(bounds)
-        #self.fitInView(bounds)
+        # bounds = self.scene.itemsBoundingRect()
+        # self.setSceneRect(bounds)
+        # self.fitInView(bounds)
 
     def initEmpty(self):
-        self.setSceneRect(0,0,DEFAULT_MAX_X, DEFAULT_MAX_Y)
+        self.setSceneRect(0, 0, DEFAULT_MAX_X, DEFAULT_MAX_Y)
 
-    def wheelEvent(self,  event):
+    def wheelEvent(self, event):
         # TODO: Support multi touch drag and drop for scrolling through the view
         if event.modifiers() == Qt.ControlModifier:
             factor = 1.1
@@ -625,7 +642,7 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
         else:
             QtWidgets.QGraphicsView.wheelEvent(self, event)
 
-    def mousePressEvent(self,  event):
+    def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             self.mousePressed = True
             # This will pass the mouse move event to the scene
@@ -636,8 +653,12 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
             newPos = event.pos()
             diff = newPos - self.dragPos
             self.dragPos = newPos
-            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - diff.x())
-            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - diff.y())
+            self.horizontalScrollBar().setValue(
+                self.horizontalScrollBar().value() - diff.x()
+            )
+            self.verticalScrollBar().setValue(
+                self.verticalScrollBar().value() - diff.y()
+            )
             event.accept()
         else:
             # This will pass the mouse move event to the scene
@@ -658,8 +679,7 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
         # This will pass the double click event to the scene
         super(FlowgraphView, self).mouseDoubleClickEvent(event)
 
-
-    '''
+    """
     def dragEnterEvent(self, event):
         key = event.mimeData().text()
         self._dragged_block = self._flow_graph.add_new_block(
@@ -681,4 +701,4 @@ class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Compo
     def dropEvent(self, event):
         self._dragged_block = None
         event.accept()
-    '''
+    """

--- a/grc/gui_qt/components/flowgraph.py
+++ b/grc/gui_qt/components/flowgraph.py
@@ -181,7 +181,6 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
             event.ignore()
 
     def add_block(self, block_key, pos=(0, 0)):
-        print(f"{block_key=}")
         block = self.platform.blocks[block_key]
 
         # Pull out its params (keep in mind we still havent added the dialog box that lets you change param values so this is more for show)

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -33,7 +33,17 @@ from qtpy.QtGui import QStandardItemModel
 # Custom modules
 from . import FlowgraphView
 from .. import base, Constants, Utils
-from .undoable_actions import ChangeStateAction, RotateAction, EnableAction, DisableAction, BypassAction, MoveAction, NewElementAction, DeleteElementAction, BlockPropsChangeAction
+from .undoable_actions import (
+    ChangeStateAction,
+    RotateAction,
+    EnableAction,
+    DisableAction,
+    BypassAction,
+    MoveAction,
+    NewElementAction,
+    DeleteElementAction,
+    BlockPropsChangeAction,
+)
 from . import DocumentationTab
 from .preferences import PreferencesDialog
 from .dialogs import ErrorsDialog
@@ -52,17 +62,18 @@ QStyle = QtWidgets.QStyle
 
 
 class MainWindow(QtWidgets.QMainWindow, base.Component):
-
     def __init__(self):
         QtWidgets.QMainWindow.__init__(self)
         base.Component.__init__(self)
 
         log.debug("Setting the main window")
-        self.setObjectName('main')
-        self.setWindowTitle(_('window-title'))
-        self.setDockOptions(QtWidgets.QMainWindow.AllowNestedDocks |
-                            QtWidgets.QMainWindow.AllowTabbedDocks |
-                            QtWidgets.QMainWindow.AnimatedDocks)
+        self.setObjectName("main")
+        self.setWindowTitle(_("window-title"))
+        self.setDockOptions(
+            QtWidgets.QMainWindow.AllowNestedDocks
+            | QtWidgets.QMainWindow.AllowTabbedDocks
+            | QtWidgets.QMainWindow.AnimatedDocks
+        )
         self.progress_bar = QtWidgets.QProgressBar()
         self.statusBar().addPermanentWidget(self.progress_bar)
         self.progress_bar.hide()
@@ -73,7 +84,9 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.setWindowIcon(icon)
 
         screen = QtWidgets.QDesktopWidget().availableGeometry()
-        log.debug("Setting window size - ({}, {})".format(screen.width(), screen.height()))
+        log.debug(
+            "Setting window size - ({}, {})".format(screen.width(), screen.height())
+        )
         self.resize(int(screen.width() * 0.50), screen.height())
 
         self.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
@@ -81,23 +94,20 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.menuBar().setNativeMenuBar(self.settings.window.NATIVE_MENUBAR)
 
         # TODO: Not sure about document mode
-        #self.setDocumentMode(True)
+        # self.setDocumentMode(True)
 
         # Generate the rest of the window
         self.createStatusBar()
 
-        #actions['Quit.triggered.connect(self.close)
-        #actions['Report.triggered.connect(self.reportDock.show)
-        #QtCore.QMetaObject.connectSlotsByName(self)
+        # actions['Quit.triggered.connect(self.close)
+        # actions['Report.triggered.connect(self.reportDock.show)
+        # QtCore.QMetaObject.connectSlotsByName(self)
 
+        # Translation support
 
-
-
-        ### Translation support
-
-        #self.setWindowTitle(_translate("blockLibraryDock", "Library", None))
-        #library.headerItem().setText(0, _translate("blockLibraryDock", "Blocks", None))
-        #QtCore.QMetaObject.connectSlotsByName(blockLibraryDock)
+        # self.setWindowTitle(_translate("blockLibraryDock", "Library", None))
+        # library.headerItem().setText(0, _translate("blockLibraryDock", "Blocks", None))
+        # QtCore.QMetaObject.connectSlotsByName(blockLibraryDock)
 
         # TODO: Move to the base controller and set actions as class attributes
         # Automatically create the actions, menus and toolbars.
@@ -110,8 +120,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.createToolbars(self.actions, self.toolbars)
         self.connectSlots()
 
-
-        ### Rest of the GUI widgets
+        # Rest of the GUI widgets
 
         # Map some of the view's functions to the controller class
         self.registerDockWidget = self.addDockWidget
@@ -148,8 +157,10 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
         self.tabWidget = QtWidgets.QTabWidget()
         self.tabWidget.setTabsClosable(True)
-        #TODO: Don't close if the tab has not been saved
-        self.tabWidget.tabCloseRequested.connect(lambda index: self.close_triggered(index))
+        # TODO: Don't close if the tab has not been saved
+        self.tabWidget.tabCloseRequested.connect(
+            lambda index: self.close_triggered(index)
+        )
         self.tabWidget.addTab(fg_view, "Untitled")
         self.setCentralWidget(self.tabWidget)
         self.currentFlowgraph.selectionChanged.connect(self.updateActions)
@@ -158,15 +169,15 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.currentFlowgraph.newElement.connect(self.registerNewElement)
         self.currentFlowgraph.deleteElement.connect(self.registerDeleteElement)
         self.currentFlowgraph.blockPropsChange.connect(self.registerBlockPropsChange)
-        #self.new_tab(self.flowgraph)
+        # self.new_tab(self.flowgraph)
 
         self.clipboard = None
         self.undoView = None
 
-    '''def show(self):
+    """def show(self):
         log.debug("Showing main window")
         self.show()
-    '''
+    """
 
     @property
     def currentView(self):
@@ -174,7 +185,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
     @property
     def currentFlowgraph(self):
-        #something is fishy here
+        # something is fishy here
         return self.tabWidget.currentWidget().flowgraph
 
     @QtCore.Slot(QtCore.QPointF)
@@ -202,206 +213,325 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.updateActions()
 
     def createActions(self, actions):
-        '''
+        """
         Defines all actions for this view.
         Controller manages connecting signals to slots implemented in the controller
-        '''
+        """
         log.debug("Creating actions")
 
         # File Actions
-        actions['new'] = Action(Icons("document-new"), _("new"), self,
-                                shortcut=Keys.New, statusTip=_("new-tooltip"))
+        actions["new"] = Action(
+            Icons("document-new"),
+            _("new"),
+            self,
+            shortcut=Keys.New,
+            statusTip=_("new-tooltip"),
+        )
 
-        actions['open'] = Action(Icons("document-open"), _("open"), self,
-                                 shortcut=Keys.Open, statusTip=_("open-tooltip"))
+        actions["open"] = Action(
+            Icons("document-open"),
+            _("open"),
+            self,
+            shortcut=Keys.Open,
+            statusTip=_("open-tooltip"),
+        )
 
-        actions['close'] = Action(Icons("window-close"), _("close"), self,
-                                  shortcut=Keys.Close, statusTip=_("close-tooltip"))
+        actions["close"] = Action(
+            Icons("window-close"),
+            _("close"),
+            self,
+            shortcut=Keys.Close,
+            statusTip=_("close-tooltip"),
+        )
 
-        actions['close_all'] = Action(Icons("window-close"), _("close_all"), self,
-                                      statusTip=_("close_all-tooltip"))
-        actions['save'] = Action(Icons("document-save"), _("save"), self,
-                                 shortcut=Keys.Save, statusTip=_("save-tooltip"))
+        actions["close_all"] = Action(
+            Icons("window-close"),
+            _("close_all"),
+            self,
+            statusTip=_("close_all-tooltip"),
+        )
+        actions["save"] = Action(
+            Icons("document-save"),
+            _("save"),
+            self,
+            shortcut=Keys.Save,
+            statusTip=_("save-tooltip"),
+        )
 
-        actions['save_as'] = Action(Icons("document-save-as"), _("save_as"), self,
-                                    shortcut=Keys.SaveAs, statusTip=_("save_as-tooltip"))
+        actions["save_as"] = Action(
+            Icons("document-save-as"),
+            _("save_as"),
+            self,
+            shortcut=Keys.SaveAs,
+            statusTip=_("save_as-tooltip"),
+        )
 
-        actions['save_copy'] = Action(_("save_copy"), self)
+        actions["save_copy"] = Action(_("save_copy"), self)
 
-        actions['screen_capture'] = Action(Icons('camera-photo'), _("screen_capture"), self,
-                                           shortcut=Keys.Print, statusTip=_("screen_capture-tooltip"))
+        actions["screen_capture"] = Action(
+            Icons("camera-photo"),
+            _("screen_capture"),
+            self,
+            shortcut=Keys.Print,
+            statusTip=_("screen_capture-tooltip"),
+        )
 
-        actions['exit'] = Action(Icons("application-exit"), _("exit"), self,
-                                 shortcut=Keys.Quit, statusTip=_("exit-tooltip"))
+        actions["exit"] = Action(
+            Icons("application-exit"),
+            _("exit"),
+            self,
+            shortcut=Keys.Quit,
+            statusTip=_("exit-tooltip"),
+        )
 
         # Edit Actions
-        actions['undo'] = Action(Icons('edit-undo'), _("undo"), self,
-                                 shortcut=Keys.Undo, statusTip=_("undo-tooltip"))
+        actions["undo"] = Action(
+            Icons("edit-undo"),
+            _("undo"),
+            self,
+            shortcut=Keys.Undo,
+            statusTip=_("undo-tooltip"),
+        )
 
-        actions['redo'] = Action(Icons('edit-redo'), _("redo"), self,
-                                 shortcut=Keys.Redo, statusTip=_("redo-tooltip"))
+        actions["redo"] = Action(
+            Icons("edit-redo"),
+            _("redo"),
+            self,
+            shortcut=Keys.Redo,
+            statusTip=_("redo-tooltip"),
+        )
 
-        actions['view_undo_stack'] = Action("View undo stack", self)
+        actions["view_undo_stack"] = Action("View undo stack", self)
 
-        actions['cut'] = Action(Icons('edit-cut'), _("cut"), self,
-                                shortcut=Keys.Cut, statusTip=_("cut-tooltip"))
+        actions["cut"] = Action(
+            Icons("edit-cut"),
+            _("cut"),
+            self,
+            shortcut=Keys.Cut,
+            statusTip=_("cut-tooltip"),
+        )
 
-        actions['copy'] = Action(Icons('edit-copy'), _("copy"), self,
-                                 shortcut=Keys.Copy, statusTip=_("copy-tooltip"))
+        actions["copy"] = Action(
+            Icons("edit-copy"),
+            _("copy"),
+            self,
+            shortcut=Keys.Copy,
+            statusTip=_("copy-tooltip"),
+        )
 
-        actions['paste'] = Action(Icons('edit-paste'), _("paste"), self,
-                                  shortcut=Keys.Paste, statusTip=_("paste-tooltip"))
+        actions["paste"] = Action(
+            Icons("edit-paste"),
+            _("paste"),
+            self,
+            shortcut=Keys.Paste,
+            statusTip=_("paste-tooltip"),
+        )
 
-        actions['delete'] = Action(Icons('edit-delete'), _("delete"), self,
-                                   shortcut=Keys.Delete, statusTip=_("delete-tooltip"))
+        actions["delete"] = Action(
+            Icons("edit-delete"),
+            _("delete"),
+            self,
+            shortcut=Keys.Delete,
+            statusTip=_("delete-tooltip"),
+        )
 
-        actions['undo'].setEnabled(False)
-        actions['redo'].setEnabled(False)
-        actions['cut'].setEnabled(False)
-        actions['copy'].setEnabled(False)
-        actions['paste'].setEnabled(False)
-        actions['delete'].setEnabled(False)
+        actions["undo"].setEnabled(False)
+        actions["redo"].setEnabled(False)
+        actions["cut"].setEnabled(False)
+        actions["copy"].setEnabled(False)
+        actions["paste"].setEnabled(False)
+        actions["delete"].setEnabled(False)
 
-        actions['select_all'] = Action(Icons('edit-select_all'), _("select_all"), self,
-                                   shortcut=Keys.SelectAll, statusTip=_("select_all-tooltip"))
+        actions["select_all"] = Action(
+            Icons("edit-select_all"),
+            _("select_all"),
+            self,
+            shortcut=Keys.SelectAll,
+            statusTip=_("select_all-tooltip"),
+        )
 
-        actions['select_none'] = Action(_("Select None"), self,
-                                        statusTip=_("select_none-tooltip"))
+        actions["select_none"] = Action(
+            _("Select None"), self, statusTip=_("select_none-tooltip")
+        )
 
-        actions['rotate_ccw'] = Action(Icons('object-rotate-left'), _("rotate_ccw"), self,
-                                       shortcut=Keys.MoveToPreviousChar,
-                                       statusTip=_("rotate_ccw-tooltip"))
+        actions["rotate_ccw"] = Action(
+            Icons("object-rotate-left"),
+            _("rotate_ccw"),
+            self,
+            shortcut=Keys.MoveToPreviousChar,
+            statusTip=_("rotate_ccw-tooltip"),
+        )
 
-        actions['rotate_cw'] = Action(Icons('object-rotate-right'), _("rotate_cw"), self,
-                                      shortcut=Keys.MoveToNextChar,
-                                      statusTip=_("rotate_cw-tooltip"))
+        actions["rotate_cw"] = Action(
+            Icons("object-rotate-right"),
+            _("rotate_cw"),
+            self,
+            shortcut=Keys.MoveToNextChar,
+            statusTip=_("rotate_cw-tooltip"),
+        )
 
-        actions['rotate_cw'].setEnabled(False)
-        actions['rotate_ccw'].setEnabled(False)
+        actions["rotate_cw"].setEnabled(False)
+        actions["rotate_ccw"].setEnabled(False)
 
-        actions['enable'] = Action(_("enable"), self,
-                                   shortcut="E")
-        actions['disable'] = Action(_("disable"), self,
-                                   shortcut="D")
-        actions['bypass'] = Action(_("bypass"), self,
-                                   shortcut="B")
+        actions["enable"] = Action(_("enable"), self, shortcut="E")
+        actions["disable"] = Action(_("disable"), self, shortcut="D")
+        actions["bypass"] = Action(_("bypass"), self, shortcut="B")
 
-        actions['enable'].setEnabled(False)
-        actions['disable'].setEnabled(False)
-        actions['bypass'].setEnabled(False)
+        actions["enable"].setEnabled(False)
+        actions["disable"].setEnabled(False)
+        actions["bypass"].setEnabled(False)
 
-        actions['vertical_align_top'] = Action(_("vertical_align_top"), self)
-        actions['vertical_align_middle'] = Action(_("vertical_align_middle"), self)
-        actions['vertical_align_bottom'] = Action(_("vertical_align_bottom"), self)
+        actions["vertical_align_top"] = Action(_("vertical_align_top"), self)
+        actions["vertical_align_middle"] = Action(_("vertical_align_middle"), self)
+        actions["vertical_align_bottom"] = Action(_("vertical_align_bottom"), self)
 
-        actions['vertical_align_top'].setEnabled(False)
-        actions['vertical_align_middle'].setEnabled(False)
-        actions['vertical_align_bottom'].setEnabled(False)
+        actions["vertical_align_top"].setEnabled(False)
+        actions["vertical_align_middle"].setEnabled(False)
+        actions["vertical_align_bottom"].setEnabled(False)
 
+        actions["horizontal_align_left"] = Action(_("horizontal_align_left"), self)
+        actions["horizontal_align_center"] = Action(_("horizontal_align_center"), self)
+        actions["horizontal_align_right"] = Action(_("horizontal_align_right"), self)
 
-        actions['horizontal_align_left'] = Action(_("horizontal_align_left"), self)
-        actions['horizontal_align_center'] = Action(_("horizontal_align_center"), self)
-        actions['horizontal_align_right'] = Action(_("horizontal_align_right"), self)
+        actions["horizontal_align_left"].setEnabled(False)
+        actions["horizontal_align_center"].setEnabled(False)
+        actions["horizontal_align_right"].setEnabled(False)
 
-        actions['horizontal_align_left'].setEnabled(False)
-        actions['horizontal_align_center'].setEnabled(False)
-        actions['horizontal_align_right'].setEnabled(False)
+        actions["create_hier"] = Action(_("create_hier_block"), self)
+        actions["open_hier"] = Action(_("open_hier_block"), self)
+        actions["toggle_source_bus"] = Action(_("toggle_source_bus"), self)
+        actions["toggle_sink_bus"] = Action(_("toggle_sink_bus"), self)
 
-        actions['create_hier'] = Action(_("create_hier_block"), self)
-        actions['open_hier'] = Action(_("open_hier_block"), self)
-        actions['toggle_source_bus'] = Action(_("toggle_source_bus"), self)
-        actions['toggle_sink_bus'] = Action(_("toggle_sink_bus"), self)
+        actions["create_hier"].setEnabled(False)
+        actions["open_hier"].setEnabled(False)
+        actions["toggle_source_bus"].setEnabled(False)
+        actions["toggle_sink_bus"].setEnabled(False)
 
-        actions['create_hier'].setEnabled(False)
-        actions['open_hier'].setEnabled(False)
-        actions['toggle_source_bus'].setEnabled(False)
-        actions['toggle_sink_bus'].setEnabled(False)
-
-        actions['properties'] = Action(Icons('document-properties'), _("flowgraph-properties"),
-                                       self, statusTip=_("flowgraph-properties-tooltip"))
-        actions['properties'].setEnabled(False)
+        actions["properties"] = Action(
+            Icons("document-properties"),
+            _("flowgraph-properties"),
+            self,
+            statusTip=_("flowgraph-properties-tooltip"),
+        )
+        actions["properties"].setEnabled(False)
 
         # View Actions
-        actions['snap_to_grid'] = Action(_("snap_to_grid"), self)
-        actions['snap_to_grid'].setCheckable(True)
+        actions["snap_to_grid"] = Action(_("snap_to_grid"), self)
+        actions["snap_to_grid"].setCheckable(True)
 
-        actions['toggle_grid'] = Action(_("toggle_grid"), self, shortcut='G',
-                                   statusTip=_("toggle_grid-tooltip"))
+        actions["toggle_grid"] = Action(
+            _("toggle_grid"), self, shortcut="G", statusTip=_("toggle_grid-tooltip")
+        )
 
-        actions['errors'] = Action(Icons('dialog-error'), _("errors"), self,
-                                   statusTip=_("errors-tooltip"))
+        actions["errors"] = Action(
+            Icons("dialog-error"), _("errors"), self, statusTip=_("errors-tooltip")
+        )
 
-        actions['find'] = Action(Icons('edit-find'), _("find"), self,
-                                 shortcut=Keys.Find,
-                                 statusTip=_("find-tooltip"))
+        actions["find"] = Action(
+            Icons("edit-find"),
+            _("find"),
+            self,
+            shortcut=Keys.Find,
+            statusTip=_("find-tooltip"),
+        )
 
         # Help Actions
-        actions['about'] = Action(Icons('help-about'), _("about"), self,
-                                  statusTip=_("about-tooltip"))
+        actions["about"] = Action(
+            Icons("help-about"), _("about"), self, statusTip=_("about-tooltip")
+        )
 
-        actions['about_qt'] = Action(self.style().standardIcon(QStyle.SP_TitleBarMenuButton), _("about-qt"), self,
-                                     statusTip=_("about-tooltip"))
+        actions["about_qt"] = Action(
+            self.style().standardIcon(QStyle.SP_TitleBarMenuButton),
+            _("about-qt"),
+            self,
+            statusTip=_("about-tooltip"),
+        )
 
-        actions['generate'] = Action(Icons('system-run'), _("process-generate"), self,
-                                     shortcut='F5', statusTip=_("process-generate-tooltip"))
+        actions["generate"] = Action(
+            Icons("system-run"),
+            _("process-generate"),
+            self,
+            shortcut="F5",
+            statusTip=_("process-generate-tooltip"),
+        )
 
-        actions['execute'] = Action(Icons('media-playback-start'), _("process-execute"),
-                                    self, shortcut='F6',
-                                    statusTip=_("process-execute-tooltip"))
+        actions["execute"] = Action(
+            Icons("media-playback-start"),
+            _("process-execute"),
+            self,
+            shortcut="F6",
+            statusTip=_("process-execute-tooltip"),
+        )
 
-        actions['kill'] = Action(Icons('process-stop'), _("process-kill"), self,
-                                 shortcut='F7', statusTip=_("process-kill-tooltip"))
+        actions["kill"] = Action(
+            Icons("process-stop"),
+            _("process-kill"),
+            self,
+            shortcut="F7",
+            statusTip=_("process-kill-tooltip"),
+        )
 
-        actions['help'] = Action(Icons('help-browser'), _("help"), self,
-                                 shortcut=Keys.HelpContents, statusTip=_("help-tooltip"))
+        actions["help"] = Action(
+            Icons("help-browser"),
+            _("help"),
+            self,
+            shortcut=Keys.HelpContents,
+            statusTip=_("help-tooltip"),
+        )
 
         # Tools Actions
 
-        actions['filter_design_tool'] = Action(_("&Filter Design Tool"), self)
+        actions["filter_design_tool"] = Action(_("&Filter Design Tool"), self)
 
-        actions['set_default_qt_gui_theme'] = Action(_("Set Default &Qt GUI Theme"), self)
+        actions["set_default_qt_gui_theme"] = Action(
+            _("Set Default &Qt GUI Theme"), self
+        )
 
-        actions['module_browser'] = Action(_("&OOT Module Browser"), self)
+        actions["module_browser"] = Action(_("&OOT Module Browser"), self)
 
-        actions['show_flowgraph_complexity'] = Action(_("show_flowgraph_complexity"), self)
-        actions['show_flowgraph_complexity'].setCheckable(True)
+        actions["show_flowgraph_complexity"] = Action(
+            _("show_flowgraph_complexity"), self
+        )
+        actions["show_flowgraph_complexity"].setCheckable(True)
 
         # Help Actions
 
-        actions['types'] = Action(_("&Types"), self)
+        actions["types"] = Action(_("&Types"), self)
 
-        actions['keys'] = Action(_("&Keys"), self)
+        actions["keys"] = Action(_("&Keys"), self)
 
-        actions['parser_errors'] = Action("Parser Errors", self)
+        actions["parser_errors"] = Action("Parser Errors", self)
 
-        actions['get_involved'] = Action(_("&Get Involved"), self)
+        actions["get_involved"] = Action(_("&Get Involved"), self)
 
-        actions['preferences'] = Action(Icons('preferences-system'), _("preferences"), self,
-                                        statusTip=_("preferences-tooltip"))
+        actions["preferences"] = Action(
+            Icons("preferences-system"),
+            _("preferences"),
+            self,
+            statusTip=_("preferences-tooltip"),
+        )
 
-        actions['reload'] = Action(Icons('view-refresh'), _("reload"), self,
-                                        statusTip=_("reload-tooltip"))
+        actions["reload"] = Action(
+            Icons("view-refresh"), _("reload"), self, statusTip=_("reload-tooltip")
+        )
 
         # Disable some actions, by default
-        actions['save'].setEnabled(True)
-        actions['errors'].setEnabled(False)
-
-
-
+        actions["save"].setEnabled(True)
+        actions["errors"].setEnabled(False)
 
     def updateDocTab(self):
         pass
-        '''
+        """
         doc_txt = self._app().DocumentationTab._text
         blocks = self.currentFlowgraph.selected_blocks()
         if len(blocks) == 1:
             #print(blocks[0].documentation)
             doc_string = blocks[0].documentation['']
             doc_txt.setText(doc_string)
-        '''
+        """
 
     def updateActions(self):
-        ''' Update the available actions based on what is selected '''
+        """Update the available actions based on what is selected"""
 
         blocks = self.currentFlowgraph.selected_blocks()
         conns = self.currentFlowgraph.selected_connections()
@@ -411,75 +541,77 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         valid_fg = self.currentFlowgraph.is_valid()
         saved_fg = self.currentView.saved
 
-        self.actions['save'].setEnabled(saved_fg)
+        self.actions["save"].setEnabled(saved_fg)
 
-        self.actions['undo'].setEnabled(canUndo)
-        self.actions['redo'].setEnabled(canRedo)
-        self.actions['generate'].setEnabled(valid_fg)
-        self.actions['execute'].setEnabled(valid_fg)
-        self.actions['errors'].setEnabled(not valid_fg)
-        self.actions['kill'].setEnabled(False) # TODO: Set this properly
+        self.actions["undo"].setEnabled(canUndo)
+        self.actions["redo"].setEnabled(canRedo)
+        self.actions["generate"].setEnabled(valid_fg)
+        self.actions["execute"].setEnabled(valid_fg)
+        self.actions["errors"].setEnabled(not valid_fg)
+        self.actions["kill"].setEnabled(False)  # TODO: Set this properly
 
-        self.actions['cut'].setEnabled(False)
-        self.actions['copy'].setEnabled(False)
-        self.actions['paste'].setEnabled(False)
-        self.actions['delete'].setEnabled(False)
-        self.actions['rotate_cw'].setEnabled(False)
-        self.actions['rotate_ccw'].setEnabled(False)
-        self.actions['enable'].setEnabled(False)
-        self.actions['disable'].setEnabled(False)
-        self.actions['bypass'].setEnabled(False)
-        self.actions['properties'].setEnabled(False)
-        self.actions['create_hier'].setEnabled(False)
-        self.actions['toggle_source_bus'].setEnabled(False)
-        self.actions['toggle_sink_bus'].setEnabled(False)
+        self.actions["cut"].setEnabled(False)
+        self.actions["copy"].setEnabled(False)
+        self.actions["paste"].setEnabled(False)
+        self.actions["delete"].setEnabled(False)
+        self.actions["rotate_cw"].setEnabled(False)
+        self.actions["rotate_ccw"].setEnabled(False)
+        self.actions["enable"].setEnabled(False)
+        self.actions["disable"].setEnabled(False)
+        self.actions["bypass"].setEnabled(False)
+        self.actions["properties"].setEnabled(False)
+        self.actions["create_hier"].setEnabled(False)
+        self.actions["toggle_source_bus"].setEnabled(False)
+        self.actions["toggle_sink_bus"].setEnabled(False)
 
         if self.clipboard:
-            self.actions['paste'].setEnabled(True)
+            self.actions["paste"].setEnabled(True)
 
         if len(conns) > 0:
-            self.actions['delete'].setEnabled(True)
+            self.actions["delete"].setEnabled(True)
 
         if len(blocks) > 0:
-            self.actions['cut'].setEnabled(True)
-            self.actions['copy'].setEnabled(True)
-            self.actions['delete'].setEnabled(True)
-            self.actions['rotate_cw'].setEnabled(True)
-            self.actions['rotate_ccw'].setEnabled(True)
-            self.actions['enable'].setEnabled(True)
-            self.actions['disable'].setEnabled(True)
-            self.actions['bypass'].setEnabled(True)
-            self.actions['toggle_source_bus'].setEnabled(True)
-            self.actions['toggle_sink_bus'].setEnabled(True)
+            self.actions["cut"].setEnabled(True)
+            self.actions["copy"].setEnabled(True)
+            self.actions["delete"].setEnabled(True)
+            self.actions["rotate_cw"].setEnabled(True)
+            self.actions["rotate_ccw"].setEnabled(True)
+            self.actions["enable"].setEnabled(True)
+            self.actions["disable"].setEnabled(True)
+            self.actions["bypass"].setEnabled(True)
+            self.actions["toggle_source_bus"].setEnabled(True)
+            self.actions["toggle_sink_bus"].setEnabled(True)
 
-            self.actions['vertical_align_top'].setEnabled(False)
-            self.actions['vertical_align_middle'].setEnabled(False)
-            self.actions['vertical_align_bottom'].setEnabled(False)
+            self.actions["vertical_align_top"].setEnabled(False)
+            self.actions["vertical_align_middle"].setEnabled(False)
+            self.actions["vertical_align_bottom"].setEnabled(False)
 
-            self.actions['horizontal_align_left'].setEnabled(False)
-            self.actions['horizontal_align_center'].setEnabled(False)
-            self.actions['horizontal_align_right'].setEnabled(False)
+            self.actions["horizontal_align_left"].setEnabled(False)
+            self.actions["horizontal_align_center"].setEnabled(False)
+            self.actions["horizontal_align_right"].setEnabled(False)
 
             if len(blocks) == 1:
-                self.actions['properties'].setEnabled(True)
-                self.actions['create_hier'].setEnabled(True) # TODO: Other requirements for enabling this?
+                self.actions["properties"].setEnabled(True)
+                self.actions["create_hier"].setEnabled(
+                    True
+                )  # TODO: Other requirements for enabling this?
 
             if len(blocks) > 1:
-                self.actions['vertical_align_top'].setEnabled(True)
-                self.actions['vertical_align_middle'].setEnabled(True)
-                self.actions['vertical_align_bottom'].setEnabled(True)
+                self.actions["vertical_align_top"].setEnabled(True)
+                self.actions["vertical_align_middle"].setEnabled(True)
+                self.actions["vertical_align_bottom"].setEnabled(True)
 
-                self.actions['horizontal_align_left'].setEnabled(True)
-                self.actions['horizontal_align_center'].setEnabled(True)
-                self.actions['horizontal_align_right'].setEnabled(True)
+                self.actions["horizontal_align_left"].setEnabled(True)
+                self.actions["horizontal_align_center"].setEnabled(True)
+                self.actions["horizontal_align_right"].setEnabled(True)
 
             for block in blocks:
                 if not block.can_bypass():
-                    self.actions['bypass'].setEnabled(False)
+                    self.actions["bypass"].setEnabled(False)
                     break
 
     def createMenus(self, actions, menus):
-        ''' Setup the main menubar for the application '''
+        """Setup the main menubar for the application"""
         log.debug("Creating menus")
 
         # Global menu options
@@ -487,73 +619,73 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
         # Setup the file menu
         file = Menu("&File")
-        file.addAction(actions['new'])
-        file.addAction(actions['open'])
-        file.addAction(actions['close'])
-        file.addAction(actions['close_all'])
+        file.addAction(actions["new"])
+        file.addAction(actions["open"])
+        file.addAction(actions["close"])
+        file.addAction(actions["close_all"])
         file.addSeparator()
-        file.addAction(actions['save'])
-        file.addAction(actions['save_as'])
-        file.addAction(actions['save_copy'])
+        file.addAction(actions["save"])
+        file.addAction(actions["save_as"])
+        file.addAction(actions["save_copy"])
         file.addSeparator()
-        file.addAction(actions['screen_capture'])
+        file.addAction(actions["screen_capture"])
         file.addSeparator()
-        file.addAction(actions['preferences'])
+        file.addAction(actions["preferences"])
         file.addSeparator()
-        file.addAction(actions['exit'])
-        menus['file'] = file
+        file.addAction(actions["exit"])
+        menus["file"] = file
 
         # Setup the edit menu
         edit = Menu("&Edit")
-        edit.addAction(actions['undo'])
-        edit.addAction(actions['redo'])
-        edit.addAction(actions['view_undo_stack'])
+        edit.addAction(actions["undo"])
+        edit.addAction(actions["redo"])
+        edit.addAction(actions["view_undo_stack"])
         edit.addSeparator()
-        edit.addAction(actions['cut'])
-        edit.addAction(actions['copy'])
-        edit.addAction(actions['paste'])
-        edit.addAction(actions['delete'])
-        edit.addAction(actions['select_all'])
-        edit.addAction(actions['select_none'])
+        edit.addAction(actions["cut"])
+        edit.addAction(actions["copy"])
+        edit.addAction(actions["paste"])
+        edit.addAction(actions["delete"])
+        edit.addAction(actions["select_all"])
+        edit.addAction(actions["select_none"])
         edit.addSeparator()
-        edit.addAction(actions['rotate_ccw'])
-        edit.addAction(actions['rotate_cw'])
+        edit.addAction(actions["rotate_ccw"])
+        edit.addAction(actions["rotate_cw"])
 
         align = Menu("&Align")
-        menus['align'] = align
-        align.addAction(actions['vertical_align_top'])
-        align.addAction(actions['vertical_align_middle'])
-        align.addAction(actions['vertical_align_bottom'])
+        menus["align"] = align
+        align.addAction(actions["vertical_align_top"])
+        align.addAction(actions["vertical_align_middle"])
+        align.addAction(actions["vertical_align_bottom"])
         align.addSeparator()
-        align.addAction(actions['horizontal_align_left'])
-        align.addAction(actions['horizontal_align_center'])
-        align.addAction(actions['horizontal_align_right'])
+        align.addAction(actions["horizontal_align_left"])
+        align.addAction(actions["horizontal_align_center"])
+        align.addAction(actions["horizontal_align_right"])
 
         edit.addMenu(align)
         edit.addSeparator()
-        edit.addAction(actions['enable'])
-        edit.addAction(actions['disable'])
-        edit.addAction(actions['bypass'])
+        edit.addAction(actions["enable"])
+        edit.addAction(actions["disable"])
+        edit.addAction(actions["bypass"])
         edit.addSeparator()
 
         more = Menu("&More")
-        menus['more'] = more
-        more.addAction(actions['create_hier'])
-        more.addAction(actions['open_hier'])
-        more.addAction(actions['toggle_source_bus'])
-        more.addAction(actions['toggle_sink_bus'])
+        menus["more"] = more
+        more.addAction(actions["create_hier"])
+        more.addAction(actions["open_hier"])
+        more.addAction(actions["toggle_source_bus"])
+        more.addAction(actions["toggle_sink_bus"])
 
         edit.addMenu(more)
-        edit.addAction(actions['properties'])
-        menus['edit'] = edit
+        edit.addAction(actions["properties"])
+        menus["edit"] = edit
 
         # Setup submenu
         panels = Menu("&Panels")
-        menus['panels'] = panels
+        menus["panels"] = panels
         panels.setEnabled(False)
 
         toolbars = Menu("&Toolbars")
-        menus['toolbars'] = toolbars
+        menus["toolbars"] = toolbars
         toolbars.setEnabled(False)
 
         # Setup the view menu
@@ -561,73 +693,73 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         view.addMenu(panels)
         view.addMenu(toolbars)
         view.addSeparator()
-        view.addAction(actions['toggle_grid'])
-        view.addAction(actions['find'])
-        menus['view'] = view
+        view.addAction(actions["toggle_grid"])
+        view.addAction(actions["find"])
+        menus["view"] = view
 
         # Setup the build menu
         build = Menu("&Build")
-        build.addAction(actions['errors'])
-        build.addAction(actions['generate'])
-        build.addAction(actions['execute'])
-        build.addAction(actions['kill'])
-        menus['build'] = build
+        build.addAction(actions["errors"])
+        build.addAction(actions["generate"])
+        build.addAction(actions["execute"])
+        build.addAction(actions["kill"])
+        menus["build"] = build
 
         # Setup the tools menu
         tools = Menu("&Tools")
-        tools.addAction(actions['filter_design_tool'])
-        tools.addAction(actions['set_default_qt_gui_theme'])
-        tools.addAction(actions['module_browser'])
+        tools.addAction(actions["filter_design_tool"])
+        tools.addAction(actions["set_default_qt_gui_theme"])
+        tools.addAction(actions["module_browser"])
         tools.addSeparator()
-        tools.addAction(actions['show_flowgraph_complexity'])
-        menus['tools'] = tools
+        tools.addAction(actions["show_flowgraph_complexity"])
+        menus["tools"] = tools
 
         # Setup the help menu
         help = Menu("&Help")
-        help.addAction(actions['help'])
-        help.addAction(actions['types'])
-        help.addAction(actions['keys'])
-        help.addAction(actions['parser_errors'])
+        help.addAction(actions["help"])
+        help.addAction(actions["types"])
+        help.addAction(actions["keys"])
+        help.addAction(actions["parser_errors"])
         help.addSeparator()
-        help.addAction(actions['get_involved'])
-        help.addAction(actions['about'])
-        help.addAction(actions['about_qt'])
-        menus['help'] = help
+        help.addAction(actions["get_involved"])
+        help.addAction(actions["about"])
+        help.addAction(actions["about_qt"])
+        menus["help"] = help
 
     def createToolbars(self, actions, toolbars):
         log.debug("Creating toolbars")
 
         # Main toolbar
         file = Toolbar("File")
-        file.addAction(actions['new'])
-        file.addAction(actions['open'])
-        file.addAction(actions['save'])
-        file.addAction(actions['close'])
-        toolbars['file'] = file
+        file.addAction(actions["new"])
+        file.addAction(actions["open"])
+        file.addAction(actions["save"])
+        file.addAction(actions["close"])
+        toolbars["file"] = file
 
         # Edit toolbar
         edit = Toolbar("Edit")
-        edit.addAction(actions['undo'])
-        edit.addAction(actions['redo'])
+        edit.addAction(actions["undo"])
+        edit.addAction(actions["redo"])
         edit.addSeparator()
-        edit.addAction(actions['cut'])
-        edit.addAction(actions['copy'])
-        edit.addAction(actions['paste'])
-        edit.addAction(actions['delete'])
-        toolbars['edit'] = edit
+        edit.addAction(actions["cut"])
+        edit.addAction(actions["copy"])
+        edit.addAction(actions["paste"])
+        edit.addAction(actions["delete"])
+        toolbars["edit"] = edit
 
         # Run Toolbar
-        run = Toolbar('Run')
-        run.addAction(actions['errors'])
-        run.addAction(actions['generate'])
-        run.addAction(actions['execute'])
-        run.addAction(actions['kill'])
-        toolbars['run'] = run
+        run = Toolbar("Run")
+        run.addAction(actions["errors"])
+        run.addAction(actions["generate"])
+        run.addAction(actions["execute"])
+        run.addAction(actions["kill"])
+        toolbars["run"] = run
 
         # Misc Toolbar
-        misc = Toolbar('Misc')
-        misc.addAction(actions['reload'])
-        toolbars['misc'] = misc
+        misc = Toolbar("Misc")
+        misc.addAction(actions["reload"])
+        toolbars["misc"] = misc
 
     def createStatusBar(self):
         log.debug("Creating status bar")
@@ -635,19 +767,25 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
     def open(self):
         Open = QtWidgets.QFileDialog.getOpenFileName
-        filename, filtr = Open(self, self.actions['open'].statusTip(),
-                               filter='Flow Graph Files (*.grc);;All files (*.*)')
+        filename, filtr = Open(
+            self,
+            self.actions["open"].statusTip(),
+            filter="Flow Graph Files (*.grc);;All files (*.*)",
+        )
         return filename
 
     def save(self):
         Save = QtWidgets.QFileDialog.getSaveFileName
-        filename, filtr = Save(self, self.actions['save'].statusTip(),
-                               filter='Flow Graph Files (*.grc);;All files (*.*)')
+        filename, filtr = Save(
+            self,
+            self.actions["save"].statusTip(),
+            filter="Flow Graph Files (*.grc);;All files (*.*)",
+        )
         return filename
 
     # Overridden methods
     def addDockWidget(self, location, widget):
-        ''' Adds a dock widget to the view. '''
+        """Adds a dock widget to the view."""
         # This overrides QT's addDockWidget so that a 'show' menu auto can automatically be
         # generated for this action.
         super().addDockWidget(location, widget)
@@ -658,10 +796,10 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
         # Create the new action and wire it to the show/hide for the widget
         self.menus["panels"].addAction(widget.toggleViewAction())
-        self.menus['panels'].setEnabled(True)
+        self.menus["panels"].setEnabled(True)
 
     def addToolBar(self, toolbar):
-        ''' Adds a toolbar to the main window '''
+        """Adds a toolbar to the main window"""
         # This is also overridden so a show menu item can automatically be added
         super().addToolBar(toolbar)
         name = toolbar.windowTitle()
@@ -669,16 +807,16 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
         # Create the new action and wire it to the show/hide for the widget
         self.menus["toolbars"].addAction(toolbar.toggleViewAction())
-        self.menus['toolbars'].setEnabled(True)
+        self.menus["toolbars"].setEnabled(True)
 
     def addMenu(self, menu):
-        ''' Adds a menu to the main window '''
+        """Adds a menu to the main window"""
         help = self.menus["help"].menuAction()
         self.menuBar().insertMenu(help, menu)
 
     # Action Handlers
     def new_triggered(self):
-        log.debug('New')
+        log.debug("New")
         log.debug("Loading flowgraph model")
         fg_view = FlowgraphView(self)
         fg_view.centerOn(0, 0)
@@ -688,9 +826,8 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
         self.tabWidget.addTab(fg_view, "Untitled")
 
-
     def open_triggered(self):
-        log.debug('open')
+        log.debug("open")
         filename = self.open()
 
         if filename:
@@ -703,56 +840,61 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             self.currentFlowgraph.selectionChanged.connect(self.updateActions)
 
     def save_triggered(self):
-        log.debug('save')
+        log.debug("save")
         filename = self.currentFlowgraph.filename
 
         if filename:
             try:
                 self.platform.save_flow_graph(filename, self.currentView)
             except IOError:
-                log.error('Save failed')
+                log.error("Save failed")
                 return
 
-            log.info(f'Saved {filename}')
+            log.info(f"Saved {filename}")
             self.currentView.saved = True
         else:
-            log.debug('Flowgraph does not have a filename')
+            log.debug("Flowgraph does not have a filename")
             self.save_as_triggered()
 
-
     def save_as_triggered(self):
-        log.debug('Save As')
-        filename, filtr = QtWidgets.QFileDialog.getSaveFileName(self, self.actions['save'].statusTip(),
-                               filter='Flow Graph Files (*.grc);;All files (*.*)')
+        log.debug("Save As")
+        filename, filtr = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            self.actions["save"].statusTip(),
+            filter="Flow Graph Files (*.grc);;All files (*.*)",
+        )
         if filename:
             self.currentFlowgraph.filename = filename
             try:
                 self.platform.save_flow_graph(filename, self.currentView)
             except IOError:
-                log.error('Save (as) failed')
+                log.error("Save (as) failed")
                 return
 
-            log.info(f'Saved (as) {filename}')
+            log.info(f"Saved (as) {filename}")
             self.currentView.saved = True
         else:
-            log.debug('Cancelled Save As action')
+            log.debug("Cancelled Save As action")
 
     def save_copy_triggered(self):
-        log.debug('Save Copy')
-        filename, filtr = QtWidgets.QFileDialog.getSaveFileName(self, self.actions['save'].statusTip(),
-                               filter='Flow Graph Files (*.grc);;All files (*.*)')
+        log.debug("Save Copy")
+        filename, filtr = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            self.actions["save"].statusTip(),
+            filter="Flow Graph Files (*.grc);;All files (*.*)",
+        )
         if filename:
             try:
                 self.platform.save_flow_graph(filename, self.currentView)
             except IOError:
-                log.error('Save (copy) failed')
+                log.error("Save (copy) failed")
 
-            log.info(f'Saved (copy) {filename}')
+            log.info(f"Saved (copy) {filename}")
         else:
-            log.debug('Cancelled Save Copy action')
+            log.debug("Cancelled Save Copy action")
 
     def close_triggered(self, tab_index=None):
-        log.debug(f'Closing a tab (index {tab_index})')
+        log.debug(f"Closing a tab (index {tab_index})")
 
         if tab_index is None:
             tab_index = self.tabWidget.currentIndex()
@@ -761,12 +903,16 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             self.tabWidget.removeTab(tab_index)
         else:
             message = "Save changes before closing?"
-
-            ad = QtWidgets.QMessageBox()
-            ad.setWindowTitle("Unsaved Changes")
-            ad.setText(message)
-            ad.setStandardButtons(QtWidgets.QMessageBox.Discard | QtWidgets.QMessageBox.Cancel | QtWidgets.QMessageBox.Save)
-            response = ad.exec()
+            response = QtWidgets.QMessageBox.question(
+                None,
+                "Unsaved Changes",
+                message,
+                QtWidgets.QMessageBox.StandardButtons(
+                    QtWidgets.QMessageBox.Discard
+                    | QtWidgets.QMessageBox.Cancel
+                    | QtWidgets.QMessageBox.Save
+                ),
+            )
 
             if response == QtWidgets.QMessageBox.Discard:
                 self.tabWidget.removeTab(tab_index)
@@ -783,7 +929,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             self.new_triggered()
 
     def close_all_triggered(self):
-        log.debug('close')
+        log.debug("close")
 
         while self.tabWidget.count() > 1:
             self.close_triggered()
@@ -791,138 +937,146 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.close_triggered()
 
     def print_triggered(self):
-        log.debug('print')
+        log.debug("print")
 
     def screen_capture_triggered(self):
-        log.debug('screen capture')
+        log.debug("screen capture")
         # TODO: Should be user-set somehow
         background_transparent = True
 
         Save = QtWidgets.QFileDialog.getSaveFileName
-        file_path, filtr = Save(self, self.actions['save'].statusTip(),
-                               filter='PDF files (*.pdf);;PNG files (*.png);;SVG files (*.svg)')
+        file_path, filtr = Save(
+            self,
+            self.actions["save"].statusTip(),
+            filter="PDF files (*.pdf);;PNG files (*.png);;SVG files (*.svg)",
+        )
         if file_path is not None:
             try:
                 Utils.make_screenshot(
-                    self.currentView, file_path, background_transparent)
+                    self.currentView, file_path, background_transparent
+                )
             except ValueError:
-                Messages.send('Failed to generate screenshot\n')
+                Messages.send("Failed to generate screenshot\n")
 
     def undo_triggered(self):
-        log.debug('undo')
+        log.debug("undo")
         self.currentFlowgraph.undoStack.undo()
         self.updateActions()
 
     def redo_triggered(self):
-        log.debug('redo')
+        log.debug("redo")
         self.currentFlowgraph.undoStack.redo()
         self.updateActions()
 
     def view_undo_stack_triggered(self):
-        log.debug('view_undo_stack')
+        log.debug("view_undo_stack")
         self.undoView = QtWidgets.QUndoView(self.currentFlowgraph.undoStack)
         self.undoView.setWindowTitle("Undo stack")
         self.undoView.show()
 
     def cut_triggered(self):
-        log.debug('cut')
+        log.debug("cut")
         self.copy_triggered()
         self.currentFlowgraph.delete_selected()
         self.updateActions()
 
     def copy_triggered(self):
-        log.debug('copy')
+        log.debug("copy")
         self.clipboard = self.currentFlowgraph.copy_to_clipboard()
         self.updateActions()
 
     def paste_triggered(self):
-        log.debug('paste')
+        log.debug("paste")
         if self.clipboard:
             self.currentFlowgraph.paste_from_clipboard(self.clipboard)
             self.currentFlowgraph.update()
         else:
-            log.debug('clipboard is empty')
+            log.debug("clipboard is empty")
 
     def delete_triggered(self):
-        log.debug('delete')
+        log.debug("delete")
         action = DeleteElementAction(self.currentFlowgraph)
         self.currentFlowgraph.undoStack.push(action)
         self.updateActions()
 
     def select_all_triggered(self):
-        log.debug('select_all')
+        log.debug("select_all")
         self.currentFlowgraph.select_all()
         self.updateActions()
 
     def select_none_triggered(self):
-        log.debug('select_none')
+        log.debug("select_none")
         self.currentFlowgraph.clearSelection()
         self.updateActions()
 
     def rotate_ccw_triggered(self):
         # Pass to Undo/Redo
-        log.debug('rotate_ccw')
+        log.debug("rotate_ccw")
         rotateCommand = RotateAction(self.currentFlowgraph, -90)
         self.currentFlowgraph.undoStack.push(rotateCommand)
         self.updateActions()
 
     def rotate_cw_triggered(self):
         # Pass to Undo/Redo
-        log.debug('rotate_cw')
+        log.debug("rotate_cw")
         rotateCommand = RotateAction(self.currentFlowgraph, 90)
         self.currentFlowgraph.undoStack.push(rotateCommand)
         self.updateActions()
 
     def toggle_source_bus_triggered(self):
-        log.debug('toggle_source_bus')
+        log.debug("toggle_source_bus")
         for b in self.currentFlowgraph.selected_blocks():
-                b.bussify('source')
+            b.bussify("source")
         self.currentFlowgraph.update()
 
     def toggle_sink_bus_triggered(self):
-        log.debug('toggle_source_bus')
+        log.debug("toggle_source_bus")
         for b in self.currentFlowgraph.selected_blocks():
-                b.bussify('sink')
+            b.bussify("sink")
         self.currentFlowgraph.update()
 
     def errors_triggered(self):
-        log.debug('errors')
+        log.debug("errors")
         err = ErrorsDialog(self.currentFlowgraph)
         err.exec()
 
     def find_triggered(self):
-        log.debug('find block')
+        log.debug("find block")
         self._app().BlockLibrary._search_bar.setFocus()
 
     def get_involved_triggered(self):
-        log.debug('get involved')
+        log.debug("get involved")
         ad = QtWidgets.QMessageBox()
         ad.setWindowTitle("Get Involved Instructions")
-        ad.setText("""\
+        ad.setText(
+            """\
             <b>Welcome to the GNU Radio Community!</b><br/><br/>
             For more details on contributing to GNU Radio and getting engaged with our great community visit <a href="https://wiki.gnuradio.org/index.php/HowToGetInvolved">here</a>.<br/><br/>
             You can also join our <a href="https://chat.gnuradio.org/">Matrix chat server</a>, IRC Channel (#gnuradio) or contact through our <a href="https://lists.gnu.org/mailman/listinfo/discuss-gnuradio">mailing list (discuss-gnuradio)</a>.
-        """)
+        """
+        )
         ad.exec()
 
     def about_triggered(self):
-        log.debug('about')
+        log.debug("about")
         config = self.platform.config
         py_version = sys.version.split()[0]
-        ad = QtWidgets.QMessageBox.about(self, "About GNU Radio", f"GNU Radio {config.version} (Python {py_version})")
+        ad = QtWidgets.QMessageBox.about(
+            self, "About GNU Radio", f"GNU Radio {config.version} (Python {py_version})"
+        )
 
     def about_qt_triggered(self):
-        log.debug('about_qt')
+        log.debug("about_qt")
         QtWidgets.QApplication.instance().aboutQt()
 
     def properties_triggered(self):
-        log.debug('properties')
+        log.debug("properties")
 
     def enable_triggered(self):
-        log.debug('enable')
+        log.debug("enable")
         all_enabled = True
         for block in self.currentFlowgraph.selected_blocks():
-            if not block.state == 'enabled':
+            if not block.state == "enabled":
                 all_enabled = False
                 break
 
@@ -934,10 +1088,10 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.updateActions()
 
     def disable_triggered(self):
-        log.debug('disable')
+        log.debug("disable")
         all_disabled = True
         for block in self.currentFlowgraph.selected_blocks():
-            if not block.state == 'disabled':
+            if not block.state == "disabled":
                 all_disabled = False
                 break
 
@@ -949,10 +1103,10 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.updateActions()
 
     def bypass_triggered(self):
-        log.debug('bypass')
+        log.debug("bypass")
         all_bypassed = True
         for block in self.currentFlowgraph.selected_blocks():
-            if not block.state == 'bypassed':
+            if not block.state == "bypassed":
                 all_bypassed = False
                 break
 
@@ -964,29 +1118,31 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.updateActions()
 
     def generate_triggered(self):
-        log.debug('generate')
+        log.debug("generate")
         if not self.currentView.saved:
             self.save_triggered()
-        if not self.currentView.saved: # The line above was cancelled
+        if not self.currentView.saved:  # The line above was cancelled
             log.error("Cannot generate a flowgraph without saving first")
             return
 
         filename = self.currentFlowgraph.filename
-        generator = self.platform.Generator(self.currentFlowgraph, os.path.dirname(filename))
+        generator = self.platform.Generator(
+            self.currentFlowgraph, os.path.dirname(filename)
+        )
         generator.write()
-        log.info(f'Generated {filename}')
+        log.info(f"Generated {filename}")
 
     def execute_triggered(self):
-        log.debug('execute')
+        log.debug("execute")
         filename = self.currentFlowgraph.filename
-        py_path = filename[:-3] + 'py'
-        subprocess.Popen(f'/usr/bin/python {py_path}', shell=True)
+        py_path = filename[:-3] + "py"
+        subprocess.Popen(f"/usr/bin/python {py_path}", shell=True)
 
     def kill_triggered(self):
-        log.debug('kill')
+        log.debug("kill")
 
     def show_help(parent):
-        """ Display basic usage tips. """
+        """Display basic usage tips."""
         message = """\
             <b>Usage Tips</b>
             \n\
@@ -1010,9 +1166,8 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         ad.exec()
 
     def types_triggered(self):
-        log.debug('types')
-        colors = [(name, color)
-              for name, key, sizeof, color in Constants.CORE_TYPES]
+        log.debug("types")
+        colors = [(name, color) for name, key, sizeof, color in Constants.CORE_TYPES]
         max_len = 10 + max(len(name) for name, code in colors)
 
         message = """
@@ -1020,9 +1175,9 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         <tbody>
         """
 
-        message += '\n'.join(
+        message += "\n".join(
             '<tr bgcolor="{color}"><td><tt>{name}</tt></td></tr>'
-            ''.format(color=color, name=name)
+            "".format(color=color, name=name)
             for name, color in colors
         )
         message += "</tbody></table>"
@@ -1032,7 +1187,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         ad.exec()
 
     def keys_triggered(self):
-        log.debug('keys')
+        log.debug("keys")
 
         message = """\
             <b>Keyboard Shortcuts</b>
@@ -1074,31 +1229,34 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         ad.exec()
 
     def preferences_triggered(self):
-        log.debug('preferences')
+        log.debug("preferences")
         prefs_dialog = PreferencesDialog()
         if prefs_dialog.exec_():
             prefs_dialog.save_all()
 
-
     def exit_triggered(self):
-        log.debug('exit')
+        log.debug("exit")
         # TODO: Make sure all flowgraphs have been saved
         self.app.exit()
 
     def help_triggered(self):
-        log.debug('help')
+        log.debug("help")
         self.show_help()
 
     def report_triggered(self):
-        log.debug('report')
+        log.debug("report")
 
     def library_triggered(self):
-        log.debug('library_triggered')
+        log.debug("library_triggered")
 
     def library_toggled(self):
-        log.debug('library_toggled')
+        log.debug("library_toggled")
 
     def filter_design_tool_triggered(self):
-        log.debug('filter_design_tool')
-        subprocess.Popen('gr_filter_design',
-                             shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        log.debug("filter_design_tool")
+        subprocess.Popen(
+            "gr_filter_design",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )

--- a/grc/gui_qt/grc.py
+++ b/grc/gui_qt/grc.py
@@ -34,14 +34,14 @@ from .helpers.profiling import StopWatch
 
 # Logging
 # Setup the logger to use a different name than the file name
-log = logging.getLogger('grc.application')
+log = logging.getLogger("grc.application")
 
 
 class Application(QtWidgets.QApplication):
-    '''
+    """
     This is the main QT application for GRC.
     It handles setting up the application components and actions and handles communication between different components in the system.
-    '''
+    """
 
     def __init__(self, settings, platform):
         # Note. Logger must have the correct naming convention to share handlers
@@ -53,9 +53,9 @@ class Application(QtWidgets.QApplication):
         QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
         QtWidgets.QApplication.__init__(self, settings.argv)
 
-
         try:
             import qdarkstyle
+
             self.setStyleSheet(qdarkstyle.load_stylesheet())
         except ImportError:
             log.warning("Did not find QDarkstyle. Dark mode disabled")
@@ -63,7 +63,6 @@ class Application(QtWidgets.QApplication):
         # Save references to the global settings and gnuradio platform
         self.settings = settings
         self.platform = platform
-
 
         # Load the main view class and initialize QMainWindow
         log.debug("ARGV - {0}".format(settings.argv))
@@ -76,26 +75,36 @@ class Application(QtWidgets.QApplication):
         log.debug("Creating main application window")
         stopwatch = StopWatch()
         self.MainWindow = components.MainWindow()
-        stopwatch.lap('mainwindow')
+        stopwatch.lap("mainwindow")
         self.Console = components.Console()
-        stopwatch.lap('console')
+        stopwatch.lap("console")
         self.BlockLibrary = components.BlockLibrary()
-        stopwatch.lap('blocklibrary')
-        #self.DocumentationTab = components.DocumentationTab()
-        #stopwatch.lap('documentationtab')
+        stopwatch.lap("blocklibrary")
+        # self.DocumentationTab = components.DocumentationTab()
+        # stopwatch.lap('documentationtab')
         self.WikiTab = components.WikiTab()
-        stopwatch.lap('wikitab')
+        stopwatch.lap("wikitab")
 
         # Debug times
-        log.debug("Loaded MainWindow controller - {:.4f}s".format(stopwatch.elapsed("mainwindow")))
-        log.debug("Loaded Console component - {:.4f}s".format(stopwatch.elapsed("console")))
-        log.debug("Loaded BlockLibrary component - {:.4}s".format(stopwatch.elapsed("blocklibrary")))
-        #log.debug("Loaded DocumentationTab component - {:.4}s".format(stopwatch.elapsed("documentationtab")))
+        log.debug(
+            "Loaded MainWindow controller - {:.4f}s".format(
+                stopwatch.elapsed("mainwindow")
+            )
+        )
+        log.debug(
+            "Loaded Console component - {:.4f}s".format(stopwatch.elapsed("console"))
+        )
+        log.debug(
+            "Loaded BlockLibrary component - {:.4}s".format(
+                stopwatch.elapsed("blocklibrary")
+            )
+        )
+        # log.debug("Loaded DocumentationTab component - {:.4}s".format(stopwatch.elapsed("documentationtab")))
 
         # Print Startup information once everything has loaded
         log.critical("TODO: Change welcome message.")
 
-        welcome = '''
+        welcome = """
         linux; GNU C++ version 4.8.2; Boost_105400; UHD_003.007.002-94-ge56809a0
 
         <<< Welcome to GNU Radio Companion 3.7.6git-1-g01deede >>>
@@ -105,15 +114,16 @@ class Application(QtWidgets.QApplication):
           /home/seth/Dev/gnuradio/target/share/gnuradio/grc/blocks
           /home/seth/.grc_gnuradio
         Loading: \"/home/seth/Dev/persistent-ew/gnuradio/target/flex_rx.grc\"
-        '''
+        """
 
         config = platform.config
-        paths="\n\t".join(platform.config.block_paths)
-        welcome = f"<<< Welcome to {config.name} {config.version} >>>\n\n" \
-                  f"Preferences file: {config.gui_prefs_file}\n" \
-                  f"Block paths:\n\t{paths}\n"
+        paths = "\n\t".join(platform.config.block_paths)
+        welcome = (
+            f"<<< Welcome to {config.name} {config.version} >>>\n\n"
+            f"Preferences file: {config.gui_prefs_file}\n"
+            f"Block paths:\n\t{paths}\n"
+        )
         log.info(textwrap.dedent(welcome))
-
 
     # Global registration functions
     #  - Handles the majority of child controller interaciton
@@ -122,14 +132,16 @@ class Application(QtWidgets.QApplication):
         pass
 
     def registerDockWidget(self, widget, location=0):
-        ''' Allows child controllers to register a widget that can be docked in the main window '''
+        """Allows child controllers to register a widget that can be docked in the main window"""
         # TODO: Setup the system to automatically add new "Show <View Name>" menu items when a new
         # dock widget is added.
-        log.debug("Registering widget ({0}, {1})".format(widget.__class__.__name__, location))
+        log.debug(
+            "Registering widget ({0}, {1})".format(widget.__class__.__name__, location)
+        )
         self.MainWindow.registerDockWidget(location, widget)
 
     def registerMenu(self, menu):
-        ''' Allows child controllers to register an a menu rather than just a single action '''
+        """Allows child controllers to register an a menu rather than just a single action"""
         # TODO: Need to have several capabilities:
         #  - Menu's need the ability to have a priority for ordering
         #  - When registering, the controller needs to specific target menu
@@ -142,11 +154,11 @@ class Application(QtWidgets.QApplication):
         self.MainWindow.registerMenu(menu)
 
     def registerAction(self, action, menu):
-        ''' Allows child controllers to register a global action shown in the main window '''
+        """Allows child controllers to register a global action shown in the main window"""
         pass
 
     def run(self):
-        ''' Launches the main QT event loop '''
+        """Launches the main QT event loop"""
         # Show the main window after everything is initialized.
         self.MainWindow.show()
-        return (self.exec_())
+        return self.exec_()


### PR DESCRIPTION
## Description
This PR adds the ability to double-click on a block to add it to a flowgraph. With this, it simplifies many of the qt-specific tests, focusing on making them standalone, and easier to read.

## Related Issue
None

## Which blocks/areas does this affect?
GRC (Qt)

## Testing Done
The `tests/test_qtbot.py` tests were run and passed, and individual testing was done to ensure double click works

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
