### PR TITLE
blocks: Fix loop bound in Null Source

### DIFF
--- a/gr-blocks/lib/null_source_impl.cc
+++ b/gr-blocks/lib/null_source_impl.cc
@@ -38,7 +38,7 @@ int null_source_impl::work(int noutput_items,
                            gr_vector_void_star& output_items)
 {
     void* optr;
-    for (size_t n = 0; n < input_items.size(); n++) {
+    for (size_t n = 0; n < output_items.size(); n++) {
         optr = (void*)output_items[n];
         memset(optr, 0, noutput_items * output_signature()->sizeof_stream_item(n));
     }


### PR DESCRIPTION
## Description
In 92b01e30373e6ed36d1067e2bcba661d2253f34a, the Null Source was extended to support multiple outputs. But its `work` function iterates over inputs instead of outputs, so it doesn't write any output. It only gets away with this because double-mapped buffers are initialized to zero. But as noted in https://github.com/gnuradio/gnuradio/issues/7041#issuecomment-1881100761, this is not true of all buffer implementations, so Null Sink should write zeroes to its outputs.

## Related Issue
Fixes #7041.

## Which blocks/areas does this affect?
* Null Source

## Testing Done
I added a log message inside the `work` loop to verify that `memset` was being invoked.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
