### PR TITLE
runtime: Use MAP_FIXED flag to ensure buffer halves are contiguous

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
@@ -101,19 +101,11 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(size_t size) : gr::vmcircbuf(si
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
-    // unmap the 2nd half
-    if (munmap((char*)first_copy + size, size) == -1) {
-        close(shm_fd); // cleanup
-        d_logger->error("munmap (1) failed");
-        throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
-    }
-
-    // map the first half into the now available hole where the
-    // second half used to be.
+    // map the first half into the second half of the address space.
     void* second_copy = mmap((char*)first_copy + size,
                              size,
                              PROT_READ | PROT_WRITE,
-                             MAP_SHARED,
+                             MAP_SHARED | MAP_FIXED,
                              shm_fd,
                              (off_t)0);
 


### PR DESCRIPTION
## Description
It was recently reported that Gqrx crashes on FreeBSD:

https://github.com/gqrx-sdr/gqrx/issues/1275

After some digging, I found that the crash occurs because `vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open` allocates a discontiguous double-mapped buffer. This happens because the `mmap` system call is free to ignore the supplied `addr` argument (which is only a suggestion) and choose its own address for the mapping.

This can be fixed by using the `MAP_FIXED` flag, which tells `mmap` that the `addr` argument must be used as-is.

The `vmcircbuf_mmap_tmpfile` implementation has an explicit contiguity check (which simply throws an exception if the returned buffer is discontiguous). With the addition of the `MAP_FIXED` flag, I don't think this check is necessary.

## Related Issue
* https://github.com/gqrx-sdr/gqrx/issues/1275

## Which blocks/areas does this affect?
Circular Buffers

## Testing Done
To test the `mmap`-based circular buffer implementations, run the following:

`echo -n gr::vmcircbuf_mmap_shm_open_factory > ~/.gnuradio/prefs/vmcircbuf_default_factory`
OR
`echo -n gr::vmcircbuf_mmap_tmpfile_factory > ~/.gnuradio/prefs/vmcircbuf_default_factory`

Before this change, `gr::vmcircbuf_mmap_shm_open_factory` works fine on Linux, but `gr::vmcircbuf_mmap_tmpfile_factory` fails immediately with the following error:

```
gr::vmcircbuf :error: non-contiguous second copy
buffer_double_mapped :error: gr::buffer::allocate_buffer: failed to allocate buffer of size 65536 KB
```

After the change, Gqrx runs fine with both implementations.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
