### PR TITLE
qtgui: Remove unnecessary imports from templates

### DIFF
--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -64,9 +64,7 @@ asserts:
 - ${start <= stop}
 
 templates:
-    imports: |- 
-        from gnuradio.qtgui import Range, RangeWidget
-        from PyQt5 import QtCore
+    imports: from PyQt5 import QtCore
     var_make: self.${id} = ${id} = ${value}
     callbacks:
     - self.set_${id}(${value})
@@ -75,8 +73,8 @@ templates:
             win = 'self._%s_win'%id
             range = 'self._%s_range'%id
         %>\
-        ${range} = Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
-        ${win} = RangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient})
+        ${range} = qtgui.Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
+        ${win} = qtgui.RangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient})
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_rfnoc_f15_display.block.yml
+++ b/gr-qtgui/grc/qtgui_rfnoc_f15_display.block.yml
@@ -69,9 +69,7 @@ outputs:
 
 
 templates:
-  imports: |-
-    from gnuradio import qtgui
-    import sip
+  imports: import sip
   make: |-
     <%
         win = 'self._%s_win' % id


### PR DESCRIPTION
## Description
When a QT GUI Range block is added to the canvas in GRC, there is a noticeable delay, which does not occur for other blocks. This happens because `from gnuradio.qtgui import Range, RangeWidget` causes a large number of shared libraries to be loaded. The import is unnecessary, because the flow graph template already imports `gnuradio.qtgui`:

https://github.com/gnuradio/gnuradio/blob/53de3dd32a9fc9ba1fa4e834487749340a6859a3/grc/core/generator/flow_graph.py.mako#L24-L30

The import can also cause a crash on Windows, as noted in #6914.

Note: The QT GUI RFNoC Fosphor Display (Byte Vector) block has the same bug, ~~but I'll fix that in a separate PR to make backporting simpler. (The block is not present in GNU Radio 3.10.)~~ **Update: The QT GUI RFNoC Fosphor Display (Byte Vector) block was in fact already merged to maint-3.10, so I'll include it here as well.**

## Related Issue
Fixes #6914.

## Which blocks/areas does this affect?
* QT GUI Range
* QT GUI RFNoC Fosphor Display (Byte Vector)

## Testing Done
In GRC, I made a flow graph containing a Range widget and verified that the flow graph still executed normally.

I do not have RFNoC-capable hardware, so the only testing I did with the QT GUI RFNoC Fosphor Display (Byte Vector) block was to drop it onto a flow graph and verify that the delay was gone.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
