### PR TITLE
blocks: Include a trailing newline in SigMF metadata (backport to maint-3.10)

### DIFF
--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -86,3 +86,4 @@ class sigmf_sink_minimal(gr.hier_block2):
 
         with open(filename + '.sigmf-meta', 'w') as f_meta:
             json.dump(meta_dict, f_meta, indent=2)
+            f_meta.write('\n')


### PR DESCRIPTION
Backport #6886