### PR TITLE
blocks: fix repeat block tag propagation

### DIFF
--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012 Free Software Foundation, Inc.
+ * Copyright 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -12,6 +13,7 @@
 #define INCLUDED_REPEAT_IMPL_H
 
 #include <gnuradio/blocks/repeat.h>
+#include <cstdint>
 
 namespace gr {
 namespace blocks {
@@ -37,6 +39,19 @@ private:
 
     void msg_set_interpolation(const pmt::pmt_t& msg);
     const pmt::pmt_t c_msg_port;
+
+    //! \brief helper function to propagate tags manually
+    void copy_tags(int consumed, int produced, int num_items)
+    {
+        std::vector<tag_t> tags;
+        const auto start_in = nitems_read(0) + static_cast<uint64_t>(consumed);
+        const auto start_out = nitems_written(0) + static_cast<uint64_t>(produced);
+        get_tags_in_range(tags, 0, start_in, start_in + num_items);
+        for (const auto& tag : tags) {
+            const auto offset = d_interp * (tag.offset - start_in) + start_out;
+            add_item_tag(0, offset, tag.key, tag.value);
+        }
+    }
 };
 
 } /* namespace blocks */

--- a/gr-blocks/python/blocks/qa_repeat.py
+++ b/gr-blocks/python/blocks/qa_repeat.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2008,2010,2012,2013 Free Software Foundation, Inc.
+# Copyright 2023 Daniel Estevez <daniel@destevez.net>
 #
 # This file is part of GNU Radio
 #
@@ -8,9 +9,11 @@
 #
 #
 
+import time
 
-from gnuradio import gr, gr_unittest, blocks
+from gnuradio import gr, gr_unittest, blocks, pdu
 import numpy as np
+import pmt
 
 
 class test_repeat(gr_unittest.TestCase):
@@ -33,6 +36,71 @@ class test_repeat(gr_unittest.TestCase):
         sizes = ((3**10 + 2, 3), (3**6, 1), (4, 5), (10**6, 1), (10 * 2, 10 * 3))
         for size, repetitions in sizes:
             self.run_fg(size, repetitions, f"N = {size}, r = {repetitions}: not equal")
+
+    def test_tag_propagation(self):
+        N = 1000
+        r = 17
+        tags_in = [
+            gr.tag_utils.python_to_tag((
+                j, pmt.intern("test_tag"), pmt.from_long(j), pmt.PMT_NIL))
+            for j in range(N)
+        ]
+        src = blocks.vector_source_i([0] * N, tags=tags_in)
+        rpt = blocks.repeat(gr.sizeof_int, r)
+        dst = blocks.vector_sink_i()
+        self.tb.connect(src, rpt, dst)
+        self.tb.run()
+        tags_out = dst.tags()
+        self.assertEqual(len(tags_in), len(tags_out))
+        for t_in, t_out in zip(tags_in, tags_out):
+            self.assertEqual(t_out.offset, r * t_in.offset)
+            self.assertEqual(t_in.key, t_out.key)
+            self.assertEqual(t_in.value, t_out.value)
+
+    def test_tag_propagation_rate_change(self):
+        # This uses a pdu_to_tagged_stream block to control when data is
+        # produced, allowing us to change the repetition rate exactly when we
+        # want.
+        N1 = 1000
+        r1 = 17
+        N2 = 2000
+        r2 = 13
+        tags_in = [
+            gr.tag_utils.python_to_tag((
+                j, pmt.intern("test_tag"), pmt.from_long(j), pmt.PMT_NIL))
+            for j in range(N1 + N2)
+        ]
+        src_tags = blocks.vector_source_b([0] * (N1 + N2), tags=tags_in)
+        src_data = pdu.pdu_to_tagged_stream(gr.types.byte_t)
+        tag_gate = blocks.tag_gate(gr.sizeof_char)
+        tag_share = blocks.tag_share(gr.sizeof_char, gr.sizeof_char)
+        rpt = blocks.repeat(gr.sizeof_char, r1)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src_data, tag_gate, tag_share, rpt, dst)
+        self.tb.connect(src_tags, (tag_share, 1))
+        self.tb.start()
+        data_pdu = pmt.cons(pmt.PMT_NIL, pmt.make_u8vector(N1, 0))
+        src_data.to_basic_block()._post(pmt.intern("pdus"), data_pdu)
+        # Wait for some time for the data to flow through
+        time.sleep(0.1)
+        rpt.set_interpolation(r2)
+        data_pdu = pmt.cons(pmt.PMT_NIL, pmt.make_u8vector(N2, 0))
+        src_data.to_basic_block()._post(pmt.intern("pdus"), data_pdu)
+        src_data.to_basic_block()._post(
+            pmt.intern('system'),
+            pmt.cons(pmt.intern('done'), pmt.from_long(1)))
+        self.tb.wait()
+        self.assertEqual(len(dst.data()), N1 * r1 + N2 * r2)
+        tags_out = dst.tags()
+        self.assertEqual(len(tags_out), len(tags_in))
+        for t_in, t_out in zip(tags_in[:N1], tags_out[:N1]):
+            self.assertEqual(t_out.offset, r1 * t_in.offset)
+            self.assertEqual(t_in.key, t_out.key)
+            self.assertEqual(t_in.value, t_out.value)
+        for t_in, t_out in zip(tags_in[N1:], tags_out[N1:]):
+            self.assertEqual(t_out.offset, N1 * r1 + r2 * (t_in.offset - N1))
+            self.assertEqual(t_in.key, t_out.key)
+            self.assertEqual(t_in.value, t_out.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The repeat block was refactored as a general block in #6813 (it was a sync_interpolator before). However, tag propagation was missing from the refactor. Manual tag propagation needs to be done if the block is a general block, because the automatic tag propagation preserves the offset of tags, which is not what we want for the repeat block.

Incidentally, before the refactor tag propagation was also somehow broken for interpolation changes at runtime. After an interpolation change, tags would disappear in the output for some time, or appear in the wrong place.

The tag propagation behaviour introduced by this block is the most natural one. Tags from each input item are copied to the first repetition of such input item in the output.

Additionally, two QA tests for tag propagation have been added. One of them does no interpolation changes at runtime, and the other does one interpolation change at runtime. The two tests do not pass with the previous version of the repeat block, but they pass after adding this fix.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Repeat block.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Added two QA tests that fail with the current `main` but pass with this fix. 

Additionally, I have used the following flowgraph to see the effects of interpolation changes at runtime in the output tags.
[test_repeat.zip](https://github.com/gnuradio/gnuradio/files/12595733/test_repeat.zip)
This flowgraph can be used to see how tag propagation was broken even before #6813.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary => *TODO:* The wiki doesn't say anything about how Repeat does propagation. We might want to add a sentence saying that "Tags from each input item are copied to the first repetition of such input item in the output."
- [x] I have added tests to cover my changes, and all previous tests pass.
