### PR TITLE
Feature/fix fft_filter.h doc string

### DIFF
--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -28,7 +28,7 @@ namespace kernel {
  *
  * \details
  * This block performs fast convolution using the
- * overlap-and-save algorithm. The filtering is performand in
+ * overlap-and-add algorithm. The filtering is performand in
  * the frequency domain instead of the time domain (see
  * gr::filter::kernel::fir_filter_fff). For an input signal x
  * and filter coefficients (taps) t, we compute y as:
@@ -141,7 +141,7 @@ public:
  *
  * \details
  * This block performs fast convolution using the
- * overlap-and-save algorithm. The filtering is performand in
+ * overlap-and-add algorithm. The filtering is performand in
  * the frequency domain instead of the time domain (see
  * gr::filter::kernel::fir_filter_ccc). For an input signal x
  * and filter coefficients (taps) t, we compute y as:
@@ -254,7 +254,7 @@ public:
  *
  * \details
  * This block performs fast convolution using the
- * overlap-and-save algorithm. The filtering is performand in
+ * overlap-and-add algorithm. The filtering is performand in
  * the frequency domain instead of the time domain (see
  * gr::filter::kernel::fir_filter_ccf). For an input signal x
  * and filter coefficients (taps) t, we compute y as:
@@ -351,7 +351,7 @@ public:
      * \details This value could be equal to ntaps, but we often
      * build a longer filter to allow us to calculate a more
      * efficient FFT. This value is the actual size of the filters
-     * used in the calculation of the overlap-and-save operation.
+     * used in the calculation of the overlap-and-add operation.
      */
     unsigned int filtersize() const;
 

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -260,7 +260,6 @@ int fft_filter_ccc::filter(int nitems, const gr_complex* input, gr_complex* outp
         d_invfft->execute(); // compute inv xform
 
         // add in the overlapping tail
-
         for (j = 0; j < tailsize(); j++)
             d_invfft->get_outbuf()[j] += d_tail[j];
 
@@ -394,7 +393,6 @@ int fft_filter_ccf::filter(int nitems, const gr_complex* input, gr_complex* outp
         d_invfft->execute(); // compute inv xform
 
         // add in the overlapping tail
-
         for (j = 0; j < tailsize(); j++)
             d_invfft->get_outbuf()[j] += d_tail[j];
 

--- a/gr-filter/python/filter/bindings/fft_filter_python.cc
+++ b/gr-filter/python/filter/bindings/fft_filter_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fft_filter.h)                                              */
-/* BINDTOOL_HEADER_FILE_HASH(209a90728e0accc2186c762cf484e0ad)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8b29f86b6e19b6f36e8ca9c989d51286)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
The doc strings describes the fft filter algorithm as overlap-and-save, but according to gr-filter/lib/fft_filter.cc on line 132, 264, 398 it's overlap-and-add.

fixes #5741

## Description
The fft filter header files has misleading information about how the FFT filter is working. Header file says it's overlap-save, but in the .cc file it describes overlap-add as far as I understood.

## Related Issue
Fixes #5741

## Which blocks/areas does this affect?
gr-filter

## Testing Done
Static code check, compilation of gnuradio

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
