### PR TITLE
project: add tox.ini, so that editors use the same formatting as github CI

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -29,7 +29,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: quentinguidee/pep8-action@v1
       with:
+        # -----------------------------------
+        # UPDATE tox.ini when making changes!
         arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605 --exclude *.yml.py'
+        # -----------------------------------
   # Doxygen gets built separately. It has a lot of output and its own weirdness.
   doxygen:
     name: Doxygen

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[pycodestyle]
+# -------------------------------------------------------------
+# UPDATE .github/workflows/make-test.yml's WHEN MAKING CHANGES!
+# -------------------------------------------------------------
+# from github workflow:
+# arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605 --exclude *.yml.py'
+max-line-length = 120
+extend-ignore = E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605


### PR DESCRIPTION
## Description

I've been a bit annoyed by the fact that my neovim + pylsp would not complain about the same formatting as the CI.

Adding this instructs the pycodestyle as used by pylsp to adopt the same style.

## Which blocks/areas does this affect?

None directly, hopefully future Python quality


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
