### PR TITLE
digital: add sps setter to symbol_sync

### DIFF
--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -115,6 +115,7 @@ templates:
     - set_loop_bandwidth(${loop_bw})
     - set_damping_factor(${damping})
     - set_ted_gain(${ted_gain})
+    - set_sps(${sps})
 
 cpp_templates:
     includes: ['#include <gnuradio/digital/symbol_sync_${type}.h>']
@@ -138,6 +139,7 @@ cpp_templates:
     - set_loop_bandwidth(${loop_bw})
     - set_damping_factor(${damping})
     - set_ted_gain(${ted_gain})
+    - set_sps(${sps})
     translations:
         digital\.: 'digital::'
 

--- a/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright (C) 2017 Free Software Foundation, Inc.
+ * Copyright (C) 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -180,6 +181,14 @@ public:
     virtual float beta() const = 0;
 
     /*!
+     * \brief Returns the nominal clock period in samples per symbol.
+     *
+     * \details
+     * See the doecumentation for set_sps() for more details.
+     */
+    virtual float sps() const = 0;
+
+    /*!
      * \brief Set the normalized approximate loop bandwidth.
      *
      * \details
@@ -296,6 +305,17 @@ public:
      * \param beta    PI filter integral gain
      */
     virtual void set_beta(float beta) = 0;
+
+    /*!
+     * \brief Set the nominal clock period in samples per symbol.
+     *
+     * \details
+     * Sets the nominal clock period, resetting some of the tracking
+     * loop variables to adjust to the new clock period.
+     *
+     * \param sps     User specified nominal clock period in samples per symbol.
+     */
+    virtual void set_sps(float sps) = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright (C) 2017 Free Software Foundation, Inc.
+ * Copyright (C) 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -180,6 +181,14 @@ public:
     virtual float beta() const = 0;
 
     /*!
+     * \brief Returns the nominal clock period in samples per symbol.
+     *
+     * \details
+     * See the doecumentation for set_sps() for more details.
+     */
+    virtual float sps() const = 0;
+
+    /*!
      * \brief Set the normalized approximate loop bandwidth.
      *
      * \details
@@ -296,6 +305,17 @@ public:
      * \param beta    PI filter integral gain
      */
     virtual void set_beta(float beta) = 0;
+
+    /*!
+     * \brief Set the nominal clock period in samples per symbol.
+     *
+     * \details
+     * Sets the nominal clock period, resetting some of the tracking
+     * loop variables to adjust to the new clock period.
+     *
+     * \param sps     User specified nominal clock period in samples per symbol.
+     */
+    virtual void set_sps(float sps) = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/symbol_sync_cc_impl.h
+++ b/gr-digital/lib/symbol_sync_cc_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright (C) 2017 Free Software Foundation, Inc.
+ * Copyright (C) 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -46,6 +47,7 @@ public:
     float ted_gain() const override { return d_clock.get_ted_gain(); }
     float alpha() const override { return d_clock.get_alpha(); }
     float beta() const override { return d_clock.get_beta(); }
+    float sps() const override { return d_sps; }
 
     void set_loop_bandwidth(float omega_n_norm) override
     {
@@ -55,6 +57,7 @@ public:
     void set_ted_gain(float ted_gain) override { d_clock.set_ted_gain(ted_gain); }
     void set_alpha(float alpha) override { d_clock.set_alpha(alpha); }
     void set_beta(float beta) override { d_clock.set_beta(beta); }
+    void set_sps(float sps) override;
 
 private:
     // Timing Error Detector
@@ -88,6 +91,9 @@ private:
     bool d_symbol_clock;
     float d_inst_clock_period;
     float d_avg_clock_period;
+
+    float d_sps;
+    float d_max_deviation;
 
     // Block output
     const float d_osps;
@@ -130,6 +136,8 @@ private:
                         uint64_t nitems_wr,
                         int oidx);
     void save_expiring_tags(uint64_t nitems_rd, int consumed);
+
+    void check_interps();
 
     // Optional Diagnostic Outputs
     void setup_optional_outputs(gr_vector_void_star& output_items);

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright (C) 2017 Free Software Foundation, Inc.
+ * Copyright (C) 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -72,6 +73,8 @@ symbol_sync_ff_impl::symbol_sync_ff_impl(enum ted_type detector_type,
       d_inst_output_period(sps / static_cast<float>(osps)),
       d_inst_clock_period(sps),
       d_avg_clock_period(sps),
+      d_sps(sps),
+      d_max_deviation(max_deviation),
       d_osps(static_cast<float>(osps)),
       d_osps_n(osps),
       d_tags(),
@@ -111,13 +114,7 @@ symbol_sync_ff_impl::symbol_sync_ff_impl(enum ted_type detector_type,
     sync_reset_internal_clocks();
     d_inst_interp_period = d_inst_clock_period / d_interps_per_symbol;
 
-    if (d_interps_per_symbol > sps)
-        d_logger->warn("block performing more interpolations per "
-                       "symbol ({:g}) than input samples per symbol "
-                       "({:g}). Consider reducing osps or "
-                       "increasing sps",
-                       d_interps_per_symbol,
-                       sps);
+    check_interps();
 
     // Timing Error Detector
     d_ted->sync_reset();
@@ -134,6 +131,48 @@ symbol_sync_ff_impl::symbol_sync_ff_impl(enum ted_type detector_type,
 }
 
 symbol_sync_ff_impl::~symbol_sync_ff_impl() {}
+
+void symbol_sync_ff_impl::set_sps(float sps)
+{
+    gr::thread::scoped_lock l(d_setlock);
+
+    d_sps = sps;
+
+    const auto max_period = sps + d_max_deviation;
+    const auto min_period = sps - d_max_deviation;
+    d_clock.set_max_avg_period(max_period);
+    d_clock.set_min_avg_period(min_period);
+    d_clock.set_nom_avg_period(sps);
+    d_clock.set_avg_period(sps);
+    d_clock.set_inst_period(sps);
+    d_clock.set_phase(0.0f);
+
+    d_inst_output_period = sps / d_osps;
+    d_inst_clock_period = sps;
+    d_avg_clock_period = sps;
+
+    sync_reset_internal_clocks();
+
+    d_inst_interp_period = d_inst_clock_period / d_interps_per_symbol;
+
+    check_interps();
+
+    d_ted->sync_reset();
+    d_interp->sync_reset(sps);
+    set_relative_rate(d_osps / sps);
+}
+
+void symbol_sync_ff_impl::check_interps()
+{
+    if (d_interps_per_symbol > d_sps) {
+        d_logger->warn("block performing more interpolations per "
+                       "symbol ({:g}) than input samples per symbol "
+                       "({:g}). Consider reducing osps or "
+                       "increasing sps",
+                       d_interps_per_symbol,
+                       d_sps);
+    }
+}
 
 //
 // Block Internal Clocks
@@ -388,6 +427,8 @@ int symbol_sync_ff_impl::general_work(int noutput_items,
                                       gr_vector_const_void_star& input_items,
                                       gr_vector_void_star& output_items)
 {
+    gr::thread::scoped_lock l(d_setlock);
+
     // max input to consume
     const int ni = ninput_items[0] - static_cast<int>(d_interp->ntaps());
     if (ni <= 0)

--- a/gr-digital/lib/symbol_sync_ff_impl.h
+++ b/gr-digital/lib/symbol_sync_ff_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright (C) 2017 Free Software Foundation, Inc.
+ * Copyright (C) 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -47,6 +48,7 @@ public:
     float ted_gain() const override { return d_clock.get_ted_gain(); }
     float alpha() const override { return d_clock.get_alpha(); }
     float beta() const override { return d_clock.get_beta(); }
+    float sps() const override { return d_sps; }
 
     void set_loop_bandwidth(float omega_n_norm) override
     {
@@ -56,6 +58,7 @@ public:
     void set_ted_gain(float ted_gain) override { d_clock.set_ted_gain(ted_gain); }
     void set_alpha(float alpha) override { d_clock.set_alpha(alpha); }
     void set_beta(float beta) override { d_clock.set_beta(beta); }
+    void set_sps(float sps) override;
 
 private:
     // Timing Error Detector
@@ -89,6 +92,9 @@ private:
     bool d_symbol_clock;
     float d_inst_clock_period;
     float d_avg_clock_period;
+
+    float d_sps;
+    float d_max_deviation;
 
     // Block output
     const float d_osps;
@@ -131,6 +137,8 @@ private:
                         uint64_t nitems_wr,
                         int oidx);
     void save_expiring_tags(uint64_t nitems_rd, int consumed);
+
+    void check_interps();
 
     // Optional Diagnostic Outputs
     void setup_optional_outputs(gr_vector_void_star& output_items);

--- a/gr-digital/python/digital/bindings/docstrings/symbol_sync_cc_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/symbol_sync_cc_pydoc_template.h
@@ -42,6 +42,9 @@ static const char* __doc_gr_digital_symbol_sync_cc_alpha = R"doc()doc";
 static const char* __doc_gr_digital_symbol_sync_cc_beta = R"doc()doc";
 
 
+static const char* __doc_gr_digital_symbol_sync_cc_sps = R"doc()doc";
+
+
 static const char* __doc_gr_digital_symbol_sync_cc_set_loop_bandwidth = R"doc()doc";
 
 
@@ -55,3 +58,6 @@ static const char* __doc_gr_digital_symbol_sync_cc_set_alpha = R"doc()doc";
 
 
 static const char* __doc_gr_digital_symbol_sync_cc_set_beta = R"doc()doc";
+
+
+static const char* __doc_gr_digital_symbol_sync_cc_set_sps = R"doc()doc";

--- a/gr-digital/python/digital/bindings/docstrings/symbol_sync_ff_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/symbol_sync_ff_pydoc_template.h
@@ -42,6 +42,9 @@ static const char* __doc_gr_digital_symbol_sync_ff_alpha = R"doc()doc";
 static const char* __doc_gr_digital_symbol_sync_ff_beta = R"doc()doc";
 
 
+static const char* __doc_gr_digital_symbol_sync_ff_sps = R"doc()doc";
+
+
 static const char* __doc_gr_digital_symbol_sync_ff_set_loop_bandwidth = R"doc()doc";
 
 
@@ -55,3 +58,6 @@ static const char* __doc_gr_digital_symbol_sync_ff_set_alpha = R"doc()doc";
 
 
 static const char* __doc_gr_digital_symbol_sync_ff_set_beta = R"doc()doc";
+
+
+static const char* __doc_gr_digital_symbol_sync_ff_set_sps = R"doc()doc";

--- a/gr-digital/python/digital/bindings/symbol_sync_cc_python.cc
+++ b/gr-digital/python/digital/bindings/symbol_sync_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(symbol_sync_cc.h)                                          */
-/* BINDTOOL_HEADER_FILE_HASH(2cd8cd8dbe6deaf22c1afe62c9e6eb07)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3e6c61bd68602374f7606400df601db5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -72,6 +72,9 @@ void bind_symbol_sync_cc(py::module& m)
         .def("beta", &symbol_sync_cc::beta, D(symbol_sync_cc, beta))
 
 
+        .def("sps", &symbol_sync_cc::sps, D(symbol_sync_cc, sps))
+
+
         .def("set_loop_bandwidth",
              &symbol_sync_cc::set_loop_bandwidth,
              py::arg("omega_n_norm"),
@@ -100,6 +103,12 @@ void bind_symbol_sync_cc(py::module& m)
              &symbol_sync_cc::set_beta,
              py::arg("beta"),
              D(symbol_sync_cc, set_beta))
+
+
+        .def("set_sps",
+             &symbol_sync_cc::set_sps,
+             py::arg("sps"),
+             D(symbol_sync_cc, set_sps))
 
         ;
 }

--- a/gr-digital/python/digital/bindings/symbol_sync_ff_python.cc
+++ b/gr-digital/python/digital/bindings/symbol_sync_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(symbol_sync_ff.h)                                          */
-/* BINDTOOL_HEADER_FILE_HASH(c429d2ce1720dde0c36c3d57dc2a1c26)                     */
+/* BINDTOOL_HEADER_FILE_HASH(466b930711794f3d336fe88792faf2d0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -72,6 +72,9 @@ void bind_symbol_sync_ff(py::module& m)
         .def("beta", &symbol_sync_ff::beta, D(symbol_sync_ff, beta))
 
 
+        .def("sps", &symbol_sync_ff::sps, D(symbol_sync_ff, sps))
+
+
         .def("set_loop_bandwidth",
              &symbol_sync_ff::set_loop_bandwidth,
              py::arg("omega_n_norm"),
@@ -100,6 +103,12 @@ void bind_symbol_sync_ff(py::module& m)
              &symbol_sync_ff::set_beta,
              py::arg("beta"),
              D(symbol_sync_ff, set_beta))
+
+
+        .def("set_sps",
+             &symbol_sync_ff::set_sps,
+             py::arg("sps"),
+             D(symbol_sync_ff, set_sps))
 
         ;
 }


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

This adds a method to update the samples/symbol of the symbol_sync block at runtime. When the set_sps() method is called, it resets all the internal symbol synchronization loop status and ajusts values for the new samples/symbol, so synchronization is lost and the loop needs to lock again. This is reasonable, because the set_sps() method can only be called asynchronously with respect to symbol rate changes in the input sample stream. A more advanced runtime change could use tags to update the samples/symbol at a specific point without losing loop lock, but this commit does not cover this use case.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

No related issue.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

The Symbol Sync block.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Testing has been done with the following flowgraph, which generates a square-pulse BPSK signal with an integer sps, runs Symbol Sync on it, and allows runtime changes of sps with an QT GUI entry.
[test_symbol_sync.zip](https://github.com/gnuradio/gnuradio/files/12646107/test_symbol_sync.zip)


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- ~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~ -> No documentation updates are probably needed. The user-facing consequences of this change is that now the Samples per Symbol parameter is underlined in GRC, so in a sense, the change is self-documenting.
- [ ] I have added tests to cover my changes, and all previous tests pass. -> I haven't added any unit tests for this. It seems tricky to write a good unit test that performs an sps change at runtime.
