### PR TITLE
GRC: allow variable expressions for enum fields

### DIFF
--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -126,3 +126,9 @@ def validate_gui_hint(param, _) -> None:
         param.parse_gui_hint(param.value)
     except Exception as e:
         raise ValidateError(str(e))
+
+
+@validates('enum')
+def validate_enum(param, _):
+    if param.get_evaluated() not in param.options:
+        raise ValidateError(f'Value {param.get_evaluated()} is not in enum options: {param.options}')

--- a/grc/gui/canvas/param.py
+++ b/grc/gui/canvas/param.py
@@ -34,17 +34,17 @@ class Param(CoreParam):
         elif dtype == 'dir_select':
             input_widget_cls = ParamWidgets.DirectoryParam
 
-        elif dtype == 'enum':
-            input_widget_cls = ParamWidgets.EnumParam
-
-        elif self.options:
-            input_widget_cls = ParamWidgets.EnumEntryParam
-
         elif dtype == '_multiline':
             input_widget_cls = ParamWidgets.MultiLineEntryParam
 
         elif dtype == '_multiline_python_external':
             input_widget_cls = ParamWidgets.PythonEditorParam
+
+        # elif dtype == '_enum_static':
+        #     input_widget_cls = ParamWidgets.EnumParam
+
+        elif self.options:
+            input_widget_cls = ParamWidgets.EnumEntryParam
 
         else:
             input_widget_cls = ParamWidgets.EntryParam
@@ -145,6 +145,8 @@ class Param(CoreParam):
         elif t in ('file_open', 'file_save'):
             dt_str = self.get_value()
             truncate = -1
+        elif t == 'enum':
+            dt_str = self.options[e]
         else:
             # Other types
             dt_str = str(e)


### PR DESCRIPTION
## Description
Block properties with `dtype: enum` can now be controlled dynamically by variables or expressions. The evaluated expression is then checked against the enum's `options`.

## Related Issue
Fixes #6870

## Which blocks/areas does this affect?
GRC

## Testing Done
[dvb_enums.grc](https://github.com/gnuradio/gnuradio/files/13562854/dvb_enums.grc.txt).txt

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.