### PR TITLE
blocks: msq_pair_to_var QA: wait up to 1 s.

### DIFF
--- a/gr-blocks/python/blocks/qa_msg_pair_to_var.py
+++ b/gr-blocks/python/blocks/qa_msg_pair_to_var.py
@@ -13,12 +13,10 @@ from gnuradio import blocks
 from gnuradio import gr_unittest
 from gnuradio import gr
 import pmt
-import sys
 import time
 
 
 class test_msg_pair_to_var(gr_unittest.TestCase):
-
     def setUp(self):
         self.backend = gr.dictionary_logger_backend()
         gr.logging().add_default_sink(self.backend)
@@ -36,46 +34,72 @@ class test_msg_pair_to_var(gr_unittest.TestCase):
 
         dut = blocks.msg_pair_to_var(test_f)
         test_msg = pmt.cons(pmt.intern("foo"), pmt.from_uint64(canary))
-        src = blocks.message_strobe(test_msg, 10)
+        src = blocks.message_strobe(test_msg, 50)
         self.tb.msg_connect(*(src, pmt.intern("strobe")),
                             *(dut, blocks.msg_pair_to_var.IN_PORT))
+
+        start_time = time.monotonic_ns()
         self.tb.start()
-        time.sleep(15e-3)
+
+        # Sleep for at most a second
+        for counter in range(20):
+            time.sleep(50e-3)
+            if self.test_val == canary:
+                break
         self.tb.stop()
         self.tb.wait()
+        stopped_time = time.monotonic_ns()
+        timecount = round((stopped_time - start_time) * 1e-6)
 
-        self.assertEqual(self.test_val, canary,
-                         f"Test value {hex(self.test_val)} not found to be canary {hex(canary)}")
+        self.assertEqual(
+            self.test_val,
+            canary,
+            f"Test value {hex(self.test_val)} not found to be canary {hex(canary)} within {timecount} ms",
+        )
 
     def test_exceptions(self):
         lark = 0xDEAFBEEF
         nightingale = 0xDEAFB16D
-        self.test_val = 0
+        self.test_val = False
 
         def test_f(value: int = 0):
             if value == nightingale and value != lark:
+                self.test_val = True
                 raise Exception("It was the nightingale, and not the lark")
 
         dut = blocks.msg_pair_to_var(test_f)
         test_msg = pmt.cons(pmt.intern("birb"), pmt.from_uint64(nightingale))
-        src = blocks.message_strobe(test_msg, 10)
-        self.tb.msg_connect(*(src, pmt.intern("strobe")),
-                            *(dut, blocks.msg_pair_to_var.IN_PORT))
+        src = blocks.message_strobe(test_msg, 50)
+        self.tb.msg_connect(
+            *(src, pmt.intern("strobe")), *(dut, blocks.msg_pair_to_var.IN_PORT)
+        )
+
+        start_time = time.monotonic_ns()
         self.tb.start()
+
+        # Sleep for at most a second
+        for counter in range(19):
+            time.sleep(50e-3)
+            if self.test_val:
+                break
+        # some time for Exception bubbling, which should happen without yields
         time.sleep(50e-3)
         self.tb.stop()
         self.tb.wait()
+        stopped_time = time.monotonic_ns()
+        timecount = round((stopped_time - start_time) * 1e-6)
 
         logged = self.backend.get_map()
-        self.assertIn("msg_pair_to_var", logged, "should have logged; didn't.")
+        self.assertIn("msg_pair_to_var", logged, f"should have logged; didn't within {timecount} ms.")
         log_entries = logged["msg_pair_to_var"]
         for timestamp, entry in log_entries:
             self.assertRegex(
                 entry,
                 r"Error when calling <function .*\.test_exceptions\..*.test_f.*> with 3736056173" +
                 r".*reason: It was the nightingale, and not the lark.*",
-                f"Log entry '{entry}' from {timestamp} doesn't contain Shakespeare")
+                f"Log entry '{entry}' from {timestamp} doesn't contain Shakespeare",
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     gr_unittest.run(test_msg_pair_to_var)


### PR DESCRIPTION
Also, fix minor stylistic and include issues

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
`test_calling` was effectively only leaving 5 ms for thread wakeup, message delivery and python function calling; that was very flaky in high-load CI environments.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #6981

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

CI

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Will test in CI.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
