### PR TITLE
iio: Remove extra element from fmcomms2 YML

### DIFF
--- a/gr-iio/grc/iio_fmcomms2_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_sink.block.yml
@@ -7,7 +7,7 @@ parameters:
     label: Input Type
     dtype: enum
     options: [fc32, sc16]
-    option_labels: [int16, Complex float32, Complex int16]
+    option_labels: [Complex float32, Complex int16]
     option_attributes:
         type: [fc32, sc16]
     hide: part

--- a/gr-iio/grc/iio_fmcomms2_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_source.block.yml
@@ -7,7 +7,7 @@ parameters:
     label: Output Type
     dtype: enum
     options: [fc32, sc16]
-    option_labels: [int16, Complex float32, Complex int16]
+    option_labels: [Complex float32, Complex int16]
     option_attributes:
         type: [fc32, sc16]
     hide: part


### PR DESCRIPTION
A quick fix to https://github.com/gnuradio/gnuradio/issues/6895

I don't think this fully solves the issues with the IO signature of the Pluto blocks though. But I noticed this while debugging that issue. I need to sign this commit, but posting this for visibility given the 3.10 RC1