### PR TITLE
runtime: use XDG_CONFIG_DIR for the userconf path

### DIFF
--- a/gnuradio-runtime/include/gnuradio/sys_paths.h
+++ b/gnuradio-runtime/include/gnuradio/sys_paths.h
@@ -11,17 +11,18 @@
 #define GR_SYS_PATHS_H
 
 #include <gnuradio/api.h>
+#include <filesystem>
 
 namespace gr {
 
 //! directory to create temporary files
-GR_RUNTIME_API const char* tmp_path();
+GR_RUNTIME_API std::filesystem::path tmp_path();
 
 //! directory to store application data
-GR_RUNTIME_API const char* appdata_path();
+GR_RUNTIME_API std::filesystem::path appdata_path();
 
 //! directory to store user configuration
-GR_RUNTIME_API const char* userconf_path();
+GR_RUNTIME_API std::filesystem::path userconf_path();
 
 } /* namespace gr */
 

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -65,7 +65,7 @@ std::vector<std::string> prefs::_sys_prefs_filenames()
     // Find if there is a ~/.gnuradio/config.conf file and add this to
     // the end of the file list to override any preferences in the
     // installed path config files.
-    fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    const auto userconf = gr::userconf_path() / "config.conf";
     if (fs::exists(userconf)) {
         fnames.push_back(userconf.string());
     }
@@ -141,7 +141,7 @@ void prefs::save()
     const std::string conf = to_string();
 
     // Write temp file.
-    const fs::path tmp = fs::path(gr::userconf_path()) / "config.conf.tmp";
+    const auto tmp = gr::userconf_path() / "config.conf.tmp";
     std::ofstream fout(tmp);
     fout << conf;
     fout.close();
@@ -158,7 +158,7 @@ void prefs::save()
     }
 
     // Atomic rename.
-    const fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    const auto userconf = gr::userconf_path() / "config.conf";
     fs::rename(tmp, userconf);
     // If fs::rename() fails, we'll leak the tempfile and throw. That's fine.
     // If the user wants it (it was written successfully) they can have it.


### PR DESCRIPTION
This changes the config path from ~/.gnuradio to ~/.config/gnuradio. On windows this maps to %APPDATA%/.config/gnuradio.
This was requested in #3631. 
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Adhering to the XDG specification help reduce clutter of custom dotfile locations in $HOME...

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #3631

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
runtime

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
CMake build and ctest.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.

Not sure how I should document this or where to even start. Dito testing :-)