### PR TITLE
network: Add timeout to prevent qa_tcp_sink from hanging

### DIFF
--- a/gr-network/python/network/qa_tcp_sink.py
+++ b/gr-network/python/network/qa_tcp_sink.py
@@ -31,6 +31,7 @@ class qa_tcp_sink (gr_unittest.TestCase):
 
     def test_restart(self):
         serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        serversocket.settimeout(30.0)
         serversocket.bind(('localhost', 2000))
         serversocket.listen()
 


### PR DESCRIPTION
## Description
On the sparc64 architecture, GNU Radio's circular buffers seem to be completely broken. (I'll open an issue for this, and have a look later to see if I can track down the root cause.) This causes most tests to fail. But `qa_tcp_sink` hangs, forcing the Debian build server to wait for 10 hours:

```
        Start 261: qa_tcp_sink
E: Build killed with signal TERM after 600 minutes of inactivity
```

## Which blocks/areas does this affect?
QA test for TCP Sink.

## Testing Done
I verified that the test still passes, and that it exits after 30 seconds if I comment out the final `self.tb.start()` and `self.tb.stop()` lines to induce a hang.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
