### PR TITLE
CI: Don't force generic VOLK kernels during CI

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -66,24 +66,24 @@ jobs:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
             cxxflags: -Werror
-            ctest_args: '-E ""'
-            # ldpath: 
+            ctest_args: '-E "^(qa_fecapi_cc|qa_polar_decoder_sc|qa_polar_decoder_sc_list|qa_polar_decoder_sc_systematic)$"'
+            # ldpath:
           - distro: 'Ubuntu 22.04'
             containerid: 'gnuradio/ci:ubuntu-22.04-3.9'
             cxxflags: -Werror
-            ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
+            ctest_args: '-E "^qa_polar_decoder_sc_systematic$"'
             # ldpath:
           - distro: 'Fedora 37 (with 0xFE memory initialization)'
             containerid: 'gnuradio/ci:fedora-37-3.9'
             cxxflags: -Werror -ftrivial-auto-var-init=pattern
-            ctest_args: '-E ""'
+            ctest_args: '-E "^qa_polar_decoder_sc_systematic$"'
             ldpath: /usr/local/lib64/
           - distro: 'Fedora 38 (clang)'
             containerid: 'gnuradio/ci:fedora-38-3.10'
             cxxflags: -Werror
             cmakeflags: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-            ctest_args: '-E ""'
-            ldpath: /usr/local/lib64 
+            ctest_args: '-E "^qa_polar_decoder_sc_systematic$"'
+            ldpath: /usr/local/lib64
           # - distro: 'CentOS 8.4'
           #   containerid: 'gnuradio/ci:centos-8.4-3.10'
           #   cxxflags: ''
@@ -92,13 +92,13 @@ jobs:
           - distro: 'Debian 12'
             containerid: 'gnuradio/ci:debian-12-3.10'
             cxxflags: -Werror
-            ctest_args: '-E ""'
-            # ldpath: 
+            ctest_args: '-E "^qa_polar_decoder_sc_systematic$"'
+            # ldpath:
           - distro: 'Debian 11 (32-bit)'
             containerid: 'gnuradio/ci:debian-i386-11-3.10'
             containeroptions: '--platform linux/i386'
             cxxflags: -Werror
-            ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
+            ctest_args: '-E "^(qa_fecapi_cc|qa_polar_decoder_sc|qa_polar_decoder_sc_list|qa_polar_decoder_sc_systematic)$"'
             # ldpath:
     name: ${{ matrix.distro }}
     container:

--- a/.packaging/conda_recipe/bld.bat
+++ b/.packaging/conda_recipe/bld.bat
@@ -27,6 +27,7 @@ if errorlevel 1 exit 1
 
 :: test
 set SKIP_TESTS=^
+qa_polar_decoder_sc_systematic^
 %=EMPTY=%
 
 ctest --build-config Release --output-on-failure --timeout 120 -j%CPU_COUNT% -E "%SKIP_TESTS%"

--- a/.packaging/conda_recipe/build.sh
+++ b/.packaging/conda_recipe/build.sh
@@ -31,9 +31,11 @@ cmake --build . --config Release --target install
 if [[ $target_platform == linux* ]] ; then
     export QT_QPA_PLATFORM=offscreen
     SKIP_TESTS=(
+        qa_polar_decoder_sc_systematic
     )
 else
     SKIP_TESTS=(
+        qa_polar_decoder_sc_systematic
     )
 fi
 SKIP_TESTS_STR=$( IFS="|"; echo "^(${SKIP_TESTS[*]})$" )

--- a/cmake/Modules/GrTest.cmake
+++ b/cmake/Modules/GrTest.cmake
@@ -67,7 +67,7 @@ function(GR_ADD_TEST test_name)
     # We add it to the beginning of the list to use locally-built modules before installed ones.
     list(INSERT pypath 0 "${PROJECT_BINARY_DIR}/test_modules")
 
-    set(environs "VOLK_GENERIC=1" "GR_DONT_LOAD_PREFS=1" "srcdir=${srcdir}"
+    set(environs "GR_DONT_LOAD_PREFS=1" "srcdir=${srcdir}"
                  "GR_CONF_CONTROLPORT_ON=False")
     list(APPEND environs ${GR_TEST_ENVIRONS})
 


### PR DESCRIPTION
## Description
In 4ca2456b0120a6d1468665a6afd2094ad2da8998, GNU Radio's test suite was modified so that tests always execute with generic VOLK kernels instead of platform-specific ones (SSE, AVX, NEON, etc). The commit message says that this was to "help control precision issues." I suspect the intention was to get some relief from flaky tests; until recently there were many tests that checked for exact floating point equality, or had tolerances set too low.

Now that flaky tests have been corrected, I think we should consider removing the `VOLK_GENERIC` switch, so that tests will run in a more realistic environment. (End users do not typically run GNU Radio with `VOLK_GENERIC=1`.) Doing so may help catch more VOLK bugs, such as https://github.com/gnuradio/volk/issues/414.

I left this as a draft pull request for now, to see whether this reveals any new test failures. At a minimum, we'll likely need to disable `qa_polar_decoder_sc_systematic_test` on all platforms that have broken `volk_8u_x2_encodeframepolar_8u` VOLK kernels.

**Update:** The following tests fail:

All platforms:
* `qa_polar_decoder_sc_systematic_test`, due to https://github.com/gnuradio/volk/issues/414

Ubuntu 20.04 & Debian 11:
* `qa_fecapi_cc`, due to https://github.com/gnuradio/volk/pull/458, fixed in VOLK 2.5.0
* `qa_polar_decoder_sc*`, due to https://github.com/gnuradio/volk/pull/434, fixed in VOLK 2.5.0

## Which blocks/areas does this affect?
Test suite / CI.

## Testing Done
I ran CI and checked what failed.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have ~~added~~ **disabled** tests to cover my changes, and all previous tests pass.
