### PR TITLE
.clang-tidy: remove ... that snuck/sneaked into the file (backport to maint-3.10)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,4 @@ WarningsAsErrors: ''
 HeaderFilterRegex: '\.(cc|c|cpp|h|hpp)$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
-CheckOptions:
-...
 


### PR DESCRIPTION
Backport #6866