### PR TITLE
v3.10.8.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 
 #### gr-zeromq
 - Explicitly shutdown and close source/sinks to prevent hangs in some cases.
+- Require `zmq.hpp` (cppzmq) version with `context_t.shutdown()` defined.
+  If `shutdown` is not defined, the `gr-zeromq` is disabled.
 
 #### Modtool
 - Add `cmake-format` support for generated modules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include(GrComponent)
 SET(VERSION_MAJOR 3)
 SET(VERSION_API   10)
 SET(VERSION_ABI   8)
-SET(VERSION_PATCH 0-rc1)
+SET(VERSION_PATCH 0-rc2)
 include(GrVersion) #setup version info
 # cmake-format: on
 


### PR DESCRIPTION
Since v3.10.8.0-rc1
- Require `zmq.hpp` (cppzmq) version with `context_t.shutdown()` defined. If `shutdown` is not defined, the `gr-zeromq` is disabled.