### PR TITLE
grc: Make core.Connection.type not lazy

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -88,7 +88,7 @@ class Connection(Element):
     def sink_block(self):
         return self.sink_port.parent_block
 
-    @lazy_property
+    @property
     def type(self):
         return self.source_port.domain, self.sink_port.domain
 

--- a/grc/core/utils/descriptors/_lazy.py
+++ b/grc/core/utils/descriptors/_lazy.py
@@ -3,11 +3,40 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
+"""
+Class method decorators.
+"""
 
 import functools
 
+# pylint: disable=too-few-public-methods,invalid-name
 
-class lazy_property(object):
+
+class lazy_property:
+    """
+    Class method decorator, similar to @property. This causes a method that is
+    declared as @lazy_property to be evaluated once, the first time it is called.
+    Subsequent calls to this property will always return the cached value.
+
+    Careful! Not suitable for properties that change at runtime.
+
+    Example:
+
+    >>> class Foo:
+    ...     def __init__(self):
+    ...         self.x = 5
+    ...
+    ...     @lazy_property
+    ...     def xyz(self):
+    ...         return complicated_slow_function(self.x)
+    ...
+    ...
+    >>> f = Foo()
+    >>> print(f.xyz) # Will give the result, but takes long to compute
+    >>> print(f.xyz) # Blazing fast!
+    >>> f.x = 7 # Careful! f.xyz will not be updated any more!
+    >>> print(f.xyz) # Blazing fast, but returns the same value as before.
+    """
 
     def __init__(self, func):
         self.func = func
@@ -19,10 +48,15 @@ class lazy_property(object):
         value = self.func(instance)
         setattr(instance, self.func.__name__, value)
         return value
+# pylint: enable=too-few-public-methods,invalid-name
 
 
 def nop_write(prop):
-    """Make this a property with a nop setter"""
+    """
+    Make this a property with a nop setter
+
+    Effectively, makes a property read-only, with no error on write.
+    """
 
     def nop(self, value):
         pass


### PR DESCRIPTION
This fixes an issue where virtual blocks can not correctly update their type when connected to message sources/sinks.

Well, it fixes the example in #7013.

Aah, this reminds me of the good old SWIG days, where I would modify .i files without knowing what I'm doing. This is what this feels like, except this time, thought I was pretty decent at Python.

@haakov @sdh11 @skoslowski  if you wouldn't mind taking a look at this. What did I do here? Is this really a fix?

Update: OK, I see now what's going on. Well, mostly. `lazy_property` sets a value once, the first time it's read. Something in the edge-prop PR causes the `domain` attribute of a port to get set before everything is resolved, which is latched into the 'lazy property'.

I don't think `lazy_property` is necessary here, it seems a bit like a premature optimization.

## Related Issue

Fixes #7013.
Well, maybe. 

## Which blocks/areas does this affect?

See #7013.


## Testing Done

Well, I tried running the example from the bug report, and it works now.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
