### PR TITLE
modtool: (CMake) Install manifest and examples

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -129,6 +129,7 @@ add_custom_target(uninstall ${CMAKE_COMMAND} -P
 add_subdirectory(include/gnuradio/howto)
 add_subdirectory(lib)
 add_subdirectory(apps)
+add_subdirectory(examples)
 add_subdirectory(docs)
 # NOTE: manually update below to use GRC to generate C++ flowgraphs w/o python
 if(ENABLE_PYTHON)
@@ -150,3 +151,7 @@ configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/cmake/Modules/targetConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/Modules/${target}Config.cmake
     INSTALL_DESTINATION ${GR_CMAKE_DIR})
+
+install(FILES MANIFEST.md
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.md
+    DESTINATION share/gnuradio/manifests/howto)

--- a/gr-utils/modtool/templates/gr-newmod/examples/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES DESTINATION share/gnuradio/examples/howto)


### PR DESCRIPTION
This PR changes two things about gr_modtool's newmod templates:

1. Change the top-level CMakeLists.txt so that OOT install MANIFEST.md to `$PREFIX/share/gnuradio/manifests/abcdef/MANIFEST-1.2.3git.md` (in gr-abcdef's case), so that [GRC Qt's OOT](https://github.com/gnuradio/gnuradio/issues/7123) browser can find them.
2. Install examples to `$PREFIX/share/gnuradio/examples/abcdef/` such that [GRC Qt's example browser](https://github.com/gnuradio/gnuradio/issues/7117) can find them. (Disclaimer: OOT developers will probably have to add the examples manually, unless we want to glob)

Note: This PR is meant as a suggestion, and I'm very open for other ideas :)