### PR TITLE
grc: Consistently format filenames in messages

### DIFF
--- a/grc/core/Messages.py
+++ b/grc/core/Messages.py
@@ -88,11 +88,11 @@ def send_fail_load(error):
 
 
 def send_start_gen(file_path):
-    send('\nGenerating: %r\n' % file_path)
+    send('\nGenerating: "%s"\n' % file_path)
 
 
 def send_auto_gen(file_path):
-    send('>>> Generating: %r\n' % file_path)
+    send('>>> Generating: "%s"\n' % file_path)
 
 
 def send_fail_gen(error):


### PR DESCRIPTION
## Description
GRC usually formats filenames by putting double quotes around them, but when a flow graph is generated, the filename is formatted as a Python string, including escaping. On Windows, backslashes become double backslashes, making the filename harder to read. Here I've changed the messages to format the filename the same as elsewhere.

## Which blocks/areas does this affect?
GNU Radio Companion

## Testing Done
I verified that the filename is displayed in double-quoted form:
```
Generating: "C:\Users\Clayton\Documents\test.grc"
```

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
