### PR TITLE
network: improved UDP Source vectorization

### DIFF
--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -99,10 +99,17 @@ udp_source_impl::udp_source_impl(size_t itemsize,
             "least 8 bytes once header/trailer adjustments are made.");
     }
 
-    d_precomp_data_size = d_payloadsize - d_header_size;
-    d_precomp_data_over_item_size = d_precomp_data_size / d_itemsize;
+    if (d_payloadsize % d_block_size) {
+        d_logger->error("Payload size must be a multiple of item size * vector length.");
 
-    int out_multiple = (d_payloadsize - d_header_size) / d_block_size;
+        throw std::invalid_argument(
+            "Payload size must be a multiple of item size * vector length.");
+    }
+
+    d_precomp_data_size = d_payloadsize - d_header_size;
+    d_precomp_data_over_item_size = d_precomp_data_size / d_block_size;
+
+    int out_multiple = d_precomp_data_over_item_size;
 
     if (out_multiple == 1)
         out_multiple = 2; // Ensure we get pairs, for instance complex -> ichar pairs


### PR DESCRIPTION
## Description
The calculation for set_output_multiple() in did not take vectors into account correctly. Use of vectors is still tricky, as the vector size needs to divide into the payload size evenly. Incorrect values result in corrupted data.

## Related Issue
Fixes #6826

## Which blocks/areas does this affect?
UDP Source

## Testing Done
Sample GRCs provided with issue.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
