### PR TITLE
PMT: remove wrapping of C++-specific types

### DIFF
--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1447,9 +1447,6 @@ void bind_pmt(py::module& m)
           D(assoc));
 
 
-    m.def("map", &::pmt::map, py::arg("proc"), py::arg("list").none(false), D(map));
-
-
     m.def("reverse", &::pmt::reverse, py::arg("list").none(false), D(reverse));
 
 

--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1570,12 +1570,6 @@ void bind_pmt(py::module& m)
           D(is_eof_object));
 
 
-    m.def("read", &::pmt::read, py::arg("port"), D(read));
-
-
-    m.def("write", &::pmt::write, py::arg("obj").none(false), py::arg("port"), D(write));
-
-
     m.def("write_string",
           &::pmt::write_string,
           py::arg("obj").none(false),
@@ -1583,17 +1577,6 @@ void bind_pmt(py::module& m)
 
 
     m.def("print", &::pmt::print, py::arg("v").none(false), D(print));
-
-
-    m.def("serialize",
-          &::pmt::serialize,
-          py::arg("obj").none(false),
-          py::arg("sink"),
-          D(serialize));
-
-
-    m.def("deserialize", &::pmt::deserialize, py::arg("source"), D(deserialize));
-
 
     m.def("dump_sizeof", &::pmt::dump_sizeof, D(dump_sizeof));
 

--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1401,19 +1401,6 @@ void bind_pmt(py::module& m)
 
     m.def("is_any", &::pmt::is_any, py::arg("obj").none(false), D(is_any));
 
-
-    m.def("make_any", &::pmt::make_any, py::arg("any"), D(make_any));
-
-
-    m.def("any_ref", &::pmt::any_ref, py::arg("obj").none(false), D(any_ref));
-
-
-    m.def("any_set",
-          &::pmt::any_set,
-          py::arg("obj").none(false),
-          py::arg("any"),
-          D(any_set));
-
     // m.def("is_msg_accepter",&pmt::is_msg_accepter,
     //     py::arg("obj")
     // );

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -836,9 +836,6 @@ class test_pmt(unittest.TestCase):
             pmt.assoc(pmt.PMT_NIL, None)
 
         with self.assertRaises(TypeError):
-            pmt.map(None, None)
-
-        with self.assertRaises(TypeError):
             pmt.reverse(None)
 
         with self.assertRaises(TypeError):

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -909,16 +909,10 @@ class test_pmt(unittest.TestCase):
             pmt.is_eof_object(None)
 
         with self.assertRaises(TypeError):
-            pmt.write(None, None)
-
-        with self.assertRaises(TypeError):
             pmt.write_string(None)
 
         with self.assertRaises(TypeError):
             pmt.print(None)
-
-        with self.assertRaises(TypeError):
-            pmt.serialize(None, None)
 
         with self.assertRaises(TypeError):
             pmt.length(None)

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -117,7 +117,7 @@ class test_pmt(unittest.TestCase):
         self.assertEqual(const, pmt.to_long(deser))
 
     def test15(self):
-        if(self.sizeof_long <= 4):
+        if (self.sizeof_long <= 4):
             return
         const = self.MAXINT32 + 1
         x_pmt = pmt.from_long(const)
@@ -144,7 +144,7 @@ class test_pmt(unittest.TestCase):
         self.assertEqual(const, x_long)
 
     def test18(self):
-        if(self.sizeof_long <= 4):
+        if (self.sizeof_long <= 4):
             return
         const = self.MININT32 - 1
         x_pmt = pmt.from_long(const)
@@ -795,12 +795,6 @@ class test_pmt(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             pmt.is_any(None)
-
-        with self.assertRaises(TypeError):
-            pmt.any_ref(None)
-
-        with self.assertRaises(TypeError):
-            pmt.any_set(None, None)
 
         with self.assertRaises(TypeError):
             pmt.is_pdu(None)


### PR DESCRIPTION
- PMT: there's no std::any in Python, don't pybind make_any, any_ref, _set
- PMT: don_t wrap C++ pmt_t(pmt_t) functor-consumping PMT map to Python
- PMT: don_t wrap C++ iostreams, std::streambufs to Python

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

C++ std::any has no correspondent type Python, so we shouldn't wrap it

Same for iostreams, streambuffers, and C functions of std::shared_ptr<pmt_base> to shared_ptr<pmt_base>

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #6967

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

PMT wrappings that never worked were removed

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Actually, tests were removed, namely those that check for type errors for the removed wrappers.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
