### PR TITLE
GRC: generate valid C++ string parameters without explicit double quotes

### DIFF
--- a/gr-analog/grc/analog_ctcss_squelch_ff.block.yml
+++ b/gr-analog/grc/analog_ctcss_squelch_ff.block.yml
@@ -50,8 +50,5 @@ cpp_templates:
     - set_level(${level})
     - set_frequency(${freq})
     link: ['gnuradio::gnuradio-analog']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-analog/grc/analog_pwr_squelch_xx.block.yml
+++ b/gr-analog/grc/analog_pwr_squelch_xx.block.yml
@@ -49,9 +49,6 @@ cpp_templates:
     - set_threshold(${threshold})
     - set_alpha(${alpha})
     link: ['gnuradio::gnuradio-analog']
-    translations:
-        True: true
-        False: false
 
 documentation: |-
     This will either pass the input unchanged or block it, depending on

--- a/gr-audio/grc/audio_sink.block.yml
+++ b/gr-audio/grc/audio_sink.block.yml
@@ -44,10 +44,6 @@ cpp_templates:
     declarations: 'audio::sink::sptr ${id};'
     make: 'this->${id} = audio::sink::make(${samp_rate}, ${device_name}, ${ok_to_block});'
     link: ['gnuradio::gnuradio-audio']
-    translations:
-        "'": '"'
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     Not all sampling rates will be supported by your hardware.

--- a/gr-audio/grc/audio_source.block.yml
+++ b/gr-audio/grc/audio_source.block.yml
@@ -44,10 +44,6 @@ cpp_templates:
     declarations: 'audio::source::sptr ${id};'
     make: 'this->${id} = audio::source::make(${samp_rate}, ${device_name}, ${ok_to_block});'
     link: ['gnuradio::gnuradio-audio']
-    translations:
-        "'": '"'
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     Not all sampling rates will be supported by your hardware.

--- a/gr-blocks/grc/blocks_burst_tagger.block.yml
+++ b/gr-blocks/grc/blocks_burst_tagger.block.yml
@@ -60,8 +60,5 @@ cpp_templates:
     callbacks:
     - set_true_tag(${true_key},${true_value})
     - set_false_tag(${false_key},${false_value})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_complex_to_interleaved_char.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_interleaved_char.block.yml
@@ -33,9 +33,6 @@ cpp_templates:
     includes: ['#include <gnuradio/blocks/complex_to_interleaved_char.h>']
     declarations: 'blocks::complex_to_interleaved_char::sptr ${id};'
     make: 'this->${id} = blocks::complex_to_interleaved_char::make(${vector_output});'
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     This block converts a complex sample to interleaved IQ bytes.  

--- a/gr-blocks/grc/blocks_complex_to_interleaved_short.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_interleaved_short.block.yml
@@ -37,9 +37,6 @@ cpp_templates:
     make: 'this->${id} = blocks::complex_to_interleaved_short::make(${vector_output});'
     callbacks:
     - set_scale_factor(${scale_factor})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     This block converts a complex sample to interleaved IQ 16-bit values.  

--- a/gr-blocks/grc/blocks_copy.block.yml
+++ b/gr-blocks/grc/blocks_copy.block.yml
@@ -61,8 +61,5 @@ cpp_templates:
         this->${id}->set_enabled(${enabled});
     callbacks:
     - set_enabled(${enabled})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_file_descriptor_source.block.yml
+++ b/gr-blocks/grc/blocks_file_descriptor_source.block.yml
@@ -39,8 +39,5 @@ cpp_templates:
     includes: ['#include <gnuradio/blocks/file_descriptor_source.h>']
     declarations: 'blocks::file_descriptor_source::sptr ${id};'
     make: 'this->${id} = blocks::file_descriptor_source::make(${type.size}*${vlen}, ${fd}, ${repeat});'
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_file_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_sink.block.yml
@@ -52,11 +52,8 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/file_sink.h>']
     declarations: 'blocks::file_sink::sptr ${id};'
-    make: 'this->${id} = blocks::file_sink::make(${type.size}*${vlen}, "${no_quotes(file)}", ${append});'
+    make: 'this->${id} = blocks::file_sink::make(${type.size}*${vlen}, ${file}, ${append});'
     callbacks:
     - open(${file})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_file_source.block.yml
+++ b/gr-blocks/grc/blocks_file_source.block.yml
@@ -63,8 +63,5 @@ cpp_templates:
     make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length});'
     callbacks:
     - open(${file}, ${repeat})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_interleaved_char_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_interleaved_char_to_complex.block.yml
@@ -37,9 +37,6 @@ cpp_templates:
     make: 'this->${id} = blocks::interleaved_char_to_complex::make(${vector_input});'
     callbacks:
     - set_scale_factor(${scale_factor})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     This block converts interleaved IQ bytes to a float complex data type.  

--- a/gr-blocks/grc/blocks_interleaved_short_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_interleaved_short_to_complex.block.yml
@@ -46,9 +46,6 @@ cpp_templates:
     callbacks:
     - set_swap(${swap})
     - set_scale_factor(${scale_factor})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     This block converts interleaved 12/16-bit IQ samples to a float complex data 

--- a/gr-blocks/grc/blocks_mute_xx.block.yml
+++ b/gr-blocks/grc/blocks_mute_xx.block.yml
@@ -39,8 +39,5 @@ cpp_templates:
     make: 'this->${id} = blocks::mute_${type.fcn}::(bool(${mute}));'
     callbacks:
     - set_mute(bool(${mute}))
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_repack_bits_bb.block.yml
+++ b/gr-blocks/grc/blocks_repack_bits_bb.block.yml
@@ -53,6 +53,5 @@ cpp_templates:
     - set_k_and_l(${k},${l})
     translations:
         gr\.: ''
-        'True': 'true'
-        'False': 'false'
+
 file_format: 1

--- a/gr-blocks/grc/blocks_selector.block.yml
+++ b/gr-blocks/grc/blocks_selector.block.yml
@@ -93,8 +93,5 @@ cpp_templates:
     - set_enabled(${enabled})
     - set_input_index(${input_index})
     - set_output_index(${output_index})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_tag_debug.block.yml
+++ b/gr-blocks/grc/blocks_tag_debug.block.yml
@@ -61,8 +61,5 @@ cpp_templates:
         this->${id}.set_display(${display});
     callbacks:
     - set_display(${display})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_tag_gate.block.yml
+++ b/gr-blocks/grc/blocks_tag_gate.block.yml
@@ -55,8 +55,5 @@ cpp_templates:
         this->${id}.set_single_key(${single_key});
     callbacks:
     - self.${id}.set_single_key(${single_key})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_test_tag_variable_rate_ff.block.yml
+++ b/gr-blocks/grc/blocks_test_tag_variable_rate_ff.block.yml
@@ -31,8 +31,5 @@ cpp_templates:
     includes: ['#include <gnuradio/blocks/test_tag_variable_rate_ff.h>']
     declarations: 'blocks::test_tag_variable_rate_ff::sptr ${id};'
     make: 'this->${id} = blocks::test_tag_variable_rate_ff::make(${once}, ${step});'
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_throttle.block.yml
+++ b/gr-blocks/grc/blocks_throttle.block.yml
@@ -52,9 +52,6 @@ cpp_templates:
     make: 'this->${id} = blocks::throttle::make(${type.size}*${vlen}, ${samples_per_second}, ${ignoretag});'
     callbacks:
     - set_sample_rate(${samples_per_second})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 
 file_format: 1

--- a/gr-blocks/grc/blocks_throttle2.block.yml
+++ b/gr-blocks/grc/blocks_throttle2.block.yml
@@ -86,8 +86,5 @@ cpp_templates:
     callbacks:
     - 'set_sample_rate(${samples_per_second})'
     - 'set_maximum_items_per_chunk(${id}_limit(${maximum}))'
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_vector_source_x.block.yml
+++ b/gr-blocks/grc/blocks_vector_source_x.block.yml
@@ -51,8 +51,5 @@ cpp_templates:
     make: 'this->${id} = blocks::vector_source_${type.fcn}::make(${vector}, ${repeat}, ${vlen}, ${tags});'
     callbacks:
     - set_data(${vector}, ${tags})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_wavfile_sink.block.yml
+++ b/gr-blocks/grc/blocks_wavfile_sink.block.yml
@@ -143,8 +143,5 @@ cpp_templates:
     callbacks:
     ## TODO Handle std::string type when const char* argument is needed
     - this->${id}->open(${file})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-blocks/grc/blocks_wavfile_source.block.yml
+++ b/gr-blocks/grc/blocks_wavfile_source.block.yml
@@ -35,8 +35,5 @@ cpp_templates:
     declarations: 'blocks::wavfile_source::sptr ${id};'
     make: |-
       this->${id} = blocks::wavfile_source::make(${file}${'.c_str()' if str(file)[0] != "'" and str(file)[0] != "\"" else ''}, ${repeat});
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_burst_shaper.block.yml
+++ b/gr-digital/grc/digital_burst_shaper.block.yml
@@ -64,8 +64,5 @@ cpp_templates:
             ${insert_phasing},
             ${length_tag_name});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_costas_loop_cc.block.yml
+++ b/gr-digital/grc/digital_costas_loop_cc.block.yml
@@ -57,8 +57,5 @@ cpp_templates:
     link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_loop_bandwidth(${w})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_crc16_async_bb.block.yml
+++ b/gr-digital/grc/digital_crc16_async_bb.block.yml
@@ -30,8 +30,5 @@ cpp_templates:
         this->${id} = digital::crc16_async_bb::make(
             ${check});
     link: ['gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_crc32_async_bb.block.yml
+++ b/gr-digital/grc/digital_crc32_async_bb.block.yml
@@ -30,8 +30,5 @@ cpp_templates:
         this->${id} = digital::crc32_async_bb::make(
             ${check});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_crc32_bb.block.yml
+++ b/gr-digital/grc/digital_crc32_bb.block.yml
@@ -40,8 +40,5 @@ cpp_templates:
             ${lengthtagname},
             ${packed});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_crc_append.block.yml
+++ b/gr-digital/grc/digital_crc_append.block.yml
@@ -64,8 +64,5 @@ cpp_templates:
             ${input_reflected}, ${result_reflected}, ${swap_endianness},
             ${skip_header_bytes});
     link: ['gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_crc_check.block.yml
+++ b/gr-digital/grc/digital_crc_check.block.yml
@@ -73,8 +73,5 @@ cpp_templates:
             ${input_reflected}, ${result_reflected}, ${swap_endianness},
             ${discard_crc}, ${skip_header_bytes});
     link: ['gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_glfsr_source_x.block.yml
+++ b/gr-digital/grc/digital_glfsr_source_x.block.yml
@@ -45,8 +45,5 @@ cpp_templates:
             ${mask},
             ${seed});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_header_payload_demux.block.yml
+++ b/gr-digital/grc/digital_header_payload_demux.block.yml
@@ -108,8 +108,5 @@ cpp_templates:
             ${special_tags},
             ${header_padding});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_carrier_allocator_cvc.block.yml
+++ b/gr-digital/grc/digital_ofdm_carrier_allocator_cvc.block.yml
@@ -62,8 +62,5 @@ cpp_templates:
             ${len_tag_key},
             ${output_is_shifted});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_chanest_vcvc.block.yml
+++ b/gr-digital/grc/digital_ofdm_chanest_vcvc.block.yml
@@ -65,8 +65,5 @@ cpp_templates:
             ${max_carr_offset},
             ${force_one_symbol});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_frame_equalizer_vcvc.block.yml
+++ b/gr-digital/grc/digital_ofdm_frame_equalizer_vcvc.block.yml
@@ -55,8 +55,5 @@ cpp_templates:
             ${propagate_channel_state},
             ${fixed_frame_len});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_serializer_vcc.block.yml
+++ b/gr-digital/grc/digital_ofdm_serializer_vcc.block.yml
@@ -62,8 +62,5 @@ cpp_templates:
             ${carr_offset_key},
             ${input_is_shifted});
     link: ['gnuradio::gnuradio-digital']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_sync_sc_cfb.block.yml
+++ b/gr-digital/grc/digital_ofdm_sync_sc_cfb.block.yml
@@ -55,8 +55,5 @@ cpp_templates:
     link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_threshold(${threshold})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-fft/grc/fft_fft_vxx.block.yml
+++ b/gr-fft/grc/fft_fft_vxx.block.yml
@@ -69,8 +69,6 @@ cpp_templates:
     callbacks:
     - set_nthreads(${nthreads})
     translations:
-        'True': 'true'
-        'False': 'false'
         'window\.': 'fft::window::'
 
 file_format: 1

--- a/gr-filter/grc/filter_dc_blocker_xx.block.yml
+++ b/gr-filter/grc/filter_dc_blocker_xx.block.yml
@@ -38,8 +38,5 @@ cpp_templates:
     declarations: 'filter::dc_blocker_${type}::sptr ${id};'
     make: 'this->${id} = filter::dc_blocker_${type}::make(${length}, ${long_form});'
     link: ['gnuradio::gnuradio-filter']
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-filter/grc/filter_iir_filter_xxx.block.yml
+++ b/gr-filter/grc/filter_iir_filter_xxx.block.yml
@@ -60,8 +60,5 @@ cpp_templates:
     link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(fftaps, fbtaps)
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-filter/grc/filter_pfb_decimator.block.yml
+++ b/gr-filter/grc/filter_pfb_decimator.block.yml
@@ -77,8 +77,5 @@ cpp_templates:
     callbacks:
     - set_taps(taps)
     - set_channel(int(${channel}))
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-filter/grc/filter_pfb_synthesizer.block.yml
+++ b/gr-filter/grc/filter_pfb_synthesizer.block.yml
@@ -74,8 +74,5 @@ cpp_templates:
     callbacks:
     - set_taps(taps)
     - set_channel_map(ch_map)
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-network/grc/network_socket_pdu.block.yml
+++ b/gr-network/grc/network_socket_pdu.block.yml
@@ -47,9 +47,6 @@ cpp_templates:
     includes: ['#include <gnuradio/network/socket_pdu.h>']
     declarations: 'network::socket_pdu::sptr ${id};'
     make: 'this->${id} = network::socket_pdu::make("${type}", ${host}, ${port}, ${mtu}, ${tcp_no_delay});'
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     For server modes, leave Host blank to bind to all interfaces (equivalent to 0.0.0.0).

--- a/gr-network/grc/network_tuntap_pdu.block.yml
+++ b/gr-network/grc/network_tuntap_pdu.block.yml
@@ -37,8 +37,5 @@ cpp_templates:
     includes: ['#include <gnuradio/network/tuntap_pdu.h>']
     declarations: 'network::tuntap_pdu::sptr ${id};'
     make: 'this->${id} = network::tuntap_pdu::make(${ifn}, ${mtu}, ${istunflag});'
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 file_format: 1

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -483,7 +483,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
-            "${no_quotes(name)}", // name
+            ${name}, // name
             ${ 0 if (type == 'msg_complex' or type == 'msg_float') else nconnections } // nconnections
         );
 
@@ -529,10 +529,6 @@ cpp_templates:
         _${id}_win = this->${id}->qwidget();
 
         ${gui_hint() % win}
-
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -327,9 +327,7 @@ cpp_templates:
         _${id}_win = this->${id}->qwidget();
 
         ${gui_hint() % win}
-    translations:
-        'True': 'true'
-        'False': 'false'
+        
 documentation: |-
     The GUI hint can be used to position the widget within the application.     The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span].     Both the tab specification and the grid position are optional.
 

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -163,9 +163,6 @@ cpp_templates:
     ${gui_hint() % win}
     
   link: ['gnuradio::gnuradio-qtgui']
-  translations:
-    'True': 'true'
-    'False': 'false'
 
 documentation: |-
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.

--- a/gr-qtgui/grc/qtgui_tab_widget.block.yml
+++ b/gr-qtgui/grc/qtgui_tab_widget.block.yml
@@ -151,7 +151,7 @@ cpp_templates:
     QBoxLayout* ${id}_layout_${i} =new QBoxLayout(QBoxLayout::TopToBottom,${id}_widget_${i});
     QGridLayout* ${id}_grid_layout_${i} = new QGridLayout();
     ${id}_layout_${i}->addLayout(${id}_grid_layout_${i});
-    ${win}->addTab(${id}_widget_${i},"${no_quotes(label)}");
+    ${win}->addTab(${id}_widget_${i},${label});
     % endfor
     ${gui_hint() % win}
  

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -1095,7 +1095,7 @@ cpp_templates:
         ${id} = qtgui::${type.fcn}::make(
             ${size}, // size
             ${srate}, // samp_rate
-            "${no_quotes(name)}", // name
+            ${name}, // name
             ${0 if type.startswith('msg') else nconnections} // number of inputs
         );
 
@@ -1103,7 +1103,7 @@ cpp_templates:
         ${id}->set_update_time(${update_time});
         ${id}->set_y_axis(${ymin}, ${ymax});
 
-        ${id}->set_y_label("${no_quotes(ylabel)}", "${no_quotes(yunit)}");
+        ${id}->set_y_label(${ylabel}, ${yunit});
 
         ${id}->enable_tags(${entags});
         ${id}->set_trigger_mode(${tr_mode.replace('qtgui.','gr::qtgui::')}, ${tr_slope.replace('qtgui.','gr::qtgui::')}, ${tr_level}, ${tr_delay},${tr_chan}, ${tr_tag});
@@ -1167,10 +1167,6 @@ cpp_templates:
         _${id}_win = this->${id}->qwidget();
 
         ${gui_hint() % win}
-
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -326,7 +326,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
-            "${no_quotes(name)}", // name
+            ${name}, // name
             ${ (0 if type.startswith('msg') else nconnections) } // number of inputs
         );
 
@@ -368,10 +368,6 @@ cpp_templates:
         _${id}_win = this->${id}->qwidget();
 
         ${gui_hint() % win}
-
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.

--- a/gr-zeromq/grc/zeromq_pub_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_sink.block.yml
@@ -78,8 +78,5 @@ cpp_templates:
         ${drop_on_hwm},
         ${bind});
     link: ['gnuradio::gnuradio-zeromq']
-    translations:
-      'True': 'true'
-      'False': 'false'
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_pull_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_source.block.yml
@@ -64,9 +64,6 @@ cpp_templates:
               ${hwm},
               ${bind});
     link: ['gnuradio::gnuradio-zeromq']
-    translations:
-      'True': 'true'
-      'False': 'false'
 
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_push_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_push_sink.block.yml
@@ -64,9 +64,6 @@ cpp_templates:
               ${hwm},
               ${bind});
     link: ['gnuradio::gnuradio-zeromq']
-    translations:
-      'True': 'true'
-      'False': 'false'
 
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_rep_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_rep_sink.block.yml
@@ -65,8 +65,5 @@ cpp_templates:
         ${hwm},
         ${bind});
     link: ['gnuradio::gnuradio-zeromq']
-    translations:
-      'True': 'true'
-      'False': 'false'
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_req_source.block.yml
+++ b/gr-zeromq/grc/zeromq_req_source.block.yml
@@ -64,8 +64,5 @@ cpp_templates:
         ${hwm},
         ${bind});
     link: ['gnuradio::gnuradio-zeromq']
-    translations:
-      'True': 'true'
-      'False': 'false'
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_sub_source.block.yml
+++ b/gr-zeromq/grc/zeromq_sub_source.block.yml
@@ -69,8 +69,5 @@ cpp_templates:
         ${key},
         ${bind});
     link: ['gnuradio::gnuradio-zeromq']
-    translations:
-      'True': 'true'
-      'False': 'false'
 
 file_format: 1


### PR DESCRIPTION
## Description
When generating C++ code, GRC did not have a standard way to translate Python strings to C++ strings, because Mako uses simple text substitution. To address this, additional translations are added to generators for blocks and parameters/variables with the first commit.

Translations already used in the block definitions were removed with the second commit:
- manual translations with `no_quotes` helper, like in [qtgui::waterfall_sink_x](https://github.com/gnuradio/gnuradio/blob/9b3183aec7b629fd7fbb2b1574f0bb1c87eb53ee/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml#L329);
- regex translations in `cpp_templates`, like in [audio::source](https://github.com/gnuradio/gnuradio/blob/9b3183aec7b629fd7fbb2b1574f0bb1c87eb53ee/gr-audio/grc/audio_source.block.yml#L48):
```
translations:
  "'": '"'
  True: true
  False: false
```

## Related Issue
Fixes #2519
Fixes #6551

## Which blocks/areas does this affect?
GRC
Block definition files in: gr-analog, gr-audio, gr-blocks, gr-digital, gr-fft, gr-filter, gr-network, gr-qtgui, gr-zeromq

## Testing Done
Generated C++ code from this flowgraph:
[cpp_string_bug_fixed.grc.txt](https://github.com/gnuradio/gnuradio/files/13464281/cpp_string_bug_fixed.grc.txt)

Issue fixed for simple and widely-used cases:
| Condition | GRC | Display | C++ Output |
|-|-|-|-|
| String parameter is empty | `value: ''` | | `""` |
| String parameter is set to empty single-quotes | `value: ''''''` | | `""` |
| String parameter is set to empty double-quotes | `value: '""'` | | `""` |
| String parameter with no quotes | `value: 127.0.0.1` | 127.0.0.1 | `"127.0.0.1"` |
| String parameter in single quotes | `value: '''127.0.0.1'''` | 127.0.0.1 | `"127.0.0.1"` |
| String parameter in double quotes | `value: '"127.0.0.1"'` | 127.0.0.1 | `"127.0.0.1"` |
| Multi-part string in double quotes | `value: '"127.0"".0.1"'` | 127.0.0.1 | `"127.0"".0.1"` |
| Escaped double quotes in quoted strings | `value: '''127.0.\"\"0.1'''` | 127.0"".0.1 | `"127.0\"\".0.1"` |

Problems arise for these cases, because substitution is regex-based:
| Condition | GRC | Display | C++ Output |
|-|-|-|-|
| Multi-part string in single quotes | `value: '''127.0.''''0.1'''` | 127.0.0.1 | `"127.0''.0.1"` |
| Escaped single quotes in quoted strings* | `value: '''127.0.\''\''0.1'''` | 127.0''.0.1 | `"127.0\"\".0.1"` |
| Raw string literals** | `value: R'127.0.0.1'` | 127.0.0.1 | `R"127.0.0.1"` |

\* Escaped single-quotes are translated with regex when used as values for block parameters. Variable/parameter blocks do not use the regex, so they produce the correct result: "127.0.\'\'0.1".

\** C++ raw string literals require delimiters (parenthesis, etc.), while Python raw string literals don't. This C++ output does not compile.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.