### PR TITLE
Repeat: itemwise, solve buffer allocation issue (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/CMakeLists.txt
@@ -45,6 +45,7 @@ install(
           msg_handler.h
           msg_queue.h
           nco.h
+          pmt_fmt.h
           pdu.h
           prefs.h
           pycallback_object.h

--- a/gnuradio-runtime/include/gnuradio/pmt_fmt.h
+++ b/gnuradio-runtime/include/gnuradio/pmt_fmt.h
@@ -1,0 +1,23 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Marcus Müller
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+#ifndef INCLUDED_GNURADIO_PMT_FMT_H
+#define INCLUDED_GNURADIO_PMT_FMT_H
+#include <gnuradio/api.h>
+#include <pmt/pmt.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
+
+//!\brief enables PMTs to be formatted with fmt
+template <>
+struct GR_RUNTIME_API fmt::formatter<pmt::pmt_t> : formatter<std::string_view> {
+    fmt::format_context::iterator format(const pmt::pmt_t& obj,
+                                         format_context& ctx) const;
+};
+#endif

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(
     msg_queue.cc
     pagesize.cc
     pdu.cc
+    pmt_fmt.cc
     prefs.cc
     realtime.cc
     realtime_impl.cc

--- a/gnuradio-runtime/lib/pmt_fmt.cc
+++ b/gnuradio-runtime/lib/pmt_fmt.cc
@@ -1,0 +1,19 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Marcus Müller
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+#include <gnuradio/pmt_fmt.h>
+#include <pmt/pmt.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
+
+fmt::format_context::iterator
+fmt::formatter<pmt::pmt_t>::format(const pmt::pmt_t& obj, fmt::format_context& ctx) const
+{
+    return fmt::format_to(ctx.out(), "{}", pmt::write_string(obj));
+}

--- a/gr-blocks/include/gnuradio/blocks/repeat.h
+++ b/gr-blocks/include/gnuradio/blocks/repeat.h
@@ -26,7 +26,7 @@ namespace blocks {
  *      Takes a pmt_pair(pmt::mp("interpolation"), pmt_long interp), setting the
  * interpolation to interp.
  */
-class BLOCKS_API repeat : virtual public sync_interpolator
+class BLOCKS_API repeat : virtual public block
 {
 public:
     // gr::blocks::repeat::sptr

--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012 Free Software Foundation, Inc.
+ * Copyright 2023 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -12,6 +13,7 @@
 #define INCLUDED_REPEAT_IMPL_H
 
 #include <gnuradio/blocks/repeat.h>
+#include <cstdint>
 
 namespace gr {
 namespace blocks {
@@ -37,6 +39,19 @@ private:
 
     void msg_set_interpolation(const pmt::pmt_t& msg);
     const pmt::pmt_t c_msg_port;
+
+    //! \brief helper function to propagate tags manually
+    void copy_tags(int consumed, int produced, int num_items)
+    {
+        std::vector<tag_t> tags;
+        const auto start_in = nitems_read(0) + static_cast<uint64_t>(consumed);
+        const auto start_out = nitems_written(0) + static_cast<uint64_t>(produced);
+        get_tags_in_range(tags, 0, start_in, start_in + num_items);
+        for (const auto& tag : tags) {
+            const auto offset = d_interp * (tag.offset - start_in) + start_out;
+            add_item_tag(0, offset, tag.key, tag.value);
+        }
+    }
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -18,22 +18,25 @@ namespace blocks {
 
 class BLOCKS_API repeat_impl : public repeat
 {
-    const size_t d_itemsize;
-    int d_interp;
-
 public:
     repeat_impl(size_t itemsize, int d_interp);
 
     int interpolation() const override { return d_interp; }
     void set_interpolation(int interp) override;
 
-
-    int work(int noutput_items,
-             gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int general_work(int noutput_items,
+                     gr_vector_int& ninput_items,
+                     gr_vector_const_void_star& input_items,
+                     gr_vector_void_star& output_items) override;
 
 private:
-    void msg_set_interpolation(pmt::pmt_t msg);
+    const size_t d_itemsize;
+    size_t d_interp;
+    size_t d_left_to_copy;
+
+    void msg_set_interpolation(const pmt::pmt_t& msg);
+    const pmt::pmt_t c_msg_port;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/python/blocks/bindings/repeat_python.cc
+++ b/gr-blocks/python/blocks/bindings/repeat_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(repeat.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e09b086b5c70662b6d397af93cdeb2e5)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3bc3b9639597273078d551360a012379)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -33,12 +33,8 @@ void bind_repeat(py::module& m)
     using repeat = ::gr::blocks::repeat;
 
 
-    py::class_<repeat,
-               gr::sync_interpolator,
-               gr::sync_block,
-               gr::block,
-               gr::basic_block,
-               std::shared_ptr<repeat>>(m, "repeat", D(repeat))
+    py::class_<repeat, gr::block, gr::basic_block, std::shared_ptr<repeat>>(
+        m, "repeat", D(repeat))
 
         .def(py::init(&repeat::make),
              py::arg("itemsize"),

--- a/gr-blocks/python/blocks/qa_repeat.py
+++ b/gr-blocks/python/blocks/qa_repeat.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2008,2010,2012,2013 Free Software Foundation, Inc.
+# Copyright 2023 Daniel Estevez <daniel@destevez.net>
 #
 # This file is part of GNU Radio
 #
@@ -8,9 +9,11 @@
 #
 #
 
+import time
 
-from gnuradio import gr, gr_unittest, blocks
+from gnuradio import gr, gr_unittest, blocks, pdu
 import numpy as np
+import pmt
 
 
 class test_repeat(gr_unittest.TestCase):
@@ -33,6 +36,71 @@ class test_repeat(gr_unittest.TestCase):
         sizes = ((3**10 + 2, 3), (3**6, 1), (4, 5), (10**6, 1), (10 * 2, 10 * 3))
         for size, repetitions in sizes:
             self.run_fg(size, repetitions, f"N = {size}, r = {repetitions}: not equal")
+
+    def test_tag_propagation(self):
+        N = 1000
+        r = 17
+        tags_in = [
+            gr.tag_utils.python_to_tag((
+                j, pmt.intern("test_tag"), pmt.from_long(j), pmt.PMT_NIL))
+            for j in range(N)
+        ]
+        src = blocks.vector_source_i([0] * N, tags=tags_in)
+        rpt = blocks.repeat(gr.sizeof_int, r)
+        dst = blocks.vector_sink_i()
+        self.tb.connect(src, rpt, dst)
+        self.tb.run()
+        tags_out = dst.tags()
+        self.assertEqual(len(tags_in), len(tags_out))
+        for t_in, t_out in zip(tags_in, tags_out):
+            self.assertEqual(t_out.offset, r * t_in.offset)
+            self.assertEqual(t_in.key, t_out.key)
+            self.assertEqual(t_in.value, t_out.value)
+
+    def test_tag_propagation_rate_change(self):
+        # This uses a pdu_to_tagged_stream block to control when data is
+        # produced, allowing us to change the repetition rate exactly when we
+        # want.
+        N1 = 1000
+        r1 = 17
+        N2 = 2000
+        r2 = 13
+        tags_in = [
+            gr.tag_utils.python_to_tag((
+                j, pmt.intern("test_tag"), pmt.from_long(j), pmt.PMT_NIL))
+            for j in range(N1 + N2)
+        ]
+        src_tags = blocks.vector_source_b([0] * (N1 + N2), tags=tags_in)
+        src_data = pdu.pdu_to_tagged_stream(gr.types.byte_t)
+        tag_gate = blocks.tag_gate(gr.sizeof_char)
+        tag_share = blocks.tag_share(gr.sizeof_char, gr.sizeof_char)
+        rpt = blocks.repeat(gr.sizeof_char, r1)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src_data, tag_gate, tag_share, rpt, dst)
+        self.tb.connect(src_tags, (tag_share, 1))
+        self.tb.start()
+        data_pdu = pmt.cons(pmt.PMT_NIL, pmt.make_u8vector(N1, 0))
+        src_data.to_basic_block()._post(pmt.intern("pdus"), data_pdu)
+        # Wait for some time for the data to flow through
+        time.sleep(0.1)
+        rpt.set_interpolation(r2)
+        data_pdu = pmt.cons(pmt.PMT_NIL, pmt.make_u8vector(N2, 0))
+        src_data.to_basic_block()._post(pmt.intern("pdus"), data_pdu)
+        src_data.to_basic_block()._post(
+            pmt.intern('system'),
+            pmt.cons(pmt.intern('done'), pmt.from_long(1)))
+        self.tb.wait()
+        self.assertEqual(len(dst.data()), N1 * r1 + N2 * r2)
+        tags_out = dst.tags()
+        self.assertEqual(len(tags_out), len(tags_in))
+        for t_in, t_out in zip(tags_in[:N1], tags_out[:N1]):
+            self.assertEqual(t_out.offset, r1 * t_in.offset)
+            self.assertEqual(t_in.key, t_out.key)
+            self.assertEqual(t_in.value, t_out.value)
+        for t_in, t_out in zip(tags_in[N1:], tags_out[N1:]):
+            self.assertEqual(t_out.offset, N1 * r1 + r2 * (t_in.offset - N1))
+            self.assertEqual(t_in.key, t_out.key)
+            self.assertEqual(t_in.value, t_out.value)
 
 
 if __name__ == "__main__":

--- a/gr-blocks/python/blocks/qa_repeat.py
+++ b/gr-blocks/python/blocks/qa_repeat.py
@@ -10,29 +10,30 @@
 
 
 from gnuradio import gr, gr_unittest, blocks
+import numpy as np
 
 
-class test_repeat (gr_unittest.TestCase):
-
+class test_repeat(gr_unittest.TestCase):
     def setUp(self):
         self.tb = gr.top_block()
 
     def tearDown(self):
         self.tb = None
 
-    def test_001_float(self):
-        src_data = [n * 1.0 for n in range(100)]
-        dst_data = []
-        for n in range(100):
-            dst_data += [1.0 * n, 1.0 * n, 1.0 * n]
-
-        src = blocks.vector_source_f(src_data)
-        rpt = blocks.repeat(gr.sizeof_float, 3)
-        dst = blocks.vector_sink_f()
+    def run_fg(self, N, r, msg=""):
+        src_data = np.arange(N)
+        src = blocks.vector_source_i(src_data)
+        rpt = blocks.repeat(gr.sizeof_int, r)
+        dst = blocks.vector_sink_i()
         self.tb.connect(src, rpt, dst)
         self.tb.run()
-        self.assertFloatTuplesAlmostEqual(dst_data, dst.data(), 6)
+        self.assertTrue(np.array_equal(dst.data(), src_data.repeat(r)), msg)
+
+    def test_001_various_sizes(self):
+        sizes = ((3**10 + 2, 3), (3**6, 1), (4, 5), (10**6, 1), (10 * 2, 10 * 3))
+        for size, repetitions in sizes:
+            self.run_fg(size, repetitions, f"N = {size}, r = {repetitions}: not equal")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     gr_unittest.run(test_repeat)


### PR DESCRIPTION
Backport #6813 
Backport #6832 

API Note: Repeat was previously a `gr::sync_interpolator` and is now a `gr::block`. It is unlikely that users derive their own blocks from this block, the API change is low risk.