### PR TITLE
grc: Update copyright date

### DIFF
--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -1,4 +1,4 @@
-"""Copyright 2021 The GNU Radio Contributors
+"""Copyright 2024 The GNU Radio Contributors
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-2.0-or-later


### PR DESCRIPTION
## Description
The copyright date displayed in GRC was last updated in 2021 (#4451) so we're due for an update.

![Screenshot from 2024-01-10 16-00-28](https://github.com/gnuradio/gnuradio/assets/583749/86c88935-57fb-47df-bde5-4a501ab10dcc)

## Which blocks/areas does this affect?
GRC "Help -> About"

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
