### PR TITLE
grc: Fix compilation of bus ports

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -336,7 +336,6 @@ class TopBlockGenerator(object):
                 # the code for each subconnection
                 porta = con.source_port
                 portb = con.sink_port
-                fg = self._flow_graph
 
                 if porta.dtype == 'bus' and portb.dtype == 'bus':
                     # which bus port is this relative to the bus structure
@@ -344,8 +343,6 @@ class TopBlockGenerator(object):
                         for port_num_a, port_num_b in zip(porta.bus_structure, portb.bus_structure):
                             hidden_porta = porta.parent.sources[port_num_a]
                             hidden_portb = portb.parent.sinks[port_num_b]
-                            connection = fg.parent_platform.Connection(
-                                parent=self, source=hidden_porta, sink=hidden_portb)
                             code = template.render(
                                 make_port_sig=make_port_sig,
                                 source=hidden_porta,


### PR DESCRIPTION
This removes a superfluous call to `Connection.__init__()` in the top block generator which uses itself as a parent, instead of the original flowgraph as elsewhere in the same file. 0fd504e5 changed the Connection object such that passing in a parent that is not an Element is no longer valid.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue

Fixes #7059 

## Which blocks/areas does this affect?

GRC + Bus Ports

## Testing Done

Used the same FG from #7059 to test both crash and fix. Also, just by looking at the code, this seems like a safe change as the `connection` object was used nowhere.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
