### PR TITLE
qtgui: Refine use of `QLineEdit::returnPressed()` or `editingFinished()` for text entry

### DIFF
--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -21,6 +21,13 @@ parameters:
     label: Default Value
     dtype: ${ type }
     default: '0'
+-   id: entry_signal
+    label: Update Trigger
+    dtype: enum
+    default: editingFinished
+    options: [returnPressed, editingFinished]
+    option_labels: ["'Enter'", "'Enter' or focus lost"]
+    hide: part
 -   id: gui_hint
     label: GUI Hint
     dtype: gui_hint
@@ -43,7 +50,7 @@ templates:
         ${win}.addWidget(Qt.QLabel("${no_quotes(label,repr(id))}" + ": "))
         self._${id}_line_edit = Qt.QLineEdit(str(self.${id}))
         self._${id}_tool_bar.addWidget(self._${id}_line_edit)
-        self._${id}_line_edit.editingFinished.connect(
+        self._${id}_line_edit.${entry_signal}.connect(
             lambda: self.set_${id}(${type.conv}(str(self._${id}_line_edit.text()))))
         ${gui_hint() % win}
 
@@ -68,7 +75,7 @@ cpp_templates:
         this->_${id}_tool_bar->addWidget(_${id}_label);
         this->_${id}_line_edit = new QLineEdit(QString::number(this->${id}));
         this->_${id}_tool_bar->addWidget(this->_${id}_line_edit);
-        QObject::connect(this->_${id}_line_edit, &QLineEdit::editingFinished, this, [this] () {this->set_${id}(this->_${id}_line_edit->text().toInt());});
+        QObject::connect(this->_${id}_line_edit, &QLineEdit::${entry_signal}, this, [this] () {this->set_${id}(this->_${id}_line_edit->text().toInt());});
 
         ${gui_hint() % win}
 documentation: |-

--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -35,8 +35,8 @@ parameters:
     label: Widget
     dtype: enum
     default: counter_slider
-    options: [counter_slider, counter, slider, dial]
-    option_labels: [Counter + Slider, Counter, Slider, Knob]
+    options: [counter_slider, counter, slider, dial, eng_slider, eng]
+    option_labels: [Counter + Slider, Counter, Slider, Knob, Entry + Slider, Entry]
     hide: part
 -   id: orient
     label: Orientation

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -134,7 +134,8 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
     d_vlayout->addItem(d_hlayout);
     d_group->setLayout(d_vlayout);
 
-    QObject::connect(d_val, SIGNAL(editingFinished()), this, SLOT(edit_finished()));
+    // use returnPressed signal specifically to not trigger when focus is lost
+    QObject::connect(d_val, SIGNAL(returnPressed()), this, SLOT(edit_finished()));
 
     d_msg = pmt::PMT_NIL;
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This is a follow-up to #6645 which addresses comments that have arisen since that was merged. Namely:

1. Using `returnPressed` for the Message Edit Box is the preferred behavior, so reverts the prior change and restores that behavior as intended with #5592.
2. Since there are reasonable use cases for either signal with the QT GUI Entry, this provides a GRC option that allows the user to select the update trigger to be either `returnPressed` or `editingFinished`.
3. The range widget's use of `editingFinished` only arises with the `eng` and `eng_slider` variants, and for those the `editingFinished` behavior makes sense. However, in reviewing this, I discovered that neither of those variants has been exposed in GRC since they were introduced in #3163, so this PR includes a commit to make those available.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
qtgui

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I verified the new option for QT GUI Entry in GRC does generate the desired code.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
