### PR TITLE
omit build path

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -143,6 +143,8 @@ STRIP_FROM_PATH        =
 
 STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@/gnuradio-runtime/include \
                          @PROJECT_BINARY_DIR@/gnuradio-runtime/include \
+                         @PROJECT_SOURCE_DIR@/gnuradio-runtime/ \
+                         @PROJECT_BINARY_DIR@/gnuradio-runtime/ \
                          @PROJECT_SOURCE_DIR@/gr-analog/include \
                          @PROJECT_BINARY_DIR@/gr-analog/include \
                          @PROJECT_SOURCE_DIR@/gr-audio/include \

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -20,6 +20,8 @@ message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
 #Generate the constants file, now that we actually know which components will be enabled.
+cmake_path(GET CMAKE_SOURCE_DIR PARENT_PATH top_build_dir)
+string(REPLACE "${top_build_dir}" "BUILD_DIR" SAFE_COMPILER_INFO "${COMPILER_INFO}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/constants.cc.in
                ${CMAKE_CURRENT_BINARY_DIR}/constants.cc ESCAPE_QUOTES @ONLY)
 

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -68,7 +68,7 @@ const std::string c_compiler() { return "@cmake_c_compiler_version@"; }
 
 const std::string cxx_compiler() { return "@cmake_cxx_compiler_version@"; }
 
-const std::string compiler_flags() { return "@COMPILER_INFO@"; }
+const std::string compiler_flags() { return "@SAFE_COMPILER_INFO@"; }
 
 const std::string build_time_enabled_components() { return "@_gr_enabled_components@"; }
 


### PR DESCRIPTION
Support reproducible builds by replacing reference to the build path.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Because gnuradio wants to take it's set of compiler flags so that
gnuradio-config-info --cflags
can show them to the user later, this was also capturing the -ffile-prefix-map
that the Debian package build uses to keep the build path out of generated files.

Also: Doxyfile.in needed an update to its STRIP_FROM_INC_PATH config.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Last year's commit, 886485a90d044228d25ff6d5170288ce2dfaa474 :
runtime: Move block_gateway from gnuradio-runtime into gr_python
resulted in the build path showing up in the Doxygen docs again.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
In gnuradio-runtime this replaces the actual build path with a generic
"BUILD_DIR" string.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Debian's lintian tool detects when the build path is found within
files generated and installed for packaging.
Applying this patch gave a clean report in preliminary packaging of
gnuradio 3.10.8.0-rc1

Because this patch also applies to the maint-3.10 branch, please consider including this
before the next release 3.10.8.0

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
