### PR TITLE
qa: Fix deprecation warnings in tests

### DIFF
--- a/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
@@ -30,7 +30,7 @@ class test_pmt_to_python(unittest.TestCase):
         uvector = pmt2py.numpy_to_uvector(narr)
         nparr = pmt2py.uvector_to_numpy(uvector)
         self.assertEqual(nparr.dtype, narr.dtype)
-        self.assertTrue(np.alltrue(nparr == narr))
+        self.assertTrue(np.all(nparr == narr))
 
 
 if __name__ == '__main__':

--- a/gr-blocks/python/blocks/qa_multiply_matrix_xx.py
+++ b/gr-blocks/python/blocks/qa_multiply_matrix_xx.py
@@ -52,17 +52,17 @@ class test_multiply_matrix_xx (gr_unittest.TestCase):
                  ):
         """ Run the test for given input-, output- and matrix values.
         Every row from X_in is considered an input signal on a port. """
-        X_in = numpy.matrix(X_in)
-        A_matrix = numpy.matrix(A)
+        X_in = numpy.array(X_in)
+        A_matrix = numpy.array(A)
         (N, M) = A_matrix.shape
         self.assertEqual(N, X_in.shape[0])
         # Calc expected
-        Y_out_exp = numpy.matrix(numpy.zeros((M, X_in.shape[1])))
+        Y_out_exp = numpy.zeros((M, X_in.shape[1]))
         self.multiplier = BLOCK_LOOKUP[datatype]['mult'](A, tpp)
         if A2 is not None:
             self.multiplier.set_A(A2)
             A = A2
-            A_matrix = numpy.matrix(A)
+            A_matrix = numpy.array(A)
         for i in range(N):
             if tags is None:
                 these_tags = ()
@@ -70,7 +70,7 @@ class test_multiply_matrix_xx (gr_unittest.TestCase):
                 these_tags = (tags[i],)
             self.tb.connect(
                 BLOCK_LOOKUP[datatype]['src'](
-                    X_in[i].tolist()[0],
+                    X_in[i].tolist(),
                     tags=these_tags),
                 (self.multiplier,
                  i))
@@ -81,7 +81,7 @@ class test_multiply_matrix_xx (gr_unittest.TestCase):
         # Run and check
         self.tb.run()
         for i in range(X_in.shape[1]):
-            Y_out_exp[:, i] = A_matrix * X_in[:, i]
+            Y_out_exp[:, i] = numpy.matmul(A_matrix, X_in[:, i])
         Y_out = [list(x.data()) for x in sinks]
         if tags is not None:
             self.the_tags = []

--- a/gr-iio/python/iio/__init__.py
+++ b/gr-iio/python/iio/__init__.py
@@ -22,9 +22,6 @@
 Interface blocks for IIO devices
 '''
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import os
 
 try:

--- a/gr-iio/python/iio/qa_iio.py
+++ b/gr-iio/python/iio/qa_iio.py
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-from __future__ import print_function
 import time
 from gnuradio import gr, gr_unittest, iio, blocks
 

--- a/gr-iio/python/iio/qa_iio.py
+++ b/gr-iio/python/iio/qa_iio.py
@@ -44,4 +44,4 @@ class test_iio(gr_unittest.TestCase):
 
 
 if __name__ == '__main__':
-    gr_unittest.run(test_iio, "test_iio.xml")
+    gr_unittest.run(test_iio)

--- a/gr-zeromq/python/zeromq/qa_zeromq_sub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_sub.py
@@ -42,7 +42,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
 
         self.tb.start()
         time.sleep(0.05)
-        self.pub_socket.send(src_data.tostring())
+        self.pub_socket.send(src_data.tobytes())
         time.sleep(0.5)
         self.tb.stop()
         self.tb.wait()
@@ -63,7 +63,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
                     vlen),
                 'float32') *
             100]
-        src_data = [a.tostring() for a in raw_data]
+        src_data = [a.tobytes() for a in raw_data]
         zeromq_sub_source = zeromq.sub_source(
             gr.sizeof_float, vlen, self._address)
         sink = blocks.vector_sink_f(vlen)
@@ -96,7 +96,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
                     vlen),
                 'float32') *
             100]
-        src_data = [a.tostring() for a in raw_data]
+        src_data = [a.tobytes() for a in raw_data]
 
         src_data = [b"filter_key"] + src_data
 
@@ -131,7 +131,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
                     vlen),
                 'float32') *
             100]
-        src_data = [a.tostring() for a in raw_data]
+        src_data = [a.tobytes() for a in raw_data]
 
         src_data = [b"filter_key"] + src_data
 


### PR DESCRIPTION
## Description
While running the test suite (with `ctest -V`), several deprecation warnings can be seen:

qa_pmt_to_python:
```
/usr/lib/python3.10/unittest/case.py:549: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead
```

qa_multiply_matrix_xx:
```
/home/argilo/prefix_311/src/gnuradio/gr-blocks/python/blocks/qa_multiply_matrix_xx.py:55: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  X_in = numpy.matrix(X_in)
/home/argilo/prefix_311/src/gnuradio/gr-blocks/python/blocks/qa_multiply_matrix_xx.py:56: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  A_matrix = numpy.matrix(A)
/home/argilo/prefix_311/src/gnuradio/gr-blocks/python/blocks/qa_multiply_matrix_xx.py:60: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  Y_out_exp = numpy.matrix(numpy.zeros((M, X_in.shape[1])))
/home/argilo/.local/lib/python3.10/site-packages/numpy/matrixlib/defmatrix.py:70: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  return matrix(data, dtype=dtype, copy=False)
..../home/argilo/prefix_311/src/gnuradio/gr-blocks/python/blocks/qa_multiply_matrix_xx.py:65: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  A_matrix = numpy.matrix(A)
```

qa_iio:
```
DEPRECATED: Using filename with gr_unittest does no longer have any effect.
```

qa_zeromq_sub:
```
/home/argilo/prefix_311/src/gnuradio/gr-zeromq/python/zeromq/qa_zeromq_sub.py:45: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  self.pub_socket.send(src_data.tostring())
./home/argilo/prefix_311/src/gnuradio/gr-zeromq/python/zeromq/qa_zeromq_sub.py:66: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  src_data = [a.tostring() for a in raw_data]
./home/argilo/prefix_311/src/gnuradio/gr-zeromq/python/zeromq/qa_zeromq_sub.py:99: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  src_data = [a.tostring() for a in raw_data]
./home/argilo/prefix_311/src/gnuradio/gr-zeromq/python/zeromq/qa_zeromq_sub.py:134: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  src_data = [a.tostring() for a in raw_data]
```

After these changes, all warnings are gone.

Along the way, I noticed a few lingering instances of `from __future__` which can be removed since GNU Radio no longer supports Python 2.

## Which blocks/areas does this affect?
* Python interface for gr-iio
* qa_pmt_to_python
* qa_multiply_matrix_xx
* qa_iio
* qa_zeromq_sub

## Testing Done
I verified that the test suite runs without deprecation warnings after these changes.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.