### PR TITLE
runtime: Use MAP_FIXED flag to ensure buffer halves are contiguous (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
@@ -101,19 +101,11 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(size_t size) : gr::vmcircbuf(si
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
-    // unmap the 2nd half
-    if (munmap((char*)first_copy + size, size) == -1) {
-        close(shm_fd); // cleanup
-        d_logger->error("munmap (1) failed");
-        throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
-    }
-
-    // map the first half into the now available hole where the
-    // second half used to be.
+    // map the first half into the second half of the address space.
     void* second_copy = mmap((char*)first_copy + size,
                              size,
                              PROT_READ | PROT_WRITE,
-                             MAP_SHARED,
+                             MAP_SHARED | MAP_FIXED,
                              shm_fd,
                              (off_t)0);
 


### PR DESCRIPTION
Backport #6854