### PR TITLE
docs: Update RTD config to include build.tools

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,8 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
-  #tools:
-    #python: "3.9"
+  tools:
+    python: "3.10"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"


### PR DESCRIPTION
This fixes the following RTD error message:

    Problem in your project's configuration. Invalid configuration option
    "build.tools": At least one item should be provided in 'tools' or
    'commands'
