### PR TITLE
fosphor display widget: Fix std::bad_alloc

### DIFF
--- a/gr-qtgui/lib/fosphor_display_impl.cc
+++ b/gr-qtgui/lib/fosphor_display_impl.cc
@@ -48,9 +48,7 @@ fosphor_display_impl::fosphor_display_impl(const int fft_bins,
     if (qApp != NULL) {
         d_qApplication = qApp;
     } else {
-        int argc = 0;
-        char** argv = NULL;
-        d_qApplication = new QApplication(argc, argv);
+        d_qApplication = new QApplication(d_argc, &d_argv);
     }
 
     d_gui = new QFosphorSurface(fft_bins, pwr_bins, wf_lines, parent);

--- a/gr-qtgui/lib/fosphor_display_impl.h
+++ b/gr-qtgui/lib/fosphor_display_impl.h
@@ -68,6 +68,13 @@ private:
     //! Store the number of subframes per histogram frame
     const int d_subframe_num = 0;
     uint8_t* d_frame;
+    // Required now for Qt; argc must be greater than 0 and argv
+    // must have at least one valid character. Must be valid through
+    // life of the qApplication:
+    // http://harmattan-dev.nokia.com/docs/library/html/qt4/qapplication.html
+    char d_zero = 0;
+    int d_argc = 1;
+    char* d_argv = &d_zero;
 };
 
 } // namespace qtgui


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Running the tests for the fosphor_display widget sometimes leads to an std::bad _alloc error.
The reason is a wrong call to QApplication. The first argument argc must be greater than 0. See qt documentation or see comments for example in freq_sink_c_impl.h.
https://github.com/gnuradio/gnuradio/blob/fe42f6a4aacca65010939afe41910e7d55e68063/gr-qtgui/lib/freq_sink_c_impl.h#L54-L57
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
#6515 and #6828
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
fosphor_display
## Testing Done
You can test it wit a simple python script

from gnuradio import qtgui
from PyQt5 import QtGui 
from PyQt5.QtWidgets import QWidget
a=qtgui.fosphor_display(256,64,512)
print('Success fosphor_display')
b=qtgui.FosphorGlSink(1, 16, 64, 64, 1.0, 0.1, 0.99, 16.0, 1024.0)
print('Success GLSink')

Running this code several times  you'll get sometimes a bad_alloc. After this patch the bad_alloc never happend .
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
