### PR TITLE
runtime: config.in used undefined log level

### DIFF
--- a/gnuradio-runtime/gnuradio-runtime.conf.in
+++ b/gnuradio-runtime/gnuradio-runtime.conf.in
@@ -16,7 +16,7 @@ max_messages = 8192
 # levels, in ascending order of severity:
 # trace, debug, info, warning, error, critical, off
 log_level = info
-debug_level = critical
+debug_level = crit
 
 # These file names can either be 'stdout' to output to standard output
 # or 'stderr' to output to standard error. Any other string will


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

As noticed by @argilo in #6673, this was a mistake. We shouldn't be using a log level string not defined in logger.cc.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

logging!


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
