### PR TITLE
grc-qt: Set tabtext on save as

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -910,6 +910,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         log.debug("Adding flowgraph view")
 
         self.tabWidget.addTab(fg_view, "Untitled")
+        self.tabWidget.setCurrentIndex(self.tabWidget.count() - 1)
 
     def open_triggered(self, filename=None):
         log.debug("open")
@@ -967,6 +968,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
 
             log.info(f"Saved (as) {filename}")
             self.currentFlowgraphScene.set_saved(True)
+            self.tabWidget.setTabText(self.tabWidget.currentIndex(), os.path.basename(filename))
         else:
             log.debug("Cancelled Save As action")
         self.updateActions()


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
'Save as' does not affect the tab text. After this change the tab text is changed to the new filename.

'New' creates a new tab and sets the focus to the newly created tab


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
