### PR TITLE
grc: Fix way-over-backslashing in file paths

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -610,16 +610,14 @@ class Application(Gtk.Application):
             main.new_page()
             args = (GLib.Variant('s', 'qt_gui'),)
             flow_graph = main.current_page.flow_graph
-            flow_graph.options_block.params['generate_options'].set_value(str(args[0])[
-                                                                          1:-1])
+            flow_graph.options_block.params['generate_options'].set_value(args[0].get_string())
             flow_graph.options_block.params['author'].set_value(getuser())
             flow_graph_update(flow_graph)
         elif action == Actions.FLOW_GRAPH_NEW_TYPE:
             main.new_page()
             if args:
                 flow_graph = main.current_page.flow_graph
-                flow_graph.options_block.params['generate_options'].set_value(str(args[0])[
-                                                                              1:-1])
+                flow_graph.options_block.params['generate_options'].set_value(args[0].get_string())
                 flow_graph_update(flow_graph)
         elif action == Actions.FLOW_GRAPH_OPEN:
             file_paths = args[0] if args[0] else FileDialogs.OpenFlowGraph(
@@ -638,7 +636,7 @@ class Application(Gtk.Application):
         elif action == Actions.FLOW_GRAPH_CLOSE:
             main.close_page()
         elif action == Actions.FLOW_GRAPH_OPEN_RECENT:
-            file_path = str(args[0])[1:-1]
+            file_path = args[0].get_string()
             main.new_page(file_path, show=True)
             self.config.add_recent_file(file_path)
             main.tool_bar.refresh_submenus()


### PR DESCRIPTION
## Description

aka https://xkcd.com/1638/ :smile: 

Each time File -> Open Recent is used on Windows, the number of backslashes in the filename doubles.

![backslash](https://github.com/gnuradio/gnuradio/assets/583749/a31e7099-342f-444e-ab9c-7dac44e7dc54)


This happens because a `GLib.Variant` object is passed through `str()`, which produces a quoted (and escaped) string. The quotes are then removed, but the escaping remains. The underlying string can instead be accessed using the `get_string()` method.

The same broken pattern exists in two other places, so I fixed those as well.

## Which blocks/areas does this affect?
GNU Radio Companion

## Testing Done
I verified that opening recent files works correctly (both through the menu and toolbar) on Linux and Windows. I also verified that creating new files still works (both through the menu and toolbar).

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
