### PR TITLE
blocks: msg_pair_to_var: Log with block logger, not gr.log

### DIFF
--- a/gr-blocks/python/blocks/msg_pair_to_var.py
+++ b/gr-blocks/python/blocks/msg_pair_to_var.py
@@ -20,27 +20,29 @@ class msg_pair_to_var(gr.sync_block):
     unpredictable.
     """
 
+    IN_PORT = pmt.intern("inpair")
+
     def __init__(self, callback):
         gr.sync_block.__init__(
             self, name="msg_pair_to_var", in_sig=None, out_sig=None)
 
         self.callback = callback
 
-        self.message_port_register_in(pmt.intern("inpair"))
-        self.set_msg_handler(pmt.intern("inpair"), self.msg_handler)
+        self.message_port_register_in(self.IN_PORT)
+        self.set_msg_handler(self.IN_PORT, self.msg_handler)
 
     def msg_handler(self, msg):
         if not pmt.is_pair(msg) or pmt.is_dict(msg) or pmt.is_pdu(msg):
-            gr.log.warn(
-                "Input message %s is not a simple pair, dropping" % repr(msg))
+            self.logger.warn(
+                f"Input message {msg} is not a simple pair, dropping")
             return
 
         new_val = pmt.to_python(pmt.cdr(msg))
         try:
             self.callback(new_val)
         except Exception as e:
-            gr.log.error("Error when calling " + repr(self.callback) + " with " +
-                         repr(new_val) + " (reason: %s)" % repr(e))
+            self.logger.error(
+                f"Error when calling {self.callback} with {new_val} (reason: {e})")
 
     def stop(self):
         return True

--- a/gr-blocks/python/blocks/qa_msg_pair_to_var.py
+++ b/gr-blocks/python/blocks/qa_msg_pair_to_var.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Marcus Müller
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import blocks
+from gnuradio import gr_unittest
+from gnuradio import gr
+import pmt
+import sys
+import time
+
+
+class test_msg_pair_to_var(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.backend = gr.dictionary_logger_backend()
+        gr.logging().add_default_sink(self.backend)
+        self.tb = gr.top_block(catch_exceptions=False)
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_calling(self):
+        canary = 0xDEAFBEEF
+        self.test_val = 0
+
+        def test_f(value: int = 0):
+            self.test_val = value
+
+        dut = blocks.msg_pair_to_var(test_f)
+        test_msg = pmt.cons(pmt.intern("foo"), pmt.from_long(canary))
+        src = blocks.message_strobe(test_msg, 10)
+        self.tb.msg_connect(*(src, pmt.intern("strobe")),
+                            *(dut, blocks.msg_pair_to_var.IN_PORT))
+        self.tb.start()
+        time.sleep(15e-3)
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertEqual(self.test_val, canary,
+                         f"Test value {hex(self.test_val)} not found to be canary {hex(canary)}")
+
+    def test_exceptions(self):
+        lark = 0xDEAFBEEF
+        nightingale = 0xDEAFB16D
+        self.test_val = 0
+
+        def test_f(value: int = 0):
+            if value == nightingale and value != lark:
+                raise Exception("It was the nightingale, and not the lark")
+
+        dut = blocks.msg_pair_to_var(test_f)
+        test_msg = pmt.cons(pmt.intern("birb"), pmt.from_long(nightingale))
+        src = blocks.message_strobe(test_msg, 10)
+        self.tb.msg_connect(*(src, pmt.intern("strobe")),
+                            *(dut, blocks.msg_pair_to_var.IN_PORT))
+        self.tb.start()
+        time.sleep(50e-3)
+        self.tb.stop()
+        self.tb.wait()
+
+        logged = self.backend.get_map()
+        self.assertIn("msg_pair_to_var", logged, "should have logged; didn't.")
+        log_entries = logged["msg_pair_to_var"]
+        for timestamp, entry in log_entries:
+            self.assertRegex(
+                entry,
+                r"Error when calling <function .*\.test_exceptions\..*.test_f.*> with 3736056173" +
+                r".*reason: It was the nightingale, and not the lark.*",
+                f"Log entry '{entry}' from {timestamp} doesn't contain Shakespeare")
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_msg_pair_to_var)

--- a/gr-blocks/python/blocks/qa_msg_pair_to_var.py
+++ b/gr-blocks/python/blocks/qa_msg_pair_to_var.py
@@ -35,7 +35,7 @@ class test_msg_pair_to_var(gr_unittest.TestCase):
             self.test_val = value
 
         dut = blocks.msg_pair_to_var(test_f)
-        test_msg = pmt.cons(pmt.intern("foo"), pmt.from_long(canary))
+        test_msg = pmt.cons(pmt.intern("foo"), pmt.from_uint64(canary))
         src = blocks.message_strobe(test_msg, 10)
         self.tb.msg_connect(*(src, pmt.intern("strobe")),
                             *(dut, blocks.msg_pair_to_var.IN_PORT))
@@ -57,7 +57,7 @@ class test_msg_pair_to_var(gr_unittest.TestCase):
                 raise Exception("It was the nightingale, and not the lark")
 
         dut = blocks.msg_pair_to_var(test_f)
-        test_msg = pmt.cons(pmt.intern("birb"), pmt.from_long(nightingale))
+        test_msg = pmt.cons(pmt.intern("birb"), pmt.from_uint64(nightingale))
         src = blocks.message_strobe(test_msg, 10)
         self.tb.msg_connect(*(src, pmt.intern("strobe")),
                             *(dut, blocks.msg_pair_to_var.IN_PORT))


### PR DESCRIPTION
This also adds the missing unit test.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The block was logging using gr.log.warn. It should have been logging using its own logger!

also, no unit tests makes me sad.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

#6799 looked at the block, and so I looked at the block, and was met with the above issues

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
/

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
