### PR TITLE
fec: fix incorrect runtime error message

### DIFF
--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -67,7 +67,7 @@ cc_decoder_impl::cc_decoder_impl(int frame_size,
     if (k != 7 || rate != 2) {
         // used to throw std::runtime_error("cc_decoder: parameters not supported");
         throw std::invalid_argument(
-            "cc_decoder: Only k=2, rate=2 convolutional codes are supported");
+            "cc_decoder: Only k=7, rate=2 convolutional codes are supported");
     }
 
     switch (d_mode) {


### PR DESCRIPTION
## Description
Changes requirement for "k=2" to "k=7"

## Related Issue
Noted in https://github.com/gnuradio/gnuradio/pull/6926 comments
Fixes #6938

## Which blocks/areas does this affect?
CC Decoder

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
