### PR TITLE
project: add tox.ini, so that editors use the same formatting as github CI (backport to maint-3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -29,7 +29,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: quentinguidee/pep8-action@v1
       with:
+        # -----------------------------------
+        # UPDATE tox.ini when making changes!
         arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605 --exclude *.yml.py'
+        # -----------------------------------
   # Doxygen gets built separately. It has a lot of output and its own weirdness.
   doxygen:
     name: Doxygen

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[pycodestyle]
+# -------------------------------------------------------------
+# UPDATE .github/workflows/make-test.yml's WHEN MAKING CHANGES!
+# -------------------------------------------------------------
+# from github workflow:
+# arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605 --exclude *.yml.py'
+max-line-length = 120
+extend-ignore = E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605


### PR DESCRIPTION
Backport #6963 