### PR TITLE
fec: add FEC_API to CCSDS Reed-Solomon functions

### DIFF
--- a/gr-fec/include/gnuradio/fec/rs.h
+++ b/gr-fec/include/gnuradio/fec/rs.h
@@ -1,8 +1,11 @@
-#include <gnuradio/fec/api.h>
 /* User include file for the Reed-Solomon codec
  * Copyright 2002, Phil Karn KA9Q
  * May be used under the terms of the GNU General Public License (GPL)
  */
+
+#ifndef INCLUDED_RS_H
+#define INCLUDED_RS_H
+#include <gnuradio/fec/api.h>
 
 /* General purpose RS codec, 8-bit symbols */
 FEC_API void encode_rs_char(void* rs, unsigned char* data, unsigned char* parity);
@@ -35,7 +38,4 @@ FEC_API int decode_rs_8(unsigned char* data, int* eras_pos, int no_eras);
 FEC_API void encode_rs_ccsds(unsigned char* data, unsigned char* parity);
 FEC_API int decode_rs_ccsds(unsigned char* data, int* eras_pos, int no_eras);
 
-/* Tables to map from conventional->dual (Taltab) and
- * dual->conventional (Tal1tab) bases
- */
-extern unsigned char Taltab[], Tal1tab[];
+#endif /* INCLUDED_RS_H */

--- a/gr-fec/lib/reed-solomon/ccsds.h
+++ b/gr-fec/lib/reed-solomon/ccsds.h
@@ -1,1 +1,4 @@
+/* Tables to map from conventional->dual (Taltab) and
+ * dual->conventional (Tal1tab) bases
+ */
 extern unsigned char Taltab[], Tal1tab[];

--- a/gr-fec/lib/reed-solomon/char.h
+++ b/gr-fec/lib/reed-solomon/char.h
@@ -6,7 +6,7 @@
 
 #define DTYPE unsigned char
 
-#include <gnuradio/fec/api.h>
+#include <gnuradio/fec/rs.h>
 
 /* Reed-Solomon codec control block */
 struct rs {
@@ -47,12 +47,3 @@ static inline unsigned int modnn(struct rs* rs, unsigned int x)
 #define DECODE_RS decode_rs_char
 #define INIT_RS init_rs_char
 #define FREE_RS free_rs_char
-
-FEC_API void ENCODE_RS(void* p, DTYPE* data, DTYPE* parity);
-FEC_API int DECODE_RS(void* p, DTYPE* data, int* eras_pos, int no_eras);
-FEC_API void* INIT_RS(unsigned int symsize,
-                      unsigned int gfpoly,
-                      unsigned int fcr,
-                      unsigned int prim,
-                      unsigned int nroots);
-FEC_API void FREE_RS(void* p);

--- a/gr-fec/lib/reed-solomon/decode_rs_ccsds.c
+++ b/gr-fec/lib/reed-solomon/decode_rs_ccsds.c
@@ -4,6 +4,7 @@
  * Copyright 2002, Phil Karn, KA9Q
  * May be used under the terms of the GNU General Public License (GPL)
  */
+#include <gnuradio/fec/rs.h>
 #define FIXED 1
 #include "ccsds.h"
 #include "fixed.h"

--- a/gr-fec/lib/reed-solomon/encode_rs_ccsds.c
+++ b/gr-fec/lib/reed-solomon/encode_rs_ccsds.c
@@ -5,6 +5,7 @@
  * May be used under the terms of the GNU General Public License (GPL)
  */
 #define FIXED
+#include <gnuradio/fec/rs.h>
 #include "ccsds.h"
 #include "fixed.h"
 

--- a/gr-fec/lib/reed-solomon/fixed.h
+++ b/gr-fec/lib/reed-solomon/fixed.h
@@ -7,7 +7,7 @@
  */
 #define DTYPE unsigned char
 
-#include <gnuradio/fec/api.h>
+#include <gnuradio/fec/rs.h>
 
 static inline int mod255(int x)
 {
@@ -36,6 +36,3 @@ extern unsigned char CCSDS_poly[];
 
 #define ENCODE_RS encode_rs_8
 #define DECODE_RS decode_rs_8
-
-FEC_API void ENCODE_RS(DTYPE* data, DTYPE* parity);
-FEC_API int DECODE_RS(DTYPE* data, int* eras_pos, int no_eras);


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

This solves #4454. The `(en|de)code_rs_(char|8)` functions are marked as FEC_API so that they can be used by OOT modules. The `(en|de)code_rs_ccsds` functions should also be marked as FEC_API.
    
This is related to #3821. When building with MSVC, the compiler gives an error if FEC_API is attached to a function definition. It should be attached to function declarations only.
 
I have done some clean up to mark all this functions as FEC_API consistently. They are declared with FEC_API in   `include/gnuradio/fec/rs.h`, but the implementation was not including this file, so I have included it now in all the relevant places. This allows to remove some redundant declarations from char.h and fixed.h.

I have also added include guards in include/gnuradio/fec/rs.h. The .h files in reed-solomon/ don't have include guards, but they are only included in .c files in that folder (to do some sort of template instantiation in C using the preprocessor).

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

#4454.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Symbols exported by libgnuradio-fec.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

No testing. Hopefully CI will catch problems in any of the platforms.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- ~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~
- ~I have added tests to cover my changes, and all previous tests pass.~
