### PR TITLE
qtgui: Fix use-after-free in block destructors

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/displayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/displayform.h
@@ -36,7 +36,6 @@ public:
 
     virtual DisplayPlot* getPlot() = 0;
     void Reset();
-    bool isClosed() const;
 
     void enableMenu(bool en = true);
 
@@ -88,8 +87,6 @@ signals:
     void toggleGrid(bool en);
 
 protected:
-    bool d_isclosed;
-
     unsigned int d_nplots;
 
     QGridLayout* d_layout;

--- a/gr-qtgui/include/gnuradio/qtgui/eyedisplaysform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/eyedisplaysform.h
@@ -34,7 +34,6 @@ public:
     ~EyeDisplaysForm() override;
 
     void Reset();
-    bool isClosed() const;
 
     void enableMenu(bool en = true);
 
@@ -87,8 +86,6 @@ signals:
     void toggleGrid(bool en);
 
 protected:
-    bool d_isclosed;
-
     unsigned int d_nplots;
     int d_sps;
 

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -105,12 +105,7 @@ ber_sink_b_impl::ber_sink_b_impl(std::vector<float> esnos,
     set_line_alpha(d_curves, 0.25); // high transparency
 }
 
-ber_sink_b_impl::~ber_sink_b_impl()
-{
-    if (!d_main_gui->isClosed()) {
-        d_main_gui->close();
-    }
-}
+ber_sink_b_impl::~ber_sink_b_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool ber_sink_b_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/ber_sink_b_impl.h
+++ b/gr-qtgui/lib/ber_sink_b_impl.h
@@ -29,7 +29,7 @@ private:
     std::vector<volk::vector<double>> d_esno_buffers;
     std::vector<volk::vector<double>> d_ber_buffers;
 
-    ConstellationDisplayForm* d_main_gui = nullptr;
+    QPointer<ConstellationDisplayForm> d_main_gui;
     gr::high_res_timer_type d_update_time;
     std::vector<int> d_total_errors;
     int d_ber_min_errors;

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -65,8 +65,7 @@ const_sink_c_impl::const_sink_c_impl(int size,
 
 const_sink_c_impl::~const_sink_c_impl()
 {
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool const_sink_c_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/const_sink_c_impl.h
+++ b/gr-qtgui/lib/const_sink_c_impl.h
@@ -42,7 +42,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    ConstellationDisplayForm* d_main_gui = nullptr;
+    QPointer<ConstellationDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -16,7 +16,6 @@
 DisplayForm::DisplayForm(int nplots, QWidget* parent)
     : QWidget(parent), d_nplots(nplots), d_system_specified_flag(false)
 {
-    d_isclosed = false;
     d_axislabels = true;
 
     // Set the initial plot size
@@ -136,8 +135,6 @@ DisplayForm::DisplayForm(int nplots, QWidget* parent)
 
 DisplayForm::~DisplayForm()
 {
-    d_isclosed = true;
-
     // Qt deletes children when parent is deleted
     // Don't worry about deleting Display Plots - they are deleted when parents are
     // deleted
@@ -166,13 +163,10 @@ void DisplayForm::onPlotPointSelected(const QPointF p) { emit plotPointSelected(
 
 void DisplayForm::Reset() {}
 
-bool DisplayForm::isClosed() const { return d_isclosed; }
-
 void DisplayForm::enableMenu(bool en) { d_menu_on = en; }
 
 void DisplayForm::closeEvent(QCloseEvent* e)
 {
-    d_isclosed = true;
     qApp->processEvents();
     QWidget::closeEvent(e);
 }

--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -80,11 +80,7 @@ eye_sink_c_impl::eye_sink_c_impl(int size,
     declare_sample_delay(1); // delay the tags for a history of 2
 }
 
-eye_sink_c_impl::~eye_sink_c_impl()
-{
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
-}
+eye_sink_c_impl::~eye_sink_c_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool eye_sink_c_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/eye_sink_c_impl.h
+++ b/gr-qtgui/lib/eye_sink_c_impl.h
@@ -44,7 +44,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    EyeDisplayForm* d_main_gui = nullptr;
+    QPointer<EyeDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -75,11 +75,7 @@ eye_sink_f_impl::eye_sink_f_impl(int size,
     declare_sample_delay(1); // delay the tags for a history of 2
 }
 
-eye_sink_f_impl::~eye_sink_f_impl()
-{
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
-}
+eye_sink_f_impl::~eye_sink_f_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool eye_sink_f_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/eye_sink_f_impl.h
+++ b/gr-qtgui/lib/eye_sink_f_impl.h
@@ -42,7 +42,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    EyeDisplayForm* d_main_gui = nullptr;
+    QPointer<EyeDisplayForm> d_main_gui;
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;
 

--- a/gr-qtgui/lib/eyedisplaysform.cc
+++ b/gr-qtgui/lib/eyedisplaysform.cc
@@ -15,7 +15,6 @@
 EyeDisplaysForm::EyeDisplaysForm(int nplots, QWidget* parent)
     : QWidget(parent), d_nplots(nplots), d_system_specified_flag(false)
 {
-    d_isclosed = false;
     d_axislabels = true;
 
     // Set the initial plot size
@@ -139,8 +138,6 @@ EyeDisplaysForm::EyeDisplaysForm(int nplots, QWidget* parent)
 
 EyeDisplaysForm::~EyeDisplaysForm()
 {
-    d_isclosed = true;
-
     // Qt deletes children when parent is deleted
     // Don't worry about deleting Display Plots - they are deleted when parents are
     // deleted
@@ -177,13 +174,10 @@ void EyeDisplaysForm::onPlotPointSelected(const QPointF p)
 
 void EyeDisplaysForm::Reset() {}
 
-bool EyeDisplaysForm::isClosed() const { return d_isclosed; }
-
 void EyeDisplaysForm::enableMenu(bool en) { d_menu_on = en; }
 
 void EyeDisplaysForm::closeEvent(QCloseEvent* e)
 {
-    d_isclosed = true;
     qApp->processEvents();
     QWidget::closeEvent(e);
 }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -94,11 +94,7 @@ freq_sink_c_impl::freq_sink_c_impl(int fftsize,
     set_trigger_mode(TRIG_MODE_FREE, 0, 0);
 }
 
-freq_sink_c_impl::~freq_sink_c_impl()
-{
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
-}
+freq_sink_c_impl::~freq_sink_c_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool freq_sink_c_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -59,7 +59,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    FreqDisplayForm* d_main_gui = nullptr;
+    QPointer<FreqDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -94,11 +94,7 @@ freq_sink_f_impl::freq_sink_f_impl(int fftsize,
     set_trigger_mode(TRIG_MODE_FREE, 0, 0);
 }
 
-freq_sink_f_impl::~freq_sink_f_impl()
-{
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
-}
+freq_sink_f_impl::~freq_sink_f_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool freq_sink_f_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -59,7 +59,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    FreqDisplayForm* d_main_gui = nullptr;
+    QPointer<FreqDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -73,8 +73,7 @@ histogram_sink_f_impl::histogram_sink_f_impl(int size,
 
 histogram_sink_f_impl::~histogram_sink_f_impl()
 {
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool histogram_sink_f_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/histogram_sink_f_impl.h
+++ b/gr-qtgui/lib/histogram_sink_f_impl.h
@@ -41,7 +41,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    HistogramDisplayForm* d_main_gui = nullptr;
+    QPointer<HistogramDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/matrix_display.cc
+++ b/gr-qtgui/lib/matrix_display.cc
@@ -69,14 +69,10 @@ matrix_display::~matrix_display()
 {
     // Qt deletes children when parent is deleted
     d_spectrogram->detach();
-    d_isclosed = true;
 }
-
-bool matrix_display::isClosed() const { return d_isclosed; }
 
 void matrix_display::closeEvent(QCloseEvent* e)
 {
-    d_isclosed = true;
     qApp->processEvents();
     QWidget::closeEvent(e);
 }

--- a/gr-qtgui/lib/matrix_display.h
+++ b/gr-qtgui/lib/matrix_display.h
@@ -69,7 +69,6 @@ class matrix_display : public QWidget
     QMenu* d_contour_menu = nullptr;
     QMenu* d_interpolation_menu = nullptr;
     QMenu* d_color_map_menu = nullptr;
-    bool d_isclosed = false;
 
 public:
     explicit matrix_display(const std::string& name,
@@ -103,7 +102,6 @@ public:
     void set_y_axis_label(const std::string& y_axis_label);
     void set_z_axis_label(const std::string& z_axis_label);
     void initialize_mouse_actions();
-    bool isClosed() const;
 
 public slots:
     void set_data(QVector<double> data);

--- a/gr-qtgui/lib/matrix_sink_impl.cc
+++ b/gr-qtgui/lib/matrix_sink_impl.cc
@@ -70,12 +70,7 @@ matrix_sink_impl::matrix_sink_impl(const std::string& name,
 /*
  * Our virtual destructor.
  */
-matrix_sink_impl::~matrix_sink_impl()
-{
-    if (!d_display->isClosed()) {
-        d_display->close();
-    }
-}
+matrix_sink_impl::~matrix_sink_impl() { QMetaObject::invokeMethod(d_display, "close"); }
 
 void matrix_sink_impl::exec_() { d_qApplication->exec(); }
 

--- a/gr-qtgui/lib/matrix_sink_impl.h
+++ b/gr-qtgui/lib/matrix_sink_impl.h
@@ -30,7 +30,7 @@ private:
     std::vector<double> d_data;
     const char* d_argv = "";
     int d_argc = 1;
-    matrix_display* d_display;
+    QPointer<matrix_display> d_display;
     matrix_display_signal* d_signal = nullptr;
 
 public:

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -67,7 +67,7 @@ number_sink_impl::number_sink_impl(
     initialize();
 }
 
-number_sink_impl::~number_sink_impl() {}
+number_sink_impl::~number_sink_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool number_sink_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/number_sink_impl.h
+++ b/gr-qtgui/lib/number_sink_impl.h
@@ -42,7 +42,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    NumberDisplayForm* d_main_gui = nullptr;
+    QPointer<NumberDisplayForm> d_main_gui;
 
     std::vector<float> d_avg_value;
     std::vector<filter::single_pole_iir<float, float, float>> d_iir;

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -79,8 +79,7 @@ time_raster_sink_b_impl::time_raster_sink_b_impl(double samp_rate,
 
 time_raster_sink_b_impl::~time_raster_sink_b_impl()
 {
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool time_raster_sink_b_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/time_raster_sink_b_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.h
@@ -43,7 +43,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    TimeRasterDisplayForm* d_main_gui = nullptr;
+    QPointer<TimeRasterDisplayForm> d_main_gui;
 
     int d_icols;
     double d_rows, d_cols;

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -76,8 +76,7 @@ time_raster_sink_f_impl::time_raster_sink_f_impl(double samp_rate,
 
 time_raster_sink_f_impl::~time_raster_sink_f_impl()
 {
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool time_raster_sink_f_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/time_raster_sink_f_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.h
@@ -44,7 +44,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    TimeRasterDisplayForm* d_main_gui = nullptr;
+    QPointer<TimeRasterDisplayForm> d_main_gui;
 
     std::vector<float> d_mult;
     std::vector<float> d_offset;

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -85,11 +85,7 @@ time_sink_c_impl::time_sink_c_impl(int size,
     declare_sample_delay(1); // delay the tags for a history of 2
 }
 
-time_sink_c_impl::~time_sink_c_impl()
-{
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
-}
+time_sink_c_impl::~time_sink_c_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool time_sink_c_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/time_sink_c_impl.h
+++ b/gr-qtgui/lib/time_sink_c_impl.h
@@ -44,7 +44,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    TimeDisplayForm* d_main_gui = nullptr;
+    QPointer<TimeDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -82,12 +82,7 @@ time_sink_f_impl::time_sink_f_impl(int size,
     declare_sample_delay(1); // delay the tags for a history of 2
 }
 
-time_sink_f_impl::~time_sink_f_impl()
-{
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
-    // d_main_gui is a qwidget destroyed with its parent
-}
+time_sink_f_impl::~time_sink_f_impl() { QMetaObject::invokeMethod(d_main_gui, "close"); }
 
 bool time_sink_f_impl::check_topology(int ninputs, int noutputs)
 {

--- a/gr-qtgui/lib/time_sink_f_impl.h
+++ b/gr-qtgui/lib/time_sink_f_impl.h
@@ -43,7 +43,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    TimeDisplayForm* d_main_gui = nullptr;
+    QPointer<TimeDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -71,9 +71,7 @@ vector_sink_f_impl::vector_sink_f_impl(unsigned int vlen,
 
 vector_sink_f_impl::~vector_sink_f_impl()
 {
-    if (!d_main_gui->isClosed()) {
-        d_main_gui->close();
-    }
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool vector_sink_f_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/vector_sink_f_impl.h
+++ b/gr-qtgui/lib/vector_sink_f_impl.h
@@ -47,7 +47,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    VectorDisplayForm* d_main_gui = nullptr;
+    QPointer<VectorDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -88,8 +88,7 @@ waterfall_sink_c_impl::waterfall_sink_c_impl(int fftsize,
 
 waterfall_sink_c_impl::~waterfall_sink_c_impl()
 {
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool waterfall_sink_c_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -61,7 +61,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    WaterfallDisplayForm* d_main_gui = nullptr;
+    QPointer<WaterfallDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -85,8 +85,7 @@ waterfall_sink_f_impl::waterfall_sink_f_impl(int fftsize,
 
 waterfall_sink_f_impl::~waterfall_sink_f_impl()
 {
-    if (!d_main_gui->isClosed())
-        d_main_gui->close();
+    QMetaObject::invokeMethod(d_main_gui, "close");
 }
 
 bool waterfall_sink_f_impl::check_topology(int ninputs, int noutputs)

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -61,7 +61,7 @@ private:
     int d_argc = 1;
     char* d_argv = &d_zero;
     QWidget* d_parent;
-    WaterfallDisplayForm* d_main_gui = nullptr;
+    QPointer<WaterfallDisplayForm> d_main_gui;
 
     gr::high_res_timer_type d_update_time;
     gr::high_res_timer_type d_last_time;


### PR DESCRIPTION
## Description
As explained in #7050, most QT GUI sinks have a use-after-free bug in their destructors, which occurs when the user closes the GUI window. The Qt runtime deletes the the sink's `QWidget`, and then the sink attempts to dereference the deleted `QWidget` and call `isClosed()`.

To fix the problem, I've replaced the raw pointers with `QPointer`, which is automatically nulled when the underlying `QWidget` is deleted. ~~This provides a convenient way for the sink to check whether its `QWidget` still exists~~ The `QPointer` can then be used to safely invoke the `QWidget`'s `close` slot with `QMetaObject::invokeMethod`, removing the need for `isClosed()`.

The QT GUI Number Sink did not attempt to close its `QWidget`, which seems to have been an oversight. I've added the necessary code here.

The QT GUI Sink widget also does not attempt to close its `QWidget`, but it has quite a different design from the other sinks, so adding the closing logic was not straightforward, and I think it is best left to a separate pull request.

## Related Issue
Fixes #7050.

## Which blocks/areas does this affect?
* QT GUI Bercurve Sink
* QT GUI Constellation Sink
* QT GUI Eye Sink (complex, float)
* QT GUI Frequency Sink (complex, float)
* QT GUI Histogram Sink
* QT GUI Matrix Sink
* QT GUI Time Raster Sink (byte, float)
* QT GUI Time Sink (complex, float)
* QT GUI Vector Sink
* QT GUI Waterfall Sink (complex, float)
* QT GUI Number Sink

## Testing Done
I built gnuradio with GCC's `-fsanitize=address` flag, and used the following "kitchen sink" flow graph for testing:

![qtgui_sink_test](https://github.com/gnuradio/gnuradio/assets/583749/6e1f9fd9-0795-4f24-bd0c-6672f70eb8ae)

With these changes in place, the flow graph's GUI window can be closed without triggering any use-after-free warnings.

To check whether the sink blocks are still able to close their associated GUI widgets, I made the following change to the generated Python file:

```
    def sig_handler(sig=None, frame=None):
        tb.stop()
        tb.wait()

        tb.disconnect_all()
        del tb.qtgui_eye_sink_x_1
        del tb.qtgui_freq_sink_x_1
        del tb.qtgui_histogram_sink_x_0
        del tb.qtgui_number_sink_0
        del tb.qtgui_sink_x_1
        del tb.qtgui_time_raster_sink_x_0
        del tb.qtgui_time_sink_x_1
        del tb.qtgui_waterfall_sink_x_1
        del tb.qtgui_time_raster_sink_x_1
        del tb.qtgui_vector_sink_f_0
        del tb.qtgui_matrix_sink_0
        del tb.qtgui_const_sink_x_0
        del tb.qtgui_eye_sink_x_0
        del tb.qtgui_freq_sink_x_0
        del tb.qtgui_sink_x_0
        del tb.qtgui_time_sink_x_0
        del tb.qtgui_waterfall_sink_x_0

        # Qt.QApplication.quit()
```

When Ctrl+C is pressed, this will stop the flow graph and delete all the sinks, but leave the application running. All sinks are removed from the GUI, except for the "QT GUI Sink" blocks (complex & float), which were not addressed in this pull request (as mentioned above).

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.