### PR TITLE
analog: Pass through max_gain parameter in agc3_cc::make

### DIFF
--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -33,7 +33,7 @@ agc3_cc::sptr agc3_cc::make(float attack_rate,
                             float max_gain)
 {
     return gnuradio::make_block_sptr<agc3_cc_impl>(
-        attack_rate, decay_rate, reference, gain, iir_update_decim);
+        attack_rate, decay_rate, reference, gain, iir_update_decim, max_gain);
 }
 
 agc3_cc_impl::agc3_cc_impl(float attack_rate,

--- a/gr-analog/python/analog/qa_agc.py
+++ b/gr-analog/python/analog/qa_agc.py
@@ -529,6 +529,22 @@ class test_agc(gr_unittest.TestCase):
             self.assertAlmostEqual(x, ref, None,
                                    f"failed at pos {idx} (stride = {stride})", 0.1)
 
+    def test_007_agc3_constructor_arguments(self):
+        attack_rate = 1.1e-3
+        decay_rate = 1.2e-4
+        reference = 1.3
+        gain = 1.4
+        iir_update_decim = 2
+        max_gain = 1.5e4
+
+        agc3 = analog.agc3_cc(attack_rate, decay_rate, reference, gain, iir_update_decim, max_gain)
+
+        self.assertAlmostEqual(agc3.attack_rate(), attack_rate)
+        self.assertAlmostEqual(agc3.decay_rate(), decay_rate)
+        self.assertAlmostEqual(agc3.reference(), reference)
+        self.assertAlmostEqual(agc3.gain(), gain)
+        self.assertAlmostEqual(agc3.max_gain(), max_gain)
+
     def test_100(self):
         ''' Test complex feedforward agc with constant input '''
 


### PR DESCRIPTION
## Description
In #6624 a `max_gain` parameter was added to AGC3, but `agc3_cc::make` doesn't pass it through to the block constructor. Here I've added the pass-through, and also added a test which verifies that the values make it through.

## Related Issue
Fixes #6955.

## Which blocks/areas does this affect?
* AGC3

## Testing Done
I verified that the test fails without the change, and passes with it.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
