### PR TITLE
grc: Check flow graph format version

### DIFF
--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -28,6 +28,8 @@ BLOCK_DESCRIPTION_FILE_FORMAT_VERSION = 1
 # File format versions:
 #  0: undefined / legacy
 #  1: non-numeric message port keys (label is used instead)
+#  This constant is the max known version. If a version higher than this shows
+#  up, we assume we can't handle it.
 FLOW_GRAPH_FILE_FORMAT_VERSION = 1
 
 # Param tabs

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -10,7 +10,6 @@ from collections import namedtuple
 import os
 import logging
 from itertools import chain
-import re
 
 from . import (
     Messages, Constants,

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -340,6 +340,18 @@ class Platform(Element):
             from ..converter.flow_graph import from_xml
             data = from_xml(filename)
 
+        file_format = data.get('metadata', {}).get('file_format')
+        if file_format is None:
+            Messages.send(
+                '>>> WARNING: Flow graph does not contain a file format version!\n')
+        elif file_format == 0:
+            Messages.send(
+                '>>> WARNING: Flow graph format is version 0 (legacy) and will'
+                ' be converted to version 1 or higher upon saving!\n')
+        elif file_format > Constants.FLOW_GRAPH_FILE_FORMAT_VERSION:
+            raise RuntimeError(
+                f"Flow graph {filename} has unknown flow graph version!")
+
         return data
 
     def save_flow_graph(self, filename, flow_graph):


### PR DESCRIPTION
```
242c8ebf6 (Martin Braun, 9 minutes ago)
   grc: Check flow graph format version

   The constant FLOW_GRAPH_FILE_FORMAT_VERSION is now used as a check while 
   opening flow graphs. If a flow graph is opened which exceeds the 
   FLOW_GRAPH_FILE_FORMAT_VERSION known to this version of GRC, then the 
   assumption is that the .grc file was created with a later version of GRC, 
   and can't be opened in this version of GRC. In this case, the loading is 
   aborted.

   Signed-off-by: Martin Braun <martin.braun@ettus.com>

42ba2ccb7 (Martin Braun, 9 minutes ago)
   grc: Remove superfluous import

   Signed-off-by: Martin Braun <martin.braun@ettus.com>
```



## Which blocks/areas does this affect?

GRC file management.

## Testing Done

Attempt to open a flow graph that's from the future:
![image](https://github.com/gnuradio/gnuradio/assets/508035/9f48b9af-ceb3-4a62-8ffe-5641c9f0c0ca)

Old FG:
![image](https://github.com/gnuradio/gnuradio/assets/508035/2a1739d9-8a52-48ef-adb7-24adcb474d71)

(it still opens)


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.