### PR TITLE
digital: Fix early return logic in Polyphase Clock Sync

### DIFF
--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.h
@@ -44,7 +44,6 @@ private:
     int d_filtnum;
     int d_osps;
     float d_error;
-    int d_out_idx;
 
     uint64_t d_old_in, d_new_in, d_last_out;
 

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -50,8 +50,7 @@ pfb_clock_sync_fff_impl::pfb_clock_sync_fff_impl(double sps,
       d_nfilters(filter_size),
       d_max_dev(max_rate_deviation),
       d_osps(osps),
-      d_error(0),
-      d_out_idx(0)
+      d_error(0)
 {
     if (taps.empty())
         throw std::runtime_error("pfb_clock_sync_fff: please specify a filter.");
@@ -344,7 +343,7 @@ int pfb_clock_sync_fff_impl::general_work(int noutput_items,
 
     // produce output as long as we can and there are enough input samples
     while (i < noutput_items) {
-        while (d_out_idx < d_osps) {
+        for (int out_idx = 0; out_idx < d_osps; out_idx++) {
             d_filtnum = (int)floor(d_k);
 
             // Keep the current filter number in [0, d_nfilters]
@@ -361,26 +360,15 @@ int pfb_clock_sync_fff_impl::general_work(int noutput_items,
                 count -= 1;
             }
 
-            out[i + d_out_idx] = d_filters[d_filtnum].filter(&in[count + d_out_idx]);
+            out[i + out_idx] = d_filters[d_filtnum].filter(&in[count + out_idx]);
             d_k = d_k + d_rate_i + d_rate_f; // update phase
-            d_out_idx++;
 
             if (output_items.size() == 4) {
                 err[i] = d_error;
                 outrate[i] = d_rate_f;
                 outk[i] = d_k;
             }
-
-            // We've run out of output items we can create; return now.
-            if (i + d_out_idx >= noutput_items) {
-                consume_each(count);
-                return i;
-            }
         }
-
-        // reset here; if we didn't complete a full osps samples last time,
-        // the early return would take care of it.
-        d_out_idx = 0;
 
         // Update the phase and rate estimates for this symbol
         float diff = d_diff_filters[d_filtnum].filter(&in[count]);

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.h
@@ -44,7 +44,6 @@ private:
     int d_filtnum;
     int d_osps;
     float d_error;
-    int d_out_idx;
 
     void create_diff_taps(const std::vector<float>& newtaps,
                           std::vector<float>& difftaps);


### PR DESCRIPTION
## Description
I made some experimental changes to the block executor to detect buffer overruns, and found that Polyphase Clock Sync reads uninitialized memory. It also fails to process some input samples.

The Polyphase Clock Sync has an "Output SPS" (`d_osps`) property, which defaults to 1. Its main work loop produces `d_osps` output samples at a time, and it has some special logic to handle the situation where `noutput_items` is not a multiple of `d_osps`, in which case it would split the group of `d_osps` output samples across two `general_work` invocations. This logic is not needed, because the block calls `set_output_multiple`, which guarantees that `noutput_items` will always be a multiple of `d_osps`.

Unfortunately, this logic has an off-by-one error, which causes it to execute on every invocation of `general_work`. This causes the main work loop to exit one iteration early and with `d_out_idx` set to `d_osps`, which causes an output sample to be skipped at the beginning of the following `general_work` invocation. This severely degrades performance at the beginning of each group of samples processed.

By placing a Throttle block just ahead of a Polyphase Clock Sync block and setting its limit to "Max Items: 1", it can be seen that clock synchronization completely fails.

## Related Issue
I suspect that #5948 is due to this bug in Polyphase Clock Sync. The `qa_constellation_receiver` tests use `generic_demod`, which includes a Polyphase Clock Sync block.

## Which blocks/areas does this affect?
* Polyphase Clock Sync

## Testing Done
I used the following flow graph for testing. The lower the Throttle block's "Max Items" parameter, the more distortion becomes apparent in the received QPSK constellation:
![pfb_sync_fg](https://github.com/gnuradio/gnuradio/assets/583749/a7f6733a-37eb-4ff8-a2a0-aba21ec7cd0f)

Before:
![pfb_sync_before](https://github.com/gnuradio/gnuradio/assets/583749/c109f14b-188f-4086-bea2-04c42888e06e)

After:
![pfb_sync_after](https://github.com/gnuradio/gnuradio/assets/583749/1b8a2ba9-78b9-4327-8c52-e935958d98a0)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
