### PR TITLE
Use pointers to pass s32fc arguments to VOLK

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/rotator.h
+++ b/gr-blocks/include/gnuradio/blocks/rotator.h
@@ -49,7 +49,11 @@ public:
 
     void rotateN(gr_complex* out, const gr_complex* in, int n)
     {
+#if VOLK_VERSION >= 030100
+        volk_32fc_s32fc_x2_rotator2_32fc(out, in, &d_phase_incr, &d_phase, n);
+#else
         volk_32fc_s32fc_x2_rotator_32fc(out, in, d_phase_incr, &d_phase, n);
+#endif
     }
 };
 

--- a/gr-blocks/lib/multiply_by_tag_value_cc_impl.cc
+++ b/gr-blocks/lib/multiply_by_tag_value_cc_impl.cc
@@ -59,7 +59,11 @@ int multiply_by_tag_value_cc_impl::work(int noutput_items,
         end *= d_vlen;
 
         // Multiply based on the current value of k from 'start' to 'end'
+#if VOLK_VERSION >= 030100
+        volk_32fc_s32fc_multiply2_32fc(&out[start], &in[start], &d_k, (end - start));
+#else
         volk_32fc_s32fc_multiply_32fc(&out[start], &in[start], d_k, (end - start));
+#endif
         start = end;
 
         // Extract new value of k
@@ -75,8 +79,13 @@ int multiply_by_tag_value_cc_impl::work(int noutput_items,
         }
     }
 
+#if VOLK_VERSION >= 030100
+    volk_32fc_s32fc_multiply2_32fc(
+        &out[start], &in[start], &d_k, (d_vlen * noutput_items - start));
+#else
     volk_32fc_s32fc_multiply_32fc(
         &out[start], &in[start], d_k, (d_vlen * noutput_items - start));
+#endif
 
     return noutput_items;
 }

--- a/gr-blocks/lib/multiply_const_impl.cc
+++ b/gr-blocks/lib/multiply_const_impl.cc
@@ -73,7 +73,11 @@ int multiply_const_impl<gr_complex>::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
     int noi = noutput_items * d_vlen;
 
+#if VOLK_VERSION >= 030100
+    volk_32fc_s32fc_multiply2_32fc(out, in, &d_k, noi);
+#else
     volk_32fc_s32fc_multiply_32fc(out, in, d_k, noi);
+#endif
 
     return noutput_items;
 }

--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -262,7 +262,11 @@ int multiply_matrix_impl<gr_complex>::work(int noutput_items,
         gr_complex* out = reinterpret_cast<gr_complex*>(output_items[out_idx]);
         // Do input 0 first, this saves a memset
         const gr_complex* in = reinterpret_cast<const gr_complex*>(input_items[0]);
+#if VOLK_VERSION >= 030100
+        volk_32fc_s32fc_multiply2_32fc(out, in, &d_A[out_idx][0], noutput_items);
+#else
         volk_32fc_s32fc_multiply_32fc(out, in, d_A[out_idx][0], noutput_items);
+#endif
         // Then do inputs 1 through N
         for (size_t in_idx = 1; in_idx < input_items.size(); in_idx++) {
             in = reinterpret_cast<const gr_complex*>(input_items[in_idx]);

--- a/gr-blocks/lib/phase_shift_impl.cc
+++ b/gr-blocks/lib/phase_shift_impl.cc
@@ -84,7 +84,11 @@ int phase_shift_impl::work(int noutput_items,
     gr::thread::scoped_lock guard(d_setlock);
 
     if (d_shift != 0.0f) {
+#if VOLK_VERSION >= 030100
+        volk_32fc_s32fc_multiply2_32fc(out, in, &d_shift_cc, noutput_items);
+#else
         volk_32fc_s32fc_multiply_32fc(out, in, d_shift_cc, noutput_items);
+#endif
     } else {
         memcpy(out, in, sizeof(gr_complex) * noutput_items);
     }

--- a/gr-blocks/python/blocks/bindings/rotator_python.cc
+++ b/gr-blocks/python/blocks/bindings/rotator_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rotator.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(5d52f019c659d77040b16ad7541e4fd2)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3af403c5adb7af31a51113901293189d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/include/gnuradio/digital/adaptive_algorithm_cma.h
+++ b/gr-digital/include/gnuradio/digital/adaptive_algorithm_cma.h
@@ -70,8 +70,13 @@ public:
         gr_complex err_x_mu = -d_step_size * error;
 
         volk_32fc_conjugate_32fc(conj_vector.data(), in, num_taps);
+#if VOLK_VERSION >= 030100
+        volk_32fc_s32fc_multiply2_32fc(
+            prod_vector.data(), conj_vector.data(), &err_x_mu, num_taps);
+#else
         volk_32fc_s32fc_multiply_32fc(
             prod_vector.data(), conj_vector.data(), err_x_mu, num_taps);
+#endif
         volk_32fc_x2_add_32fc(taps, taps, prod_vector.data(), num_taps);
     }
 

--- a/gr-digital/include/gnuradio/digital/adaptive_algorithm_lms.h
+++ b/gr-digital/include/gnuradio/digital/adaptive_algorithm_lms.h
@@ -51,8 +51,13 @@ public:
         gr_complex err_x_mu = d_step_size * error;
 
         volk_32fc_conjugate_32fc(conj_vector.data(), in, num_taps);
+#if VOLK_VERSION >= 030100
+        volk_32fc_s32fc_multiply2_32fc(
+            prod_vector.data(), conj_vector.data(), &err_x_mu, num_taps);
+#else
         volk_32fc_s32fc_multiply_32fc(
             prod_vector.data(), conj_vector.data(), err_x_mu, num_taps);
+#endif
         volk_32fc_x2_add_32fc(taps, taps, prod_vector.data(), num_taps);
     }
 

--- a/gr-digital/python/digital/bindings/adaptive_algorithm_cma_python.cc
+++ b/gr-digital/python/digital/bindings/adaptive_algorithm_cma_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(adaptive_algorithm_cma.h) */
-/* BINDTOOL_HEADER_FILE_HASH(db6db4f2b808db300412b90c61b333b6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0b4e0edcded1314dd33e1733e867be2f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/adaptive_algorithm_lms_python.cc
+++ b/gr-digital/python/digital/bindings/adaptive_algorithm_lms_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(adaptive_algorithm_lms.h) */
-/* BINDTOOL_HEADER_FILE_HASH(f3725cfd42cb5687fe2b2191b78e96b6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(bf34ea7730349513a808de7f99e7744b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
@@ -14,6 +14,7 @@
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <volk/volk.h>
 #include <algorithm>
 #include <complex>
 
@@ -1077,8 +1078,10 @@ int dvbt_reference_signals_impl::general_work(int noutput_items,
                &out[(i * d_noutput) + (ofdm_fft_size / 2)],
                sizeof(gr_complex) * ofdm_fft_size / 2);
         ofdm_fft.execute();
-        volk_32fc_s32fc_multiply_32fc(
-            &out[i * d_noutput], ofdm_fft.get_outbuf(), normalization, ofdm_fft_size);
+        volk_32f_s32f_multiply_32f(reinterpret_cast<float*>(&out[i * d_noutput]),
+                                   reinterpret_cast<float*>(ofdm_fft.get_outbuf()),
+                                   normalization,
+                                   ofdm_fft_size * 2);
     }
 
     // Tell runtime system how many input items we consumed on

--- a/gr-dtv/lib/dvbt2/dvbt2_paprtr_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_paprtr_cc_impl.cc
@@ -671,8 +671,10 @@ int dvbt2_paprtr_cc_impl::work(int noutput_items,
                     memcpy(ones_time.data(),
                            papr_fft.get_outbuf(),
                            sizeof(gr_complex) * papr_fft_size);
-                    volk_32fc_s32fc_multiply_32fc(
-                        ones_time.data(), ones_time.data(), normalization, papr_fft_size);
+                    volk_32f_s32f_multiply_32f(reinterpret_cast<float*>(ones_time.data()),
+                                               reinterpret_cast<float*>(ones_time.data()),
+                                               normalization,
+                                               papr_fft_size * 2);
                     std::fill_n(&r[0], N_TR, 0);
                     std::fill_n(&c[0], papr_fft_size, 0);
                     for (int k = 1; k <= num_iterations; k++) {
@@ -706,7 +708,11 @@ int dvbt2_paprtr_cc_impl::work(int noutput_items,
                                 papr_fft_size;
                             ctemp[n] = std::exp(gr_complexd(0.0, vtemp));
                         }
+#if VOLK_VERSION >= 030100
+                        volk_32fc_s32fc_multiply2_32fc(v.data(), ctemp.data(), &u, N_TR);
+#else
                         volk_32fc_s32fc_multiply_32fc(v.data(), ctemp.data(), u, N_TR);
+#endif
                         volk_32f_s32f_multiply_32f(
                             (float*)rNew.data(), (float*)v.data(), alpha, N_TR * 2);
                         volk_32f_x2_subtract_32f((float*)rNew.data(),
@@ -746,8 +752,13 @@ int dvbt2_paprtr_cc_impl::work(int noutput_items,
                             ones_freq[(n + m) % papr_fft_size] = ones_time[n];
                         }
                         result = u * alpha;
+#if VOLK_VERSION >= 030100
+                        volk_32fc_s32fc_multiply2_32fc(
+                            ctemp.data(), ones_freq.data(), &result, papr_fft_size);
+#else
                         volk_32fc_s32fc_multiply_32fc(
                             ctemp.data(), ones_freq.data(), result, papr_fft_size);
+#endif
                         volk_32f_x2_subtract_32f((float*)c.data(),
                                                  (float*)c.data(),
                                                  (float*)ctemp.data(),

--- a/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.cc
@@ -2701,8 +2701,10 @@ int dvbt2_pilotgenerator_cc_impl::general_work(int noutput_items,
             memcpy(
                 &dst[0], &out[ofdm_fft_size / 2], sizeof(gr_complex) * ofdm_fft_size / 2);
             ofdm_fft.execute();
-            volk_32fc_s32fc_multiply_32fc(
-                out, ofdm_fft.get_outbuf(), normalization, ofdm_fft_size);
+            volk_32f_s32f_multiply_32f(reinterpret_cast<float*>(out),
+                                       reinterpret_cast<float*>(ofdm_fft.get_outbuf()),
+                                       normalization,
+                                       ofdm_fft_size * 2);
             out += ofdm_fft_size;
         }
     }


### PR DESCRIPTION
**Note:** This draft PR depends on https://github.com/gnuradio/volk/pull/695 being merged, and VOLK 3.1.0 being released. This PR is ready for review now, but I'll leave it as a draft until VOLK 3.1.0 is out.

## Description

Passing `lv_32fc_t` arguments by value results in Undefined Behaviour, as explained in https://github.com/gnuradio/volk/issues/442. To avoid this, we use VOLK 3.1.0's updated API, where `lv_32fc_t` arguments are passed in using pointers.

Three of the affected `volk_32fc_s32fc_multiply_32fc` calls (all in gr-dtv) did not actually use a complex scalar, so I switched those calls to `volk_32f_s32f_multiply_32f` instead.

## Related Issue
Fixes #6300.
Fixes https://github.com/gqrx-sdr/gqrx/issues/781.

VOLK issue: https://github.com/gnuradio/volk/issues/442
VOLK PR: https://github.com/gnuradio/volk/pull/695

## Which blocks/areas does this affect?
* Frequency Xlating FIR Filter
* Frequency Xlating FFT Filter
* Rotator
* Multiply by Tag Value
* Multiply Const
* Multiply by Matrix
* Phase Shift
* Adaptive Algorithm
* DVB-T Reference Signals
* DVB-T2 Tone Reservation PAPR
* DVB-T2 Pilot Generator and IFFT

## Testing Done
Using docker multiarch, I tested https://github.com/gnuradio/volk/pull/695 together with this PR on the ppc64le architecture. Prior to the changes, 10 GNU Radio tests fail (due to segfaults), and afterwards all tests pass. Gqrx also runs without issue on ppc64le with the changes in place.

I also verified that GNU Radio's test suite passes when VOLK < 3.1.0 is used.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
