### PR TITLE
gr_modtool: fix non-C++ block detection and manipulation

### DIFF
--- a/gr-utils/modtool/cli/bind.py
+++ b/gr-utils/modtool/cli/bind.py
@@ -52,7 +52,7 @@ def cli(**kwargs):
 def get_pattern(self):
     """ Get the regex pattern for block(s) to be parsed """
     if self.info['pattern'] is None:
-        block_candidates = get_block_candidates()
+        block_candidates = get_block_candidates(self.info['modname'], skip_grc=True, skip_python=True)
         with SequenceCompleter(block_candidates):
             self.info['pattern'] = cli_input(
                 'Which blocks do you want to parse? (Regex): ')

--- a/gr-utils/modtool/cli/disable.py
+++ b/gr-utils/modtool/cli/disable.py
@@ -32,7 +32,7 @@ def cli(**kwargs):
 def get_pattern(self):
     """ Get the regex pattern for block(s) to be disabled """
     if self.info['pattern'] is None:
-        block_candidates = get_block_candidates()
+        block_candidates = get_block_candidates(self.info['modname'])
         with SequenceCompleter(block_candidates):
             self.info['pattern'] = cli_input(
                 'Which blocks do you want to disable? (Regex): ')

--- a/gr-utils/modtool/cli/makeyaml.py
+++ b/gr-utils/modtool/cli/makeyaml.py
@@ -65,7 +65,8 @@ def cli(**kwargs):
 def get_pattern(self):
     """ Get the regex pattern for block(s) to be parsed """
     if self.info['pattern'] is None:
-        block_candidates = get_block_candidates()
+        block_candidates = get_block_candidates(self.info['modname'], skip_include=True,
+                                                skip_python=True, skip_grc=True)
         with SequenceCompleter(block_candidates):
             self.info['pattern'] = cli_input(
                 'Which blocks do you want to parse? (Regex): ')

--- a/gr-utils/modtool/cli/rename.py
+++ b/gr-utils/modtool/cli/rename.py
@@ -49,7 +49,7 @@ def cli(**kwargs):
 
 def get_oldname(self):
     """ Get the old block name to be replaced """
-    block_candidates = get_block_candidates()
+    block_candidates = get_block_candidates(self.info['modname'])
     if self.info['oldname'] is None:
         with SequenceCompleter(block_candidates):
             while not self.info['oldname'] or self.info['oldname'].isspace():

--- a/gr-utils/modtool/cli/rm.py
+++ b/gr-utils/modtool/cli/rm.py
@@ -32,7 +32,7 @@ def cli(**kwargs):
 def get_pattern(self):
     """ Returns the regex pattern for block(s) to be removed """
     if self.info['pattern'] is None:
-        block_candidates = get_block_candidates()
+        block_candidates = get_block_candidates(self.info['modname'])
         with SequenceCompleter(block_candidates):
             self.info['pattern'] = cli_input(
                 'Which blocks do you want to delete? (Regex): ')

--- a/gr-utils/modtool/core/base.py
+++ b/gr-utils/modtool/core/base.py
@@ -22,22 +22,35 @@ from ..tools import get_modname, SCMRepoFactory
 logger = logging.getLogger('gnuradio.modtool')
 
 
-def get_block_candidates(modname: str = None):
+def get_block_candidates(modname: str = None,
+                         skip_lib: bool = False, skip_include: bool = False,
+                         skip_python: bool = False, skip_grc: bool = False):
     """ Returns a list of all possible blocknames """
-    cpp_filters = ["*.cc", "*.cpp"]
-    cpp_blocks = []
-    for ftr in cpp_filters:
-        cpp_blocks.append(os.path.splitext(x)[0].split("_impl")[0]
-                          for x in glob.glob1("lib", ftr)
-                          if not (x.startswith("qa_") or x.startswith("test_")))
-    python_glob = (glob.glob("python/*/*.py") if modname is None
-                   else glob.glob1(f"python/{modname}", "*.py"))
-    python_blocks = (os.path.splitext(os.path.split(x)[-1])[0]
-                     for x in python_glob
-                     if not (x.startswith("qa_") or
-                             x.startswith("build") or
-                             x == "__init__.py"))
-    return set(itertools.chain(*cpp_blocks, python_blocks))
+    block_candidates = []
+    if not skip_lib:
+        cpp_filters = ["*.cc", "*.cpp"]
+        for ftr in cpp_filters:
+            block_candidates.append(os.path.splitext(x)[0].split("_impl")[0]
+                                    for x in glob.glob1("lib", ftr)
+                                    if not (x.startswith("qa_") or x.startswith("test_")))
+    if not skip_include:
+        cpp_header_glob = (glob.glob("include/gnuradio/*/*.h") if modname is None
+                           else glob.glob1(f"include/gnuradio/{modname}", "*.h"))
+        block_candidates.append(os.path.splitext(os.path.split(x)[-1])[0]
+                                for x in cpp_header_glob
+                                if x != "api.h")
+    if not skip_python:
+        python_glob = (glob.glob("python/*/*.py") if modname is None
+                       else glob.glob1(f"python/{modname}", "*.py"))
+        block_candidates.append(os.path.splitext(os.path.split(x)[-1])[0]
+                                for x in python_glob
+                                if not (x.startswith("qa_") or
+                                        x.startswith("build") or
+                                        x == "__init__.py"))
+    if not (skip_grc or modname is None):
+        block_candidates.append(x.split(".block.yml")[0].split(f"{modname}_")[-1]
+                                for x in glob.glob1("grc", "*.block.yml"))
+    return set(itertools.chain(*block_candidates))
 
 
 class ModToolException(Exception):

--- a/gr-utils/modtool/core/rename.py
+++ b/gr-utils/modtool/core/rename.py
@@ -34,7 +34,7 @@ class ModToolRename(ModTool):
         if not self.info['oldname']:
             raise ModToolException('Old block name (blockname) not specified.')
         validate_name('old block', self.info['oldname'])
-        block_candidates = get_block_candidates()
+        block_candidates = get_block_candidates(self.info['modname'])
         if self.info['oldname'] not in block_candidates:
             choices = [x for x in block_candidates if self.info['oldname'] in x]
             if len(choices) > 0:

--- a/gr-utils/modtool/core/rename.py
+++ b/gr-utils/modtool/core/rename.py
@@ -131,6 +131,9 @@ class ModToolRename(ModTool):
         hasher = hashlib.md5()
         # note this requires _run_pybind to be called after _run_include
         header_filename = os.path.join(self.info['includedir'], new + '.h')
+        if not os.path.isfile(header_filename):
+            logger.info("Not a C++ block, nothing to do here...")
+            return
         with open(header_filename, 'rb') as file_in:
             buf = file_in.read()
             hasher.update(buf)


### PR DESCRIPTION
## Description
[`get_block_candidates`](https://github.com/gnuradio/gnuradio/blob/6404f371abb97f282aa1aa270837ffa9f0ddce84/gr-utils/modtool/core/base.py#L25-L39) function is used in `gr_modtool` to detect blocks in the OOT module. However, the current implementation only detects C++ blocks, because the pattern for Python files does not check the directory recursively.

Also, the `rename` subcommand does not check for non-C++ blocks and throws an exception if there are no C++ implementation files for the selected block.

This PR presents the following fixes:
- [x] 1. Change the glob for Python block detection (`python/*.py` -> `python/*/*.py`).
- [x] 2. Add the ability to detect GRC-only (`grc/*.block.yml`) and header-only (`include/gnuradio/*/*.h`) "blocks".
- [x] 3. Add checks for the absence of C++ files in `rename` subcommand.

## Related Issue
Fixes #7008

## Which blocks/areas does this affect?
gr_modtool

## Testing Done

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
