### PR TITLE
blocks: Write debug samples at the correct time in Peak Detector2

### DIFF
--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -84,8 +84,6 @@ int peak_detector2_fb_impl::work(int noutput_items,
     if (d_found == false) {
         for (int i = 0; i < noutput_items; i++) {
             d_avg = d_alpha * iptr[i] + (1.0f - d_alpha) * d_avg;
-            if (output_items.size() == 2)
-                sigout[i] = d_avg;
             if (iptr[i] > d_avg * (1.0f + d_threshold_factor_rise)) {
                 d_found = true;
                 set_output_multiple(d_look_ahead);
@@ -100,6 +98,8 @@ int peak_detector2_fb_impl::work(int noutput_items,
                  */
                 return i;
             }
+            if (output_items.size() == 2)
+                sigout[i] = d_avg;
         }
         return noutput_items;
     } // end d_found==false
@@ -108,6 +108,8 @@ int peak_detector2_fb_impl::work(int noutput_items,
     else if (noutput_items >= d_look_ahead) {
         float peak_val = iptr[0];
         int peak_ind = 0;
+        if (output_items.size() == 2)
+            sigout[0] = d_avg;
         /*
          * Loop starts at the second sample because the first one has already been
          * filtered (see above). Result of the maximum search is correct due


### PR DESCRIPTION
## Description
I made some experimental changes to the block executor to detect buffer overruns, and found that Peak Detector2 sometimes produces an extra sample on its "debug" output port without reporting it to the scheduler.

Peak Detector2 has an optional debug output which can be used to view the internal estimated mean (`d_avg`). When a peak is detected at sample `i` in the main loop, the `work` function exits early and reports to the scheduler that it has produced `i` samples (i.e. `optr[0]` through `optr[i-1]` and `sigout[0]` through `sigout[i-1]`). However, it writes all the way up to `sigout[i]` on the debug output, producing a total of `i+1` samples.

When the scheduler then invokes the `work` function a second time and the `d_found == true` loop is executed, the block skips writing `sigout[0]` since that sample was written on the previous invocation.

Producing a sample without reporting it to the scheduler seems like a bad idea. Blocks that produce different numbers of items on each output are supposed to invoke `produce()` and return `WORK_CALLED_PRODUCE`. In Peak Detector2 we can avoid needing to do that by delaying production of the extra debug sample until the `d_found == true` case occurs.

## Which blocks/areas does this affect?
* Peak Detector2

## Testing Done
I verified that the corresponding test still passes, and no longer triggers an error with the strict block executor.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
