### PR TITLE
Revert "iio: Remove extra element from fmcomms2 YML"

### DIFF
--- a/gr-iio/grc/iio_fmcomms2_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_sink.block.yml
@@ -7,7 +7,7 @@ parameters:
     label: Input Type
     dtype: enum
     options: [fc32, sc16]
-    option_labels: [Complex float32, Complex int16]
+    option_labels: [int16, Complex float32, Complex int16]
     option_attributes:
         type: [fc32, sc16]
     hide: part

--- a/gr-iio/grc/iio_fmcomms2_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_source.block.yml
@@ -7,7 +7,7 @@ parameters:
     label: Output Type
     dtype: enum
     options: [fc32, sc16]
-    option_labels: [Complex float32, Complex int16]
+    option_labels: [int16, Complex float32, Complex int16]
     option_attributes:
         type: [fc32, sc16]
     hide: part


### PR DESCRIPTION
Reverts gnuradio/gnuradio#6896

Dynamic I/O type is not supported by the framework. Reverting along with #6857 