### PR TITLE
gr-uhd: RFNoC Rx-Streamer: Add start stream options

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
@@ -15,7 +15,9 @@ templates:
             args=${ args },
         ),
         ${ vlen },
-        True
+        ${ issue_stream_cmd },
+        ${ start_time_set },
+        uhd.time_spec(${start_time}),
     )
     %if use_default_adapter_id == 'False':
     for port, adapter_id in enumerate(${ adapter_id_list }):
@@ -66,6 +68,25 @@ parameters:
   dtype: int_vector
   default: [0,]
   hide: ${ 'all' if use_default_adapter_id else 'none' }
+- id: issue_stream_cmd
+  label: Start stream
+  dtype: bool
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: ["Yes", "No"]
+- id: start_time_set
+  label: Start time
+  dtype: bool
+  default: 'False'
+  options: ['True', 'False']
+  option_labels: ["Time spec", "Now"]
+  hide: ${ "part" if issue_stream_cmd else "all" }
+- id: start_time
+  label: "Start time spec [s]"
+  dtype: float
+  default: 0
+  hide: ${ "part" if issue_stream_cmd and start_time_set else "all" }
+  
 
 asserts:
   - ${ num_chans > 0 }

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_rx_streamer.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_rx_streamer.h
@@ -45,12 +45,16 @@ public:
      * \param vlen Vector length
      * \param issue_stream_cmd_on_start If true, the streamer sends a stream
      *                                  command upstream.
+     * \param start_time_set If true, set start time spec to the stream command
+     * \param start_time The time spec for the stream command if start_time_set is true
      */
     static sptr make(rfnoc_graph::sptr graph,
                      const size_t num_chans,
                      const ::uhd::stream_args_t& stream_args,
                      const size_t vlen = 1,
-                     const bool issue_stream_cmd_on_start = true);
+                     const bool issue_stream_cmd_on_start = true,
+                     const bool start_time_set = false,
+                     const ::uhd::time_spec_t& start_time = ::uhd::time_spec_t(0.0));
 
     //! Return the unique ID associated with the underlying RFNoC streamer
     virtual std::string get_unique_id() const = 0;

--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
@@ -32,10 +32,17 @@ rfnoc_rx_streamer::sptr rfnoc_rx_streamer::make(rfnoc_graph::sptr graph,
                                                 const size_t num_chans,
                                                 const ::uhd::stream_args_t& stream_args,
                                                 const size_t vlen,
-                                                const bool issue_stream_cmd_on_start)
+                                                const bool issue_stream_cmd_on_start,
+                                                const bool start_time_set,
+                                                const ::uhd::time_spec_t& start_time)
 {
-    return gnuradio::make_block_sptr<rfnoc_rx_streamer_impl>(
-        graph, num_chans, stream_args, vlen, issue_stream_cmd_on_start);
+    return gnuradio::make_block_sptr<rfnoc_rx_streamer_impl>(graph,
+                                                             num_chans,
+                                                             stream_args,
+                                                             vlen,
+                                                             issue_stream_cmd_on_start,
+                                                             start_time_set,
+                                                             start_time);
 }
 
 
@@ -43,7 +50,9 @@ rfnoc_rx_streamer_impl::rfnoc_rx_streamer_impl(rfnoc_graph::sptr graph,
                                                const size_t num_chans,
                                                const ::uhd::stream_args_t& stream_args,
                                                const size_t vlen,
-                                               const bool issue_stream_cmd_on_start)
+                                               const bool issue_stream_cmd_on_start,
+                                               const bool start_time_set,
+                                               const ::uhd::time_spec_t& start_time)
     : gr::sync_block(
           "rfnoc_rx_streamer",
           gr::io_signature::make(0, 0, 0),
@@ -58,7 +67,9 @@ rfnoc_rx_streamer_impl::rfnoc_rx_streamer_impl(rfnoc_graph::sptr graph,
       d_streamer(graph->create_rx_streamer(num_chans, stream_args)),
       d_unique_id(
           std::dynamic_pointer_cast<::uhd::rfnoc::node_t>(d_streamer)->get_unique_id()),
-      d_issue_stream_cmd_on_start(issue_stream_cmd_on_start)
+      d_issue_stream_cmd_on_start(issue_stream_cmd_on_start),
+      d_start_time_set(start_time_set),
+      d_start_time(start_time)
 {
     // nop
 }

--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.h
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.h
@@ -21,7 +21,9 @@ public:
                            const size_t num_chans,
                            const ::uhd::stream_args_t& stream_args,
                            const size_t vlen,
-                           const bool issue_stream_cmd_on_start);
+                           const bool issue_stream_cmd_on_start,
+                           const bool start_time_set,
+                           const ::uhd::time_spec_t& start_time);
     ~rfnoc_rx_streamer_impl() override;
 
     std::string get_unique_id() const override { return d_unique_id; }

--- a/gr-uhd/python/uhd/bindings/rfnoc_rx_streamer_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_rx_streamer_python.cc
@@ -46,6 +46,8 @@ void bind_rfnoc_rx_streamer(py::module& m)
              py::arg("stream_args"),
              py::arg("vlen") = 1,
              py::arg("issue_stream_cmd_on_start") = true,
+             py::arg("start_time_set") = false,
+             py::arg("start_time") = 0,
              D(rfnoc_rx_streamer, make))
 
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Exposes the start_stream_cmd option and the time_spec field to GNU Radio. This is used by the start-stream command of RFNoC to initiate streaming.  
The default values keep the present behaviour

| Block | Defaults | Delayed start stream
|-|-|-|
|![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/4e9afe62-54ba-44a2-9445-3be8ab2a9a39)|![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/e1412122-22d8-437b-9096-daf1f2d9f986)|![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/0c6d3c30-66e2-4cf9-a55a-8252e1909f78)


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
For RFNoC loopback flow graphs which require data from the host, and without the time_spec option, one cannot guarantee that the host is ready to provide samples by the time the RFNoC graph is started. The time_spec allows to set a delay which can ensure that.

See the thread on the mailing list for details: https://www.mail-archive.com/usrp-users@lists.ettus.com/msg16664.html

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

RFNoC Rx Streamer


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Tested with UHD 4.4.0.0 and an X310 with the following flow-graph:

![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/b77fc227-419c-4975-b822-0b0459cd8689)


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
