### PR TITLE
filter: Accept rounded output from fir_filter_fsf

### DIFF
--- a/gr-filter/python/filter/qa_fir_filter.py
+++ b/gr-filter/python/filter/qa_fir_filter.py
@@ -162,7 +162,7 @@ class test_filter(gr_unittest.TestCase):
         taps = 20 * [0.5, 0.5]
         src_data = 40 * [1, 2, 3, 4]
         expected_data = fir_filter(src_data, taps, decim)
-        expected_data = [int(e) for e in expected_data]
+        expected_data = [round(e) for e in expected_data]
 
         src = blocks.vector_source_f(src_data)
         op = filter.fir_filter_fsf(decim, taps)
@@ -170,14 +170,20 @@ class test_filter(gr_unittest.TestCase):
         self.tb.connect(src, op, dst)
         self.tb.run()
         result_data = dst.data()
-        self.assertComplexTuplesAlmostEqual(expected_data, result_data, 5)
+
+        # TODO: Remove fallback once GNU Radio's required VOLK_VERSION is >= 3.1.0
+        try:
+            self.assertEqual(expected_data, result_data)
+        except AssertionError:
+            expected_data_distorted = [int(e) for e in fir_filter(src_data, taps, decim)]
+            self.assertEqual(expected_data_distorted, result_data)
 
     def test_fir_filter_fsf_002(self):
         decim = 4
         taps = 20 * [0.5, 0.5]
         src_data = 40 * [1, 2, 3, 4]
         expected_data = fir_filter(src_data, taps, decim)
-        expected_data = [int(e) for e in expected_data]
+        expected_data = [round(e) for e in expected_data]
 
         src = blocks.vector_source_f(src_data)
         op = filter.fir_filter_fsf(decim, taps)
@@ -185,7 +191,13 @@ class test_filter(gr_unittest.TestCase):
         self.tb.connect(src, op, dst)
         self.tb.run()
         result_data = dst.data()
-        self.assertComplexTuplesAlmostEqual(expected_data, result_data, 5)
+
+        # TODO: Remove fallback once GNU Radio's required VOLK_VERSION is >= 3.1.0
+        try:
+            self.assertEqual(expected_data, result_data)
+        except AssertionError:
+            expected_data_distorted = [int(e) for e in fir_filter(src_data, taps, decim)]
+            self.assertEqual(expected_data_distorted, result_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
VOLK recently accepted https://github.com/gnuradio/volk/pull/709, which fixes truncate-toward-zero distortion in `volk_32f_x2_dot_prod_16i`. Unfortunately, this causes test failures:

```
======================================================================
FAIL: test_fir_filter_fsf_001 (__main__.test_filter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/argilo/prefix_311/src/gnuradio/gr-filter/python/filter/qa_fir_filter.py", line 173, in test_fir_filter_fsf_001
    self.assertComplexTuplesAlmostEqual(expected_data, result_data, 5)
  File "/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 73, in assertComplexTuplesAlmostEqual
    return all([
  File "/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 74, in <listcomp>
    self.assertComplexAlmostEqual(x, y, places, msg)
  File "/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 37, in assertComplexAlmostEqual
    raise self.failureException(
AssertionError: 1 != 2 within 5 places

======================================================================
FAIL: test_fir_filter_fsf_002 (__main__.test_filter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/argilo/prefix_311/src/gnuradio/gr-filter/python/filter/qa_fir_filter.py", line 188, in test_fir_filter_fsf_002
    self.assertComplexTuplesAlmostEqual(expected_data, result_data, 5)
  File "/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 73, in assertComplexTuplesAlmostEqual
    return all([
  File "/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 74, in <listcomp>
    self.assertComplexAlmostEqual(x, y, places, msg)
  File "/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 37, in assertComplexAlmostEqual
    raise self.failureException(
AssertionError: 5 != 6 within 5 places
```

This is because the tests in question assert the truncate-toward-zero behaviour in `fir_filter_fsf`. I would consider this behaviour buggy, and I would be surprised if there's any code that depends on `fir_filter_fsf` working this way. So I propose to change the tests to assert rounded output, with a temporary fallback to truncated output which can be removed once GNU Radio requires VOLK >= 3.1.0.

## Which blocks/areas does this affect?
* Decimating FIR Filter (Float->Short variant only)
* Interpolating FIR Filter (Float->Short variant only)

## Testing Done
I verified that the updated tests pass before & after the VOLK change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
