### PR TITLE
GRC: fix C++ hier block generation

### DIFF
--- a/grc/core/generator/cpp_hier_block.py
+++ b/grc/core/generator/cpp_hier_block.py
@@ -12,24 +12,22 @@ from ..io import yaml
 class CppHierBlockGenerator(CppTopBlockGenerator):
     """Extends the top block generator to also generate a block YML file"""
 
-    def __init__(self, flow_graph, file_path):
+    def __init__(self, flow_graph, output_dir):
         """
         Initialize the hier block generator object.
 
         Args:
             flow_graph: the flow graph object
-            file_path: where to write the py file (the yml goes into HIER_BLOCK_LIB_DIR)
+            output_dir: the path for written files
         """
-        CppTopBlockGenerator.__init__(self, flow_graph, file_path)
         platform = flow_graph.parent
+        if output_dir is None:
+            output_dir = platform.config.hier_block_lib_dir
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
 
-        hier_block_lib_dir = platform.config.hier_block_lib_dir
-        if not os.path.exists(hier_block_lib_dir):
-            os.mkdir(hier_block_lib_dir)
-
+        CppTopBlockGenerator.__init__(self, flow_graph, output_dir)
         self._mode = Constants.HIER_BLOCK_FILE_MODE
-        self.file_path = os.path.join(
-            hier_block_lib_dir, self._flow_graph.get_option('id'))
         self.file_path_yml = self.file_path + '.block.yml'
 
     def write(self):

--- a/grc/core/generator/cpp_templates/flow_graph.hpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.hpp.mako
@@ -42,12 +42,6 @@ class_name = flow_graph.get_option('id') + ('_' if flow_graph.get_option('id') =
 param_str = ", ".join((param.vtype + " " + param.name) for param in parameters)
 %>\
 
-% if generate_options.startswith('hb'):
-class ${class_name};
-typedef std::shared_ptr<${class_name}> ${class_name}_sptr;
-${class_name}_sptr make_${class_name}();
-% endif
-
 % if generate_options == 'no_gui':
 class ${class_name} {
 % elif generate_options.startswith('hb'):
@@ -89,7 +83,10 @@ ${indent(declarations)}
 % endif
 
 public:
-% if not generate_options.startswith('hb'):
+% if generate_options.startswith('hb'):
+    typedef std::shared_ptr<${class_name}> sptr;
+    static sptr make(${param_str});
+% else:
     top_block_sptr tb;
 % endif
     ${class_name}(${param_str});
@@ -183,10 +180,11 @@ void ${class_name}::set_${var.name} (${var.vtype} ${var.name}) {
 }
 
 % endfor
-${class_name}_sptr
-make_${class_name}()
+${class_name}::sptr
+${class_name}::make(${param_str})
 {
-    return gnuradio::get_initial_sptr(new ${class_name}());
+    return gnuradio::make_block_sptr<${class_name}>(
+        ${", ".join(param.name for param in parameters)});
 }
 % endif
 #endif

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -122,8 +122,8 @@ class CppTopBlockGenerator(object):
         Returns:
             a string of C++ code
         """
-        file_path = self.file_path + '/' + \
-            self._flow_graph.get_option('id') + '.cpp'
+        filename = self._flow_graph.get_option('id') + '.cpp'
+        file_path = os.path.join(self.file_path, filename)
 
         output = []
 
@@ -149,8 +149,8 @@ class CppTopBlockGenerator(object):
         Returns:
             a string of C++ code
         """
-        file_path = self.file_path + '/' + \
-            self._flow_graph.get_option('id') + '.hpp'
+        filename = self._flow_graph.get_option('id') + '.hpp'
+        file_path = os.path.join(self.file_path, filename)
 
         output = []
 


### PR DESCRIPTION
## Description
This PR fixes two issues I found when generating C++ hier blocks with `grcc`:
1. The `--output` argument had no effect on location of generated files; they were always put in the `$HOME/.grc_gnuradio` directory.
2. The generated `make` function (that creates a shared pointer) was not using any parameters as arguments; that resulted in a compile error, because the generated class constructor was using these parameters as arguments.

Note: new `make` function template does not use default values for arguments yet.

## Which blocks/areas does this affect?
GRC generation / `grcc`

## Testing Done
Minimal example: [cpp_hier.grc](https://github.com/gnuradio/gnuradio/files/14021893/cpp_hier.grc.txt);  
Command used: `grcc cpp_hier.grc -o ./output_dir`

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
