### PR TITLE
runtime: Remove VLA macro, usage (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/attributes.h
+++ b/gnuradio-runtime/include/gnuradio/attributes.h
@@ -67,14 +67,4 @@
 #pragma warning(disable : 4290) // C++ exception specification ignored except to indicate
                                 // a function is not __declspec(nothrow)
 #endif
-
-////////////////////////////////////////////////////////////////////////
-// implement cross-compiler VLA macros
-////////////////////////////////////////////////////////////////////////
-#ifdef _MSC_VER
-#define __GR_VLA(TYPE, buf, size) TYPE* buf = (TYPE*)alloca(sizeof(TYPE) * (size))
-#else
-#define __GR_VLA(TYPE, buf, size) TYPE buf[size]
-#endif
-
 #endif /* INCLUDED_GNURADIO_ATTRIBUTES_H */

--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.h
@@ -27,7 +27,8 @@ private:
     volk::vector<gr_complex> d_corr;
     volk::vector<gr_complex> d_gamma;
     volk::vector<float> d_lambda;
-
+    std::vector<int> d_ml_sync_peak_pos;
+    std::vector<float> d_ml_sync_phi;
     // For peak detector
     float d_threshold_factor_rise;
     float d_avg_alpha;


### PR DESCRIPTION
Backport #6818