### PR TITLE
filter: Fix undefined behaviour in fir_filter_with_buffer

### DIFF
--- a/gr-filter/lib/fir_filter_with_buffer.cc
+++ b/gr-filter/lib/fir_filter_with_buffer.cc
@@ -52,7 +52,8 @@ void fir_filter_with_buffer_fff::set_taps(const std::vector<float>& taps)
     for (int i = 0; i < d_naligned; i++) {
         d_aligned_taps[i].clear();
         d_aligned_taps[i].resize(d_ntaps + d_naligned - 1);
-        std::copy(std::begin(d_taps), std::end(d_taps), &d_aligned_taps[i][i]);
+        std::copy(
+            std::begin(d_taps), std::end(d_taps), std::begin(d_aligned_taps[i]) + i);
     }
 
     d_idx = 0;
@@ -157,7 +158,8 @@ void fir_filter_with_buffer_ccc::set_taps(const std::vector<gr_complex>& taps)
     for (int i = 0; i < d_naligned; i++) {
         d_aligned_taps[i].clear();
         d_aligned_taps[i].resize(d_ntaps + d_naligned - 1);
-        std::copy(std::begin(d_taps), std::end(d_taps), &d_aligned_taps[i][i]);
+        std::copy(
+            std::begin(d_taps), std::end(d_taps), std::begin(d_aligned_taps[i]) + i);
     }
 
     d_idx = 0;
@@ -261,7 +263,8 @@ void fir_filter_with_buffer_ccf::set_taps(const std::vector<float>& taps)
     for (int i = 0; i < d_naligned; i++) {
         d_aligned_taps[i].clear();
         d_aligned_taps[i].resize(d_ntaps + d_naligned - 1);
-        std::copy(std::begin(d_taps), std::end(d_taps), &d_aligned_taps[i][i]);
+        std::copy(
+            std::begin(d_taps), std::end(d_taps), std::begin(d_aligned_taps[i]) + i);
     }
 
     d_idx = 0;

--- a/gr-filter/lib/qa_fir_filter_with_buffer.cc
+++ b/gr-filter/lib/qa_fir_filter_with_buffer.cc
@@ -107,7 +107,7 @@ void test_decimate(unsigned int decimate)
             }
 
             // build filter
-            vector<tap_type> f1_taps(&taps[0], &taps[n]);
+            vector<tap_type> f1_taps(taps.begin(), taps.begin() + n);
             kernel::fir_filter_with_buffer_fff f1(f1_taps);
 
             // zero the output, then do the filtering
@@ -198,7 +198,7 @@ void test_decimate(unsigned int decimate)
             }
 
             // build filter
-            vector<tap_type> f1_taps(&taps[0], &taps[n]);
+            vector<tap_type> f1_taps(taps.begin(), taps.begin() + n);
             kernel::fir_filter_with_buffer_ccc f1(f1_taps);
 
             // zero the output, then do the filtering
@@ -287,7 +287,7 @@ void test_decimate(unsigned int decimate)
             }
 
             // build filter
-            vector<tap_type> f1_taps(&taps[0], &taps[n]);
+            vector<tap_type> f1_taps(taps.begin(), taps.begin() + n);
             kernel::fir_filter_with_buffer_ccf f1(f1_taps);
 
             // zero the output, then do the filtering


### PR DESCRIPTION
## Description
If GNU Radio is built with `-D_GLIBCXX_ASSERTIONS`, then `qa_fir_filter_with_buffer` fails due to Undefined Behaviour in both the test itself and the `fir_filter_with_buffer_*` classes. Accessing index *n* of a length-*n* vector is Undefined Behaviour, even if it's only to calculate the address. I've replaced the offending code with iterators.

## Related Issue
Fixes #7085.

## Which blocks/areas does this affect?
* `fir_filter_with_buffer_fff`
* `fir_filter_with_buffer_ccc`
* `fir_filter_with_buffer_ccf`

## Testing Done
I added `set(CMAKE_CXX_FLAGS "-D_GLIBCXX_ASSERTIONS ${CMAKE_CXX_FLAGS}")` to `CMakeLists.txt` and rebuilt GNU Radio, confirmed that `qa_fir_filter_with_buffer` fails, then applied the fixes and verified that it passes.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
