### PR TITLE
fec: Fix BPSK AWGN formula

### DIFF
--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -78,7 +78,7 @@ ber_sink_b_impl::ber_sink_b_impl(std::vector<float> esnos,
     for (size_t i = 0; i < esnos.size(); i++) {
         double e = pow(10.0, esnos[i] / 10.0);
         d_esno_buffers[curves][i] = esnos[i];
-        d_ber_buffers[curves][i] = std::log10(0.5 * std::erf(std::sqrt(e)));
+        d_ber_buffers[curves][i] = std::log10(0.5 * std::erfc(std::sqrt(e)));
     }
 
 


### PR DESCRIPTION
## Description
The QT GUI Bercurve Sink displays BER curves for its inputs, as well as a reference curve showing the BER of BPSK in an AWGN channel. The formula for this reference curve was accidentally broken in 9ae5d4cd3da84ce7e5a0c2abe7fec1ff8d229ae8, when `boost::math::erfc` was replaced with `std::erf` (which should have been `std::erfc`).

## Which blocks/areas does this affect?
* QT GUI Bercurve Sink

## Testing Done
The `gr-fec/examples/ber_curve_gen.grc` example is currently broken, but can be fixed with the following workarounds:

* https://github.com/gnuradio/gnuradio/issues/5627#issuecomment-1060608139
* Revert https://github.com/gnuradio/gnuradio/pull/6889

I also modified the example to remove the "Dummy" curve, which would otherwise obscure the BPSK AWGN curve.

Before:
![Screenshot from 2024-01-07 00-40-36](https://github.com/gnuradio/gnuradio/assets/583749/ca99cc38-7639-491c-9936-1522d990950b)

After:
![Screenshot from 2024-01-07 00-39-45](https://github.com/gnuradio/gnuradio/assets/583749/af13a91f-5321-421f-b7ed-b6c268c1f032)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
