### PR TITLE
grc: Only bussify blocks that have ports

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -750,14 +750,16 @@ class Block(Element):
     def bussify(self, direc):
         if direc == 'source':
             ports = self.sources
-            ports_gui = self.filter_bus_port(self.sources)
-            self.bus_structure = self.get_bus_structure('source')
-            self.bus_source = not self.bus_source
+            if ports:
+                ports_gui = self.filter_bus_port(self.sources)
+                self.bus_structure = self.get_bus_structure('source')
+                self.bus_source = not self.bus_source
         else:
             ports = self.sinks
-            ports_gui = self.filter_bus_port(self.sinks)
-            self.bus_structure = self.get_bus_structure('sink')
-            self.bus_sink = not self.bus_sink
+            if ports:
+                ports_gui = self.filter_bus_port(self.sinks)
+                self.bus_structure = self.get_bus_structure('sink')
+                self.bus_sink = not self.bus_sink
 
         # Disconnect all the connections when toggling the bus state
         for port in ports:

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -869,8 +869,8 @@ class Application(Gtk.Application):
 
         Actions.BLOCK_CREATE_HIER.set_enabled(bool(selected_blocks))
         Actions.OPEN_HIER.set_enabled(bool(selected_blocks))
-        Actions.BUSSIFY_SOURCES.set_enabled(bool(selected_blocks))
-        Actions.BUSSIFY_SINKS.set_enabled(bool(selected_blocks))
+        Actions.BUSSIFY_SOURCES.set_enabled(any(block.sources for block in selected_blocks))
+        Actions.BUSSIFY_SINKS.set_enabled(any(block.sinks for block in selected_blocks))
         Actions.RELOAD_BLOCKS.enable()
         Actions.FIND_BLOCKS.enable()
 


### PR DESCRIPTION
## Description
The "More -> Toggle Source Bus" and "More -> Toggle Sink Bus" options in GRC's context menu are enabled whenever any blocks are selected, regardless whether those blocks actually have any source or sink ports. Selecting "Toggle Source Bus" for a block that doesn't have any source ports will create a useless bus of length zero, and the same for "Toggle Sink Bus".

![Screenshot from 2024-01-10 15-14-26](https://github.com/gnuradio/gnuradio/assets/583749/00e2dab2-6aa2-4395-b840-19621150f854)

To fix this, I've changed the context menu so that "Toggle Source Bus" is only enabled if at least one of the selected blocks has a source port, and "Toggle Sink Bus" is only enabled if at least one of the selected blocks has a sink port.

Since not all of the selected blocks will necessarily have the required ports, I also changed `Block.bussify` to check whether the current block has at least one port of the required type before converting to a bus.

## Which blocks/areas does this affect?
Bus ports in GRC

## Testing Done
I manually tested GRC, selecting one or more blocks, checking whether the correct context menu items were enabled, and clicking the menu items to see whether ports are correctly bussified.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
