### PR TITLE
fec: Round before converting frame lengths to int

### DIFF
--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -15,6 +15,7 @@
 #include "async_decoder_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
+#include <cmath>
 #include <cstdio>
 
 namespace gr {
@@ -54,7 +55,7 @@ async_decoder_impl::async_decoder_impl(generic_decoder::sptr my_decoder,
     set_msg_handler(d_in_port, [this](const pmt::pmt_t& msg) { this->decode(msg); });
 
     // The maximum frame size is set by the initial frame size of the decoder.
-    d_max_bits_in = d_mtu * 8 * 1.0 / d_decoder->rate();
+    d_max_bits_in = std::lround(d_mtu * 8 * 1.0 / d_decoder->rate());
     d_tmp_f32.resize(d_max_bits_in);
 
     if (strncmp(d_decoder->get_input_conversion(), "uchar", 5) == 0) {
@@ -97,14 +98,14 @@ void async_decoder_impl::decode(const pmt::pmt_t& msg)
     // Watch out for this diff. It might be over-specializing to the
     // CC decoder in terminated mode that has an extra rate(K-1)
     // bits added on to the transmitted frame.
-    int diff =
-        d_decoder->rate() * d_decoder->get_input_size() - d_decoder->get_output_size();
+    int diff = std::lround(d_decoder->rate() * d_decoder->get_input_size()) -
+               d_decoder->get_output_size();
 
     size_t nbits_in = pmt::length(bits);
     size_t nbits_out = 0;
     size_t nblocks = 1;
     bool variable_frame_size =
-        d_decoder->set_frame_size(nbits_in * d_decoder->rate() - diff);
+        d_decoder->set_frame_size(std::lround(nbits_in * d_decoder->rate()) - diff);
 
     // Check here if the frame size is larger than what we've
     // allocated for in the constructor.
@@ -115,7 +116,7 @@ void async_decoder_impl::decode(const pmt::pmt_t& msg)
 
     // set up nbits_out
     if (variable_frame_size) {
-        nbits_out = nbits_in * d_decoder->rate() - diff;
+        nbits_out = std::lround(nbits_in * d_decoder->rate()) - diff;
     } else {
         nblocks = nbits_in / d_decoder->get_input_size();
         nbits_out = nblocks * d_decoder->get_output_size();

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/logger.h>
 #include <volk/volk.h>
+#include <cmath>
 
 namespace gr {
 namespace fec {
@@ -55,7 +56,7 @@ async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
     if (d_packed) {
         set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->encode_packed(msg); });
 
-        int max_bits_out = d_encoder->rate() * d_mtu * 8;
+        int max_bits_out = std::lround(d_encoder->rate() * d_mtu * 8);
         d_bits_out.resize(max_bits_out);
     } else {
         set_msg_handler(d_in_port,

--- a/gr-fec/lib/tagged_decoder_impl.cc
+++ b/gr-fec/lib/tagged_decoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "tagged_decoder_impl.h"
 #include <gnuradio/io_signature.h>
+#include <cmath>
 #include <cstdio>
 
 namespace gr {
@@ -48,12 +49,12 @@ tagged_decoder_impl::tagged_decoder_impl(generic_decoder::sptr my_decoder,
 
 int tagged_decoder_impl::calculate_output_stream_length(const gr_vector_int& ninput_items)
 {
-    if ((ninput_items[0] * d_decoder->rate()) > (d_mtu * 8)) {
+    if (std::lround(ninput_items[0] * d_decoder->rate()) > (d_mtu * 8)) {
         throw std::runtime_error("tagged_encoder: received frame is larger than MTU.");
     }
-    int diff =
-        d_decoder->rate() * d_decoder->get_input_size() - d_decoder->get_output_size();
-    d_decoder->set_frame_size(round(ninput_items[0] * d_decoder->rate()) - diff);
+    int diff = std::lround(d_decoder->rate() * d_decoder->get_input_size()) -
+               d_decoder->get_output_size();
+    d_decoder->set_frame_size(std::lround(ninput_items[0] * d_decoder->rate()) - diff);
     return d_decoder->get_output_size();
 }
 


### PR DESCRIPTION
## Description
The `test_async_00` test in `qa_fecapi_repetition.py` consistently fails on Debian i386. The root cause is that the FEC Async Decoder block calculates the output frame length using floating-point arithmetic, then converts the result to an integer without rounding. Floating-point error causes the result to be slightly less than 240, which is truncated to 239, shaving one bit/byte off the end of each frame. Adding `std::lround` fixes the problem.

The FEC Async Encoder and FEC Tagged Decoder blocks have similar errors, so I've fixed those as well.

## Related Issue
Fixes #7022.

## Which blocks/areas does this affect?
* FEC Async Decoder
* FEC Async Encoder
* FEC Tagged Decoder

## Testing Done
I ran the test suite to verify that the tests pass reliably on both x86_64 and i386.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
