### PR TITLE
blocks: Include a trailing newline in SigMF metadata

### DIFF
--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -86,3 +86,4 @@ class sigmf_sink_minimal(gr.hier_block2):
 
         with open(filename + '.sigmf-meta', 'w') as f_meta:
             json.dump(meta_dict, f_meta, indent=2)
+            f_meta.write('\n')


### PR DESCRIPTION
## Description
SigMF metadata files produces by the SigMF Sink (Minimal) block do not include a trailing newline, making them a bit inconvenient to work with in the terminal. I think it makes sense to include one, as sigmf-python does:

https://github.com/sigmf/sigmf-python/blob/c5aa8f30dcfa08596ffa70744422b6e4a95c4300/sigmf/sigmffile.py#L545

## Which blocks/areas does this affect?
* SigFM Sink (Minimal)

## Testing Done
I ran the following flowgraph:
![Screenshot from 2023-10-02 09-59-13](https://github.com/gnuradio/gnuradio/assets/583749/7cd116d9-0521-4248-8a95-d2996ea5decc)

This produced the following metadata file:
```
{
  "global": {
    "core:datatype": "cf32_le",
    "core:sample_rate": 32000.0,
    "core:version": "1.0.0",
    "core:hw": "ghi",
    "core:author": "abc",
    "core:description": "def"
  },
  "captures": [
    {
      "core:sample_start": 0,
      "core:frequency": 100.0
    }
  ],
  "annotations": []
}
```

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
