### PR TITLE
analog: Fix buffer overruns in AGC3

### DIFF
--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/io_signature.h>
 #include <spdlog/fmt/fmt.h>
 #include <volk/volk.h>
-#include <volk/volk_alloc.hh>
 #include <algorithm>
 #include <cmath>
 #include <numeric>

--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -56,8 +56,6 @@ agc3_cc_impl::agc3_cc_impl(float attack_rate,
     test_and_log_value_domain(iir_update_decim, "input power sampling stride");
     d_iir_update_decim = iir_update_decim;
     set_output_multiple(iir_update_decim * 4);
-    const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
-    set_alignment(std::max(1, alignment_multiple));
 }
 
 agc3_cc_impl::~agc3_cc_impl() {}


### PR DESCRIPTION
## Description
While experimenting with using `host_buffer` as a fallback for `buffer_double_mapped`, I noticed that `qa_agc` fails because `agc3_cc` overruns its input and output buffers: https://github.com/gnuradio/gnuradio/issues/7021#issuecomment-1871212351. This happens because its work function expects `noutput_items` to be a multiple of `iir_update_decim`, but its call to `set_output_multiple` is immediately overwritten by a call to `set_alignment`, which overwrites the output multiple with `volk_get_alignment() / sizeof(gr_complex)` (which could be 1, 2, 4, or 8, depending on the machine type). If `iir_update_decim` does not divide this number, then buffer overruns occur because the `work` function processes `ceil(noutput_items / iir_update_decim) * iir_update_decim` items.

## Which blocks/areas does this affect?
* AGC3

## Testing Done
I ran `qa_agc` inside valgrind, with `#define FORCE_SINGLE_MAPPED` uncommented in io_signature.h, and verified that no overruns occur. I also added debug logging and verified that the scheduler sets `noutput_items` to a multiple of `4 * iir_update_decim`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
