### PR TITLE
Use Volk kernel volk_32f_s32f_x2_convert_8u

### DIFF
--- a/gr-blocks/grc/blocks_float_uchar.block.yml
+++ b/gr-blocks/grc/blocks_float_uchar.block.yml
@@ -2,21 +2,44 @@ id: blocks_float_to_uchar
 label: Float To UChar
 flags: [ python, cpp ]
 
+parameters:
+-   id: vlen
+    label: Vector Length
+    dtype: int
+    default: '1'
+    hide: ${ 'part' if vlen == 1 else 'none' }
+-   id: scale
+    label: Scale
+    dtype: real
+    default: '1'
+-   id: bias
+    label: Bias
+    dtype: real
+    default: '0'
+
 inputs:
 -   domain: stream
     dtype: float
+    vlen: ${ vlen }
 
 outputs:
 -   domain: stream
     dtype: byte
+    vlen: ${ vlen }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.float_to_uchar()
+    make: blocks.float_to_uchar(${vlen}, ${scale}, ${bias})
+    callbacks:
+    - set_scale(${scale})
+    - set_bias(${bias})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/float_to_uchar.h>']
     declarations: 'blocks::float_to_uchar::sptr ${id};'
-    make: 'this->${id} = blocks::float_to_uchar::make();'
+    make: 'this->${id} = blocks::float_to_uchar::make(${vlen}, ${scale}, ${bias});'
+    callbacks:
+    - set_scale(${scale})
+    - set_bias(${bias})    
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/float_to_uchar.h
+++ b/gr-blocks/include/gnuradio/blocks/float_to_uchar.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012 Free Software Foundation, Inc.
+ * Copyright 2024 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -29,8 +30,32 @@ public:
 
     /*!
      * Build a float to uchar block.
+     *
+     * \param vlen vector length of data streams.
+     * \param scale a scalar multiplier to change the output signal scale.
+     * \param bias a scalar additive value to change the output signal offset.
      */
-    static sptr make();
+    static sptr make(size_t vlen = 1, float scale = 1.0, float bias = 0.0);
+
+    /*!
+     * Get the scalar multiplier value.
+     */
+    virtual float scale() const = 0;
+
+    /*!
+     * Get the scalar bias value.
+     */
+    virtual float bias() const = 0;
+
+    /*!
+     * Set the scalar multiplier value.
+     */
+    virtual void set_scale(float scale) = 0;
+
+    /*!
+     * Set the scalar bias value.
+     */
+    virtual void set_bias(float scale) = 0;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/float_array_to_uchar.cc
+++ b/gr-blocks/lib/float_array_to_uchar.cc
@@ -19,6 +19,12 @@
 static const int MIN_UCHAR = 0;
 static const int MAX_UCHAR = 255;
 
+#if VOLK_VERSION >= 030100
+void float_array_to_uchar(const float* in, unsigned char* out, int nsamples)
+{
+    volk_32f_s32f_x2_convert_8u(out, in, 1.0, 0.0, nsamples);
+}
+#else
 void float_array_to_uchar(const float* in, unsigned char* out, int nsamples)
 {
     for (int i = 0; i < nsamples; i++) {
@@ -30,3 +36,4 @@ void float_array_to_uchar(const float* in, unsigned char* out, int nsamples)
         out[i] = r;
     }
 }
+#endif

--- a/gr-blocks/lib/float_to_uchar_impl.cc
+++ b/gr-blocks/lib/float_to_uchar_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012 Free Software Foundation, Inc.
+ * Copyright 2024 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -15,20 +16,27 @@
 #include "float_array_to_uchar.h"
 #include "float_to_uchar_impl.h"
 #include <gnuradio/io_signature.h>
+#include <volk/volk.h>
+#include <cmath>
 
 namespace gr {
 namespace blocks {
 
-float_to_uchar::sptr float_to_uchar::make()
+float_to_uchar::sptr float_to_uchar::make(size_t vlen, float scale, float bias)
 {
-    return gnuradio::make_block_sptr<float_to_uchar_impl>();
+    return gnuradio::make_block_sptr<float_to_uchar_impl>(vlen, scale, bias);
 }
 
-float_to_uchar_impl::float_to_uchar_impl()
+float_to_uchar_impl::float_to_uchar_impl(size_t vlen, float scale, float bias)
     : sync_block("float_to_uchar",
-                 io_signature::make(1, 1, sizeof(float)),
-                 io_signature::make(1, 1, sizeof(unsigned char)))
+                 io_signature::make(1, 1, sizeof(float) * vlen),
+                 io_signature::make(1, 1, sizeof(unsigned char) * vlen)),
+      d_vlen(vlen),
+      d_scale(scale),
+      d_bias(bias)
 {
+    const int alignment_multiple = volk_get_alignment() / sizeof(char);
+    set_alignment(std::max(1, alignment_multiple));
 }
 
 int float_to_uchar_impl::work(int noutput_items,
@@ -38,7 +46,25 @@ int float_to_uchar_impl::work(int noutput_items,
     const float* in = (const float*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
-    float_array_to_uchar(in, out, noutput_items);
+#if VOLK_VERSION >= 030100
+    volk_32f_s32f_x2_convert_8u(out, in, d_scale, d_bias, d_vlen * noutput_items);
+#else
+    const float min_val = 0.0f;
+    const float max_val = UINT8_MAX;
+    const int nitems = d_vlen * noutput_items;
+    for (int j = 0; j < nitems; ++j) {
+        const float r = in[j] * d_scale + d_bias;
+        unsigned char u;
+        if (r > max_val) {
+            u = (uint8_t)(max_val);
+        } else if (r < min_val) {
+            u = (uint8_t)(min_val);
+        } else {
+            u = (uint8_t)(rintf(r));
+        }
+        out[j] = u;
+    }
+#endif
 
     return noutput_items;
 }

--- a/gr-blocks/lib/float_to_uchar_impl.h
+++ b/gr-blocks/lib/float_to_uchar_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012 Free Software Foundation, Inc.
+ * Copyright 2024 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of GNU Radio
  *
@@ -18,8 +19,18 @@ namespace blocks {
 
 class BLOCKS_API float_to_uchar_impl : public float_to_uchar
 {
+private:
+    const size_t d_vlen;
+    float d_scale;
+    float d_bias;
+
 public:
-    float_to_uchar_impl();
+    float_to_uchar_impl(size_t vlen, float scale, float bias);
+
+    float scale() const override { return d_scale; }
+    float bias() const override { return d_bias; }
+    void set_scale(float scale) override { d_scale = scale; }
+    void set_bias(float bias) override { d_bias = bias; }
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-blocks/python/blocks/bindings/docstrings/float_to_uchar_pydoc_template.h
+++ b/gr-blocks/python/blocks/bindings/docstrings/float_to_uchar_pydoc_template.h
@@ -22,3 +22,15 @@ static const char* __doc_gr_blocks_float_to_uchar_float_to_uchar = R"doc()doc";
 
 
 static const char* __doc_gr_blocks_float_to_uchar_make = R"doc()doc";
+
+
+static const char* __doc_gr_blocks_float_to_uchar_scale = R"doc()doc";
+
+
+static const char* __doc_gr_blocks_float_to_uchar_bias = R"doc()doc";
+
+
+static const char* __doc_gr_blocks_float_to_uchar_set_scale = R"doc()doc";
+
+
+static const char* __doc_gr_blocks_float_to_uchar_set_bias = R"doc()doc";

--- a/gr-blocks/python/blocks/bindings/float_to_uchar_python.cc
+++ b/gr-blocks/python/blocks/bindings/float_to_uchar_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(float_to_uchar.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(30cc9cfbb683f5c34d63bc65b4eb3e69)                     */
+/* BINDTOOL_HEADER_FILE_HASH(97eb3380d72dc183e496e854b46d3a95)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -39,8 +39,29 @@ void bind_float_to_uchar(py::module& m)
                gr::basic_block,
                std::shared_ptr<float_to_uchar>>(m, "float_to_uchar", D(float_to_uchar))
 
-        .def(py::init(&float_to_uchar::make), D(float_to_uchar, make))
+        .def(py::init(&float_to_uchar::make),
+             py::arg("vlen") = 1,
+             py::arg("scale") = 1.,
+             py::arg("bias") = 0.,
+             D(float_to_uchar, make))
 
+
+        .def("scale", &float_to_uchar::scale, D(float_to_uchar, scale))
+
+
+        .def("bias", &float_to_uchar::bias, D(float_to_uchar, bias))
+
+
+        .def("set_scale",
+             &float_to_uchar::set_scale,
+             py::arg("scale"),
+             D(float_to_uchar, set_scale))
+
+
+        .def("set_bias",
+             &float_to_uchar::set_bias,
+             py::arg("bias"),
+             D(float_to_uchar, set_bias))
 
         ;
 }

--- a/gr-blocks/python/blocks/qa_type_conversions.py
+++ b/gr-blocks/python/blocks/qa_type_conversions.py
@@ -242,6 +242,18 @@ class test_type_conversions(gr_unittest.TestCase):
         self.tb.run()
         self.assertEqual(expected_data, dst.data())
 
+    def test_float_to_uchar_scale_bias(self):
+        src_data = (1.0, -2.0, 3.0, -4.0, 256.0)
+        scale = 2.0
+        bias = 5.0
+        expected_data = [7, 1, 11, 0, 255]
+        src = blocks.vector_source_f(src_data)
+        op = blocks.float_to_uchar(scale=scale, bias=bias)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        self.assertEqual(expected_data, dst.data())
+
     def test_int_to_float_identity(self):
         src_data = (1, 2, 3, 4, 5)
         expected_data = [1.0, 2.0, 3.0, 4.0, 5.0]

--- a/gr-fec/lib/async_decoder_impl.h
+++ b/gr-fec/lib/async_decoder_impl.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/blocks/pack_k_bits.h>
 #include <gnuradio/fec/async_decoder.h>
+#include <volk/volk.h>
 #include <volk/volk_alloc.hh>
 
 namespace gr {
@@ -41,11 +42,15 @@ private:
 
     void decode(const pmt::pmt_t& msg);
 
+// The volk_32f_s32f_x2_convert_8u kernel is only available since Volk 3.1.
+// In earlier versions we use this ad-hoc function.
+#if !(VOLK_VERSION >= 030100)
     inline void convert_32f_to_8u(uint8_t* output_vector,
                                   const float* input_vector,
                                   const float scale,
                                   const float bias,
                                   unsigned int num_points);
+#endif
 
 public:
     async_decoder_impl(generic_decoder::sptr my_decoder,

--- a/gr-fec/python/fec/extended_tagged_decoder.py
+++ b/gr-fec/python/fec/extended_tagged_decoder.py
@@ -110,22 +110,23 @@ class extended_tagged_decoder(gr.hier_block2):
         message_collector_connected = False
 
         # anything going through the annihilator needs shifted, uchar vals
-        if (
+        needs_float_to_uchar = (
             fec.get_decoder_input_conversion(decoder_obj) == "uchar" or
             fec.get_decoder_input_conversion(decoder_obj) == "packed_bits"
-        ):
-            self.blocks.append(blocks.multiply_const_ff(48.0))
+        )
+
+        bias = 0.0
 
         if fec.get_shift(decoder_obj) != 0.0:
-            self.blocks.append(blocks.add_const_ff(fec.get_shift(decoder_obj)))
+            bias = fec.get_shift(decoder_obj)
         elif fec.get_decoder_input_conversion(decoder_obj) == "packed_bits":
-            self.blocks.append(blocks.add_const_ff(128.0))
+            bias = 128.0
 
-        if (
-            fec.get_decoder_input_conversion(decoder_obj) == "uchar" or
-            fec.get_decoder_input_conversion(decoder_obj) == "packed_bits"
-        ):
-            self.blocks.append(blocks.float_to_uchar())
+        if bias != 0.0 and not needs_float_to_uchar:
+            self.blocks.append(blocks.add_const_ff(bias))
+
+        if needs_float_to_uchar:
+            self.blocks.append(blocks.float_to_uchar(scale=48.0, bias=bias))
 
         const_index = 0  # index that corresponds to mod order for specinvert purposes
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The kernel `volk_32f_s32f_x2_convert_8u()` has been added to Volk 3.1. This PR contains 3 commits that take advantage of this kernel, maintaining backwards compatibility by providing ad-hoc alternatives with earlier Volk versions. The changes are:

1. The kernel is now used in gr-fec async_decoder if possible. This was marked as a TODO.
2. vlen, scale and bias parameters have been added to gr-blocks float_to_uchar. This makes float_to_uchar more similar to float_to_char. Since the Volk conversion kernel supports scale and bias, it is used when possible.
3. In gr-fec extended_decoder and extended_tagged_decoder, the scale and bias parameters of float_to_uchar are used instead of adding separate multiply_const and add_const blocks.

Commit 3 requires commit 2, and commit 1 is independent of the rest. I have done separate commits because the changes are only loosely related by taking advantage of the new Volk kernel. I can squash them before merging if it is preferred.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

No related issue.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

* gr-blocks: float_to_uchar
* gr-fec: async_decoder, extended_decoder, extended_tagged_decoder

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

A new test has been added for the float_to_uchar scale and bias parameters. All the tests pass.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. -> The [wiki documentation for float_to_uchar](https://wiki.gnuradio.org/index.php/Float_To_UChar) should be updated to reflect the new parameters (though this wiki page is currently empty). 
- [x] I have added tests to cover my changes, and all previous tests pass.
