### PR TITLE
grcqt: Improve logging

### DIFF
--- a/grc/gui_qt/Utils.py
+++ b/grc/gui_qt/Utils.py
@@ -7,7 +7,7 @@ from qtpy import QtGui, QtCore
 
 from . import Constants
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 def get_rotated_coordinate(coor, rotation):

--- a/grc/gui_qt/base.py
+++ b/grc/gui_qt/base.py
@@ -27,7 +27,7 @@ from qtpy import QtWidgets
 
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class Component(object):

--- a/grc/gui_qt/components/block_library.py
+++ b/grc/gui_qt/components/block_library.py
@@ -29,7 +29,7 @@ from .. import base
 from .canvas.block import Block
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class BlockSearchBar(QLineEdit):

--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -13,7 +13,7 @@ from ....core.utils import flow_graph_complexity
 from ..dialogs import PropsDialog
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 LONG_VALUE = 20  # maximum length of a param string.
 # if exceeded, '...' will be displayed

--- a/grc/gui_qt/components/canvas/flowgraph.py
+++ b/grc/gui_qt/components/canvas/flowgraph.py
@@ -36,7 +36,7 @@ from ... import Utils
 from .block import GUIBlock
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 DEFAULT_MAX_X = 400
 DEFAULT_MAX_Y = 300

--- a/grc/gui_qt/components/console.py
+++ b/grc/gui_qt/components/console.py
@@ -37,7 +37,7 @@ Icons = QtGui.QIcon.fromTheme
 Keys = QtGui.QKeySequence
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 HTML = '''

--- a/grc/gui_qt/components/example_browser.py
+++ b/grc/gui_qt/components/example_browser.py
@@ -13,7 +13,7 @@ from .. import base, Constants
 from ..properties import Paths
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class WorkerSignals(QObject):

--- a/grc/gui_qt/components/flowgraph_view.py
+++ b/grc/gui_qt/components/flowgraph_view.py
@@ -18,7 +18,7 @@ from .canvas.colors import LIGHT_FLOWGRAPH_BACKGROUND_COLOR, DARK_FLOWGRAPH_BACK
 from ...core.generator import Generator
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 DEFAULT_MAX_X = 400
 DEFAULT_MAX_Y = 300

--- a/grc/gui_qt/components/oot_browser.py
+++ b/grc/gui_qt/components/oot_browser.py
@@ -12,7 +12,7 @@ from ..properties import Paths
 
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class OOTBrowser(QtWidgets.QDialog, base.Component):

--- a/grc/gui_qt/components/preferences.py
+++ b/grc/gui_qt/components/preferences.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (QLineEdit, QTabWidget, QDialog,
 from ..properties import Paths
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class PreferencesDialog(QDialog):

--- a/grc/gui_qt/components/undoable_actions.py
+++ b/grc/gui_qt/components/undoable_actions.py
@@ -8,7 +8,7 @@ from .canvas.flowgraph import FlowgraphScene
 from .canvas.block import Block
 from ...core.base import Element
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 # Movement, rotation, enable/disable/bypass, bus ports,

--- a/grc/gui_qt/components/variable_editor.py
+++ b/grc/gui_qt/components/variable_editor.py
@@ -14,7 +14,7 @@ from ...core.base import Element
 from .canvas.flowgraph import FlowgraphScene
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class VariableEditorAction(Enum):

--- a/grc/gui_qt/components/wiki_tab.py
+++ b/grc/gui_qt/components/wiki_tab.py
@@ -26,7 +26,7 @@ from qtpy import QtWidgets
 from .. import base
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class WikiTab(QtWidgets.QDockWidget, base.Component):

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -51,7 +51,7 @@ from .dialogs import ErrorsDialog
 from ...core.base import Element
 
 # Logging
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.application.{__name__}")
 
 # Shortcuts
 Action = QtWidgets.QAction


### PR DESCRIPTION




<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
grc has the comman line option --log, which can be set to debug. Doing so enables the debug log in Application.py but not in the depending classes.
For debugging the output of the called classes  would be important,too.

In gtk-grc we have  similar problem. See #4628.

I ported the solution proposed in #4628 to the gui_qt part and it works well for these classes.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
#4628

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
