### PR TITLE
fec: Fix input buffer overrun in polar encoder

### DIFF
--- a/gr-fec/lib/polar_encoder.cc
+++ b/gr-fec/lib/polar_encoder.cc
@@ -132,17 +132,17 @@ void polar_encoder::insert_packed_frozen_bits_and_reverse(
         std::begin(d_frozen_bit_prototype), std::end(d_frozen_bit_prototype), target);
     const int* info_bit_reversed_positions_ptr = &d_info_bit_positions_reversed[0];
     int bit_num = 0;
-    unsigned char byte = *input;
+    unsigned char byte;
     int bit_pos;
     while (bit_num < num_info_bits()) {
+        if (bit_num % 8 == 0) {
+            byte = *input;
+            ++input;
+        }
         bit_pos = *info_bit_reversed_positions_ptr++;
         insert_packet_bit_into_packed_array_at_position(
             target, byte, bit_pos, bit_num % 8);
         ++bit_num;
-        if (bit_num % 8 == 0) {
-            ++input;
-            byte = *input;
-        }
     }
 }
 


### PR DESCRIPTION
## Description
I made some experimental changes to the block executor to detect buffer overruns, and found that the polar encoder overruns its input buffer by one byte when running in packed mode. The `insert_packed_frozen_bits_and_reverse` method increments the bit number at the end of each loop iteration, then reads the next byte if the bit number is a multiple of 8. This occurs on the last iteration of the loop, causing an extra byte to be read that will never be used.

To solve the problem, I moved byte loading up to the start of the loop, so that a byte is only loaded if one of its bits will actually be used.

## Which blocks/areas does this affect?
* POLAR Encoder

## Testing Done
I verified that the polar encoder tests still pass, and that my modified block executor no longer triggers a buffer overrun.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
