### PR TITLE
Fix filter tool CustomViewBox import order

### DIFF
--- a/gr-filter/python/filter/gui/CustomViewBox.py
+++ b/gr-filter/python/filter/gui/CustomViewBox.py
@@ -1,5 +1,5 @@
-import pyqtgraph as pg
 from PyQt5 import QtCore
+import pyqtgraph as pg
 
 
 class CustomViewBox(pg.ViewBox):


### PR DESCRIPTION
Filter tool wouldn't start on a fresh Ubuntu 23.10 install.

Issue was that CustomViewBox was importing PyQtGraph before PyQt5, resulting in PyQtGraph pulling in PyQt6 instead.

With PyQt5 imported first, PyQtGraph uses that instead of PyQt6.

This change fixed the issue on my PC and shouldn't have other side effects

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
