### PR TITLE
gr-digital every time

### DIFF
--- a/gr-digital/include/gnuradio/digital/header_format_crc.h
+++ b/gr-digital/include/gnuradio/digital/header_format_crc.h
@@ -61,7 +61,7 @@ public:
      * Uses the following header format:
      *  - Bits 0-11: The packet length (what was stored in the tag with key \p
      * len_tag_key)
-     *  - Bits 12-23: The header number (counts up everytime this function is called)
+     *  - Bits 12-23: The header number (counts up every time this function is called)
      *  - Bit 24-31: 8-Bit CRC
      */
     bool format(int nbytes_in,

--- a/gr-digital/include/gnuradio/digital/header_format_ofdm.h
+++ b/gr-digital/include/gnuradio/digital/header_format_ofdm.h
@@ -64,7 +64,7 @@ public:
      * Uses the following header format:
      *  - Bits 0-11: The packet length (what was stored in the tag with key \p
      * len_tag_key)
-     *  - Bits 12-23: The header number (counts up everytime this function is called)
+     *  - Bits 12-23: The header number (counts up every time this function is called)
      *  - Bit 24-31: 8-Bit CRC
      */
     bool format(int nbytes_in,

--- a/gr-digital/include/gnuradio/digital/packet_header_default.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_default.h
@@ -58,7 +58,7 @@ public:
      *
      * Uses the following header format:
      * Bits 0-11: The packet length (what was stored in the tag with key \p len_tag_key)
-     * Bits 12-23: The header number (counts up everytime this function is called)
+     * Bits 12-23: The header number (counts up every time this function is called)
      * Bit 24-31: 8-Bit CRC
      * All other bits: Are set to zero
      *

--- a/gr-digital/python/digital/bindings/header_format_crc_python.cc
+++ b/gr-digital/python/digital/bindings/header_format_crc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_format_crc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8c45adf0e2f688e58b014b05e6a8c204)                     */
+/* BINDTOOL_HEADER_FILE_HASH(de1f653b86e5e6d1c528cc91d84b4493)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/header_format_ofdm_python.cc
+++ b/gr-digital/python/digital/bindings/header_format_ofdm_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_format_ofdm.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4ec4c2872c64bdae4088678b3b0310fe)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a618263babd0ea75399d8a1e5601ab54)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/packet_header_default_python.cc
+++ b/gr-digital/python/digital/bindings/packet_header_default_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(packet_header_default.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(07dc3324dfa4a18438259d00a6a894a9)                     */
+/* BINDTOOL_HEADER_FILE_HASH(9fe278eaaa812e8ad189d54e76d7668f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
spellcheck fix with HASH updates

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Debian's lintian tool suggests replacing "everytime" with "every time"

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
This usage only appears under gr-digital in header files comments.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
This patch is applied in debian packaging for gnuradio 3.10.8.0-rc1
The build works - so the HASH values match.
The lintian finding goes away.

As this patch applies to the maint-3.10 branch as well, please consider
including it before tagging the next 3.10.8.0 release.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
