### PR TITLE
runtime: Fix signed integer overflow in fixed-point NCO and VCO

### DIFF
--- a/gnuradio-runtime/include/gnuradio/fxpt_nco.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt_nco.h
@@ -49,14 +49,14 @@ public:
     // angle_rate is a delta in radians / step
     void adjust_freq(float delta_angle_rate)
     {
-        d_phase_inc += gr::fxpt::float_to_fixed(delta_angle_rate);
+        d_phase_inc += (uint32_t)gr::fxpt::float_to_fixed(delta_angle_rate);
     }
 
     // increment current phase angle
 
     void step() { d_phase += d_phase_inc; }
 
-    void step(int n) { d_phase += d_phase_inc * n; }
+    void step(int n) { d_phase += (uint32_t)d_phase_inc * n; }
 
     // units are radians / step
     float get_phase() const { return gr::fxpt::fixed_to_float(d_phase); }

--- a/gnuradio-runtime/include/gnuradio/fxpt_vco.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt_vco.h
@@ -33,7 +33,10 @@ public:
     // radians
     void set_phase(float angle) { d_phase = fxpt::float_to_fixed(angle); }
 
-    void adjust_phase(float delta_phase) { d_phase += fxpt::float_to_fixed(delta_phase); }
+    void adjust_phase(float delta_phase)
+    {
+        d_phase += (uint32_t)fxpt::float_to_fixed(delta_phase);
+    }
 
     float get_phase() const { return fxpt::fixed_to_float(d_phase); }
 

--- a/gnuradio-runtime/lib/math/qa_fxpt_nco.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt_nco.cc
@@ -37,6 +37,21 @@ BOOST_AUTO_TEST_CASE(t0)
     ref_nco.set_freq((float)(2 * GR_M_PI / SIN_COS_FREQ));
     new_nco.set_freq((float)(2 * GR_M_PI / SIN_COS_FREQ));
 
+    ref_nco.adjust_freq((float)(GR_M_PI / 2));
+    new_nco.adjust_freq((float)(GR_M_PI / 2));
+
+    ref_nco.adjust_freq((float)(GR_M_PI / 2));
+    new_nco.adjust_freq((float)(GR_M_PI / 2));
+
+    ref_nco.adjust_freq((float)(-GR_M_PI / 2));
+    new_nco.adjust_freq((float)(-GR_M_PI / 2));
+
+    ref_nco.adjust_freq((float)(-GR_M_PI / 2));
+    new_nco.adjust_freq((float)(-GR_M_PI / 2));
+
+    ref_nco.step(10000);
+    new_nco.step(10000);
+
     BOOST_CHECK(std::abs(ref_nco.get_freq() - new_nco.get_freq()) <= SIN_COS_TOLERANCE);
 
     for (int i = 0; i < SIN_COS_BLOCK_SIZE; i++) {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_nco_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_nco_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fxpt_nco.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e3506eb8121ca9e030103d44633b8a4c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b07e4453ab60677cc88f41c8f2147b6f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_vco_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_vco_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fxpt_vco.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e43dce3c6a7df7cd2c1ff929cc6eabb1)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b4f42261861e7cca08712c7c4880f06d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
As noted in #7047, several functions in `gr::fxpt_nco` and `gr::fxpt_vco` invoke Undefined Behaviour because they allow arithmetic overflows to occur on signed integers. The arithmetic is intended to be modular (since the integers represent phase angles), so we can achieve the same result without Undefined Behaviour by casting the integers to unsigned before performing the arithmetic.

## Related Issue
Fixes #7047.

## Which blocks/areas does this affect?
* `fxpt_nco` class
* `fxpt_vco` class
* VCO block
* VCO (complex) block

## Testing Done
I verified that the VCO and VCO (complex) blocks still work correctly after the changes, and that GCC's Undefined Behaviour Sanitizer no longer reports signed integer overflows while these blocks run.

I also noticed that the broken `fxpt_nco` functions were untested, so I extended the `t0` test case to exercise them in a way that triggers integer overflows and UBSAN warnings. With the `fxpt_nco` fixes in place, the UBSAN warnings disappear.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.