### PR TITLE
dtv: Read expected data as little-endian

### DIFF
--- a/gr-dtv/python/dtv/qa_dtv.py
+++ b/gr-dtv/python/dtv/qa_dtv.py
@@ -166,7 +166,7 @@ class test_dtv(gr_unittest.TestCase):
         self.assertEqual(getsize(self.outfile), getsize(testfile))
 
         out_data = np.fromfile(self.outfile, dtype=np.float32)
-        expected_data = np.fromfile(testfile, dtype=np.float32)
+        expected_data = np.fromfile(testfile, dtype=np.dtype("<f"))
 
         self.assertFloatTuplesAlmostEqual(out_data, expected_data, 5)
 


### PR DESCRIPTION
## Description
The `qa_dtv` test compares the output of a DTV flowgraph with expected data stored in `vv009-4kfft.cfile`. The data in that file is little-endian, but it is loaded using the machine's endianness. This results in test failures on big-endian architectures. To fix this, I've changed the code to load this file as little-endian.

## Related Issue
Fixes #7015.

## Which blocks/areas does this affect?
QA test for gr-dtv.

## Testing Done
I ran the updated test on x86_64 and s390x, and it now passes on both architectures.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
