### PR TITLE
grc: use yaml.CSafeLoader for performance if available

### DIFF
--- a/grc/core/io/yaml.py
+++ b/grc/core/io/yaml.py
@@ -80,5 +80,10 @@ def dump(data, stream=None, **kwargs):
     return yaml.dump_all([data], **config)
 
 
-safe_load = yaml.safe_load
-__with_libyaml__ = yaml.__with_libyaml__
+if yaml.__with_libyaml__:
+    loader = yaml.CSafeLoader
+else:
+    loader = yaml.SafeLoader
+
+
+def safe_load(stream): return yaml.load(stream, Loader=loader)

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -52,9 +52,6 @@ class Platform(Element):
         self._block_categories = {}
         self._auto_hier_block_generate_chain = set()
 
-        if not yaml.__with_libyaml__:
-            logger.warning("Slow YAML loading (libyaml not available)")
-
     def __str__(self):
         return 'Platform - {}'.format(self.config.name)
 


### PR DESCRIPTION
## Description
This significantly speeds up creation of the block cache, where libyaml is built in to Python yaml. The cache is almost unnecessary.

The previous code noted whether `yaml.__with_libyaml__` was defined, but did not actually use the C loader.

## Which blocks/areas does this affect?
GRC

## Testing Done
Ran both branches, noted speed.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
