### PR TITLE
pmt: Check length before calling memcmp

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -886,7 +886,7 @@ bool equal(const pmt_t& x, const pmt_t& y)
         size_t len_x, len_y;
         const void* x_m = xv->uniform_elements(len_x);
         const void* y_m = yv->uniform_elements(len_y);
-        if (memcmp(x_m, y_m, len_x) == 0)
+        if ((len_x == 0) || (memcmp(x_m, y_m, len_x) == 0))
             return true;
 
         return false;


### PR DESCRIPTION
## Description
If GNU Radio is built with GCC's Undefined Behaviour Sanitizer, then the following error appears when running qa_pdu_split:

```
/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/lib/pmt/pmt.cc:889:19: runtime error: null pointer passed as argument 1, which is declared to never be null
/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/lib/pmt/pmt.cc:889:19: runtime error: null pointer passed as argument 2, which is declared to never be null
```

The line that triggers this is the following:

https://github.com/gnuradio/gnuradio/blob/86af478a88cf0521b023ad2c924c74ea38d9adcf/gr-pdu/python/pdu/qa_pdu_split.py#L96

We can avoid Undefined Behaviour by short-circuiting the `memcmp` if `len_x` is zero.

## Which blocks/areas does this affect?
`pmt::equal`

## Testing Done
I verified that the test passes without UBSAN warnings after the change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~`
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
