### PR TITLE
sys_paths: use XDG_CONFIG_HOME if present, new API

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
         std::cout << gr::prefsdir() << std::endl;
 
     if (vm.count("userprefsdir") || print_all)
-        std::cout << gr::userconf_path() << std::endl;
+        std::cout << gr::paths::userconf() << std::endl;
 
     // Not included in print all due to verbosity
     if (vm.count("prefs"))

--- a/gnuradio-runtime/include/gnuradio/sys_paths.h
+++ b/gnuradio-runtime/include/gnuradio/sys_paths.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011,2013 Free Software Foundation, Inc.
+ * Copyright 2024 mboersch, Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -10,18 +11,51 @@
 #ifndef GR_SYS_PATHS_H
 #define GR_SYS_PATHS_H
 
+#include "api.h"
 #include <gnuradio/api.h>
+#include <filesystem>
 
 namespace gr {
+namespace paths {
+/*! \brief directory to create temporary files.
+ *
+ * On UNIX-oid systems, typically /tmp.
+ */
+GR_RUNTIME_API std::filesystem::path tmp();
+
+/*! \brief directory that stores user data; typicall $HOME
+ */
+GR_RUNTIME_API std::filesystem::path appdata();
+
+/*! \brief directory that stores configuration.
+ *
+ * Defaults to $XDG_CONFIG_HOME/gnuradio (fallback: appdata()/.config/gnuradio), but if
+ * that doesn't exist, checks the legacy path, appdata()/.gnuradio
+ */
+GR_RUNTIME_API std::filesystem::path userconf();
+
+/*! \brief directory to store non-portable caches (e.g. FFTW wisdom)
+ *
+ * Defaults to $XDG_CACHE_HOME, falls back to appdata()/cache
+ */
+GR_RUNTIME_API std::filesystem::path cache();
+
+/*! \brief directory to store persistent application state (e.g. window layouts, generated
+ *          GRC hier blocks)
+ */
+/*
+GR_RUNTIME_API std::filesystem::path persistent();
+*/
+} /* namespace  paths */
 
 //! directory to create temporary files
-GR_RUNTIME_API const char* tmp_path();
+[[deprecated("use gr::paths::tmp()")]] GR_RUNTIME_API const char* tmp_path();
 
 //! directory to store application data
-GR_RUNTIME_API const char* appdata_path();
+[[deprecated("use gr::paths::appdata()")]] GR_RUNTIME_API const char* appdata_path();
 
 //! directory to store user configuration
-GR_RUNTIME_API const char* userconf_path();
+[[deprecated("use gr::paths::userconf()")]] GR_RUNTIME_API const char* userconf_path();
 
 } /* namespace gr */
 

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2006,2013,2015 Free Software Foundation, Inc.
+ * Copyright 2024 mboersch, Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -65,7 +66,8 @@ std::vector<std::string> prefs::_sys_prefs_filenames()
     // Find if there is a ~/.gnuradio/config.conf file and add this to
     // the end of the file list to override any preferences in the
     // installed path config files.
-    fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    auto userconf =
+        gr::paths::userconf() / "config.conf"; // TODO move filename to constants
     if (fs::exists(userconf)) {
         fnames.push_back(userconf.string());
     }
@@ -141,7 +143,8 @@ void prefs::save()
     const std::string conf = to_string();
 
     // Write temp file.
-    const fs::path tmp = fs::path(gr::userconf_path()) / "config.conf.tmp";
+    const auto tmp =
+        gr::paths::userconf() / "config.conf.tmp"; // TODO move filename to constants
     std::ofstream fout(tmp);
     fout << conf;
     fout.close();
@@ -158,7 +161,7 @@ void prefs::save()
     }
 
     // Atomic rename.
-    const fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    const fs::path userconf = gr::paths::userconf() / "config.conf";
     fs::rename(tmp, userconf);
     // If fs::rename() fails, we'll leak the tempfile and throw. That's fine.
     // If the user wants it (it was written successfully) they can have it.

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011,2013 Free Software Foundation, Inc.
+ * Copyright 2024 mboersch, Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -8,69 +9,134 @@
  */
 
 #include <gnuradio/sys_paths.h>
+#include <type_traits>
+#include <algorithm>
 #include <cstdlib> //getenv
 #include <filesystem>
 
 namespace gr {
 
-const char* tmp_path()
+namespace paths {
+std::filesystem::path tmp()
 {
-    const char* path;
-
     // first case, try TMP environment variable
-    path = getenv("TMP");
-    if (path)
-        return path;
+    const char* path = getenv("TMP");
+    if (path) {
+        return { path };
+    }
 
-// second case, try P_tmpdir when its defined
+    // second case, try P_tmpdir when its defined
 #ifdef P_tmpdir
     if (P_tmpdir)
-        return P_tmpdir;
+        return { P_tmpdir };
 #endif /*P_tmpdir*/
 
     // fall-through case, nothing worked
-    return "/tmp";
+    return { "/tmp" };
 }
-
-const char* appdata_path()
+std::filesystem::path appdata()
 {
-    const char* path;
-
     // first case, try HOME environment variable (unix)
-    path = getenv("HOME");
-    if (path)
-        return path;
+    const char* path = getenv("HOME");
+    if (path) {
+        return { path };
+    }
 
     // second case, try APPDATA environment variable (windows)
     path = getenv("APPDATA");
-    if (path)
-        return path;
-
-    // fall-through case, nothing worked
-    return tmp_path();
-}
-
-std::string __userconf_path()
-{
-    const char* path;
-
-    // First determine if there is an environment variable specifying the prefs path
-    path = getenv("GR_PREFS_PATH");
-    std::filesystem::path p;
     if (path) {
-        p = path;
-    } else {
-        p = appdata_path();
-        p = p / ".gnuradio";
+        return { path };
     }
 
-    return p.string();
+    // fall-through case, nothing worked
+    return tmp();
+}
+std::filesystem::path userconf()
+{
+    namespace fs = std::filesystem;
+    // explicit env variable always wins
+    const char* path = getenv("GR_PREFS_PATH");
+    if (path) {
+        return { path };
+    }
+
+    // try $XDG_CONFIG_HOME/.config/gnuradio first
+    path = getenv("XDG_CONFIG_HOME");
+    fs::path xdg_path = (path ? fs::path{ path } : appdata() / ".config") / "gnuradio";
+    if (fs::exists(xdg_path) && fs::is_directory(fs::canonical(xdg_path))) {
+        // The new path is an existing directory – use it!
+        return xdg_path;
+    }
+
+    // try the old path second
+    auto legacy_path = appdata() / ".gnuradio";
+    if (fs::exists(legacy_path) && fs::is_directory(fs::canonical(legacy_path))) {
+        // The new path is an existing directory – use it!
+        return legacy_path;
+    }
+
+    // if neither new nor old path exist as directory, return the new one.
+    return xdg_path;
 }
 
-const char* userconf_path()
+std::filesystem::path cache()
 {
-    static std::string p(__userconf_path());
-    return p.c_str();
+    namespace fs = std::filesystem;
+    // explicit env variable always wins
+    const char* path = getenv("GR_CACHE_PATH");
+    if (path) {
+        return { path };
+    }
+    path = getenv("XDG_CACHE_HOME");
+    return (path ? fs::path{ path } : appdata() / ".cache") / "gnuradio";
 }
+} // namespace paths
+
+/* windows is peculiar: a path is typically a wstring with a not standard-specified
+ * encoding. C++ is peculiar. There's no single safe way to convert without copies
+ * that aren't necessary on most platforms. We're taking the sensible way out here,
+ * and go through an intermediate string if necessary.
+ */
+template <typename path_type, bool sane>
+struct converter {
+    /* we have to make this a template type, since partial function templates are
+     * impossible */
+    static const char* c_str(const path_type& path);
+};
+template <typename path_type>
+struct converter<path_type, true> {
+    static const char* c_str(const path_type& path)
+    {
+        return (new std::string(path.c_str()))->c_str();
+    }
+};
+template <typename path_type>
+struct converter<path_type, false> {
+    static const char* c_str(const path_type& path)
+    {
+        return (new std::string(path.string()))->c_str();
+    }
+};
+const char* convert_path_to_C_string(const std::filesystem::path& path)
+{
+    /* Yes. This is a memory leak. The only alternative would have been to return the data
+     * from a temporary string, which would have been a use-after-free. Notice that the
+     * const char*-returning API was broken from the start: the original tmpdir_path()
+     * used a static local variable to work around returning data from temporary objects;
+     * which is a very bad idea, becausea suddenly the value of some C string changes
+     * because someone somewhere else changed the environ. Like we need to do in unit
+     * tests to avoid messing up system configuration, in our highly multi-threaded
+     * framework.
+     */
+    return converter<
+        std::filesystem::path,
+        std::is_convertible<decltype(path.c_str()), const char*>::value>::c_str(path);
+}
+
+const char* tmp_path() { return convert_path_to_C_string(gr::paths::tmp()); }
+
+const char* appdata_path() { return convert_path_to_C_string(gr::paths::appdata()); }
+
+const char* userconf_path() { return convert_path_to_C_string(gr::paths::userconf()); }
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -31,17 +31,22 @@ namespace gr {
 template <typename string_type>
 static auto pathname(string_type key)
 {
-    return fs::path(gr::appdata_path()) / ".gnuradio" / "prefs" / key;
+    return gr::paths::userconf() / "prefs" / key;
 }
 
 static void ensure_dir_path()
 {
-    fs::path path = fs::path(gr::appdata_path()) / ".gnuradio";
-    if (!fs::is_directory(path))
-        fs::create_directory(path);
+    // recursively make sure the directory exists
+    fs::path path;
+    for (const auto& path_component : gr::paths::userconf()) {
+        path /= path_component;
+        if (!fs::exists(path)) {
+            fs::create_directory(path);
+        }
+    }
 
     path = path / "prefs";
-    if (!fs::is_directory(path))
+    if (!fs::exists(path))
         fs::create_directory(path);
 }
 

--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -31,7 +31,7 @@ if(ENABLE_TESTING)
     include(GrTest)
     file(GLOB py_qa_test_files "qa_*.py")
     set(py_qa_test_files qa_flowgraph.py qa_prefs.py qa_python_logging.py qa_random.py
-                         qa_tag_utils.py)
+                         qa_sys_paths.py qa_tag_utils.py)
     # This is a check for whether gr-blocks is enabled
     if(ENABLE_DEFAULT OR ENABLE_GR_BLOCKS)
         list(APPEND py_qa_test_files qa_hier_block2.py qa_uncaught_exception.py)

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/sys_paths_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/sys_paths_python.cc
@@ -13,8 +13,6 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(sys_paths.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d612f4abb40047c64395b4177ff3ae1f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -29,13 +27,33 @@ namespace py = pybind11;
 
 void bind_sys_paths(py::module& m)
 {
+    auto paths = m.def_submodule("paths", "GNU Radio default paths");
+    /* would have loved to #include <pybind11/stl/filesystem.h> and return the paths
+     * directly, but that requires a pybind11 too modern for Ubuntu20.04, so for now, just
+     * return the string representation. Let's not return different types depending on the
+     * version of a dependency.
+     *
+     * TODO: revisit 3.11
 
+    paths.def("tmp", &::gr::paths::tmp);
+    paths.def("appdata", &::gr::paths::appdata);
+    paths.def("userconf", &::gr::paths::userconf);
+    paths.def("cache", &::gr::paths::cache);
+    */
+    paths.def("tmp", []() { return gr::paths::tmp().u8string(); });
+    paths.def("appdata", []() { return gr::paths::appdata().u8string(); });
+    paths.def("userconf", []() { return gr::paths::userconf().u8string(); });
+    paths.def("cache", []() { return gr::paths::cache().u8string(); });
 
-    m.def("tmp_path", &::gr::tmp_path, D(tmp_path));
-
-
-    m.def("appdata_path", &::gr::appdata_path, D(appdata_path));
-
-
-    m.def("userconf_path", &::gr::userconf_path, D(userconf_path));
+    // Legacy interfaces, deprecated
+    m.def(
+        "tmp_path", []() { return ::gr::paths::tmp().string(); }, D(tmp_path));
+    m.def(
+        "appdata_path",
+        []() { return ::gr::paths::appdata().string(); },
+        D(appdata_path));
+    m.def(
+        "userconf_path",
+        []() { return ::gr::paths::userconf().string(); },
+        D(userconf_path));
 }

--- a/gnuradio-runtime/python/gnuradio/gr/qa_prefs.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_prefs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2019,2020 Free Software Foundation, Inc.
+# Copyright 2024 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -10,6 +11,7 @@
 
 
 from gnuradio import gr, gr_unittest
+import os
 
 
 class test_prefs (gr_unittest.TestCase):
@@ -23,6 +25,45 @@ class test_prefs (gr_unittest.TestCase):
         # At the time these tests are run, there is not necessarily a default
         # configuration on the build system, so not much to do with testing
         # here
+
+    def _test_env(self, env: str, subdir: [str, None] = None):
+        import tempfile
+        oldenv = os.getenv(env, "")
+        tmpdir = tempfile.mkdtemp()
+        if subdir:
+            os.mkdir(os.path.join(tmpdir, subdir))
+            conffile = os.path.join(tmpdir, subdir, "config.conf")
+        else:
+            conffile = os.path.join(tmpdir, "config.conf")
+        f = open(conffile, "w", encoding="utf-8")
+        f.write("[TEST_SECTION]\ncanary=alive\n")
+        f.close()
+        os.environ[env] = tmpdir
+        prefs = gr.prefs()
+        self.assertEqual(prefs.get_string("TEST_SECTION", "canary", "verydead"), "alive")
+        magicvalue = 1337
+        prefs.set_long("WRITE_SECTION", "value", magicvalue)
+        self.assertEqual(prefs.get_long("WRITE_SECTION", "value", 0), magicvalue)
+        self.assertEqual(prefs.get_string("TEST_SECTION", "canary", "verydead"), "alive")
+        os.unlink(conffile)
+        if subdir:
+            os.rmdir(os.path.join(tmpdir, subdir))
+        os.rmdir(tmpdir)
+        if oldenv:
+            os.putenv(env, oldenv)
+        else:
+            os.unsetenv(env)
+
+    def test_002_react_to_GR_PREFS_PATH(self):
+        self._test_env("GR_PREFS_PATH")
+
+    def test_003_react_to_XDG_CONFIG_HOME(self):
+        oldgrprefspath = os.getenv("GR_PREFS_PATH", None)
+        if oldgrprefspath:
+            os.unsetenv("GR_PREFS_PATH")
+        self._test_env("XDG_CONFIG_HOME", "gnuradio")
+        if oldgrprefspath:
+            os.putenv("GR_PREFS_PATH", oldgrprefspath)
 
 
 if __name__ == '__main__':

--- a/gnuradio-runtime/python/gnuradio/gr/qa_sys_paths.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_sys_paths.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Marcus Müller
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest
+import os
+
+
+class test_prefs (gr_unittest.TestCase):
+
+    def _test_env(self, env: str, subdir: [str, None] = None):
+        print(gr.paths.userconf())
+        import tempfile
+        oldenv = os.getenv(env, "")
+        tmpdir = tempfile.mkdtemp()
+        targetdir = tmpdir
+        if subdir:
+            targetdir = os.path.join(tmpdir, subdir)
+            os.mkdir(targetdir)
+        os.environ[env] = targetdir
+        self.assertEqual(str(gr.paths.userconf()), targetdir)
+        if subdir:
+            os.rmdir(targetdir)
+        os.rmdir(tmpdir)
+        if oldenv:
+            os.putenv(env, oldenv)
+        else:
+            os.unsetenv(env)
+
+    def test_001_members(self):
+        self.assertTrue(gr.paths.tmp())
+        self.assertTrue(gr.paths.appdata())
+        self.assertTrue(gr.paths.userconf())
+
+    def test_002_react_to_GR_PREFS_PATH(self):
+        self._test_env("GR_PREFS_PATH")
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_prefs)


### PR DESCRIPTION
## Description
- Introduced `gr::paths::` namespace to keep the different path getters
  together
  - new `cache()` getter, because FFTW wisdom should not clutter the
    home directory, but is also not portable state nor portable config
    (compare
    [`XDG_CACHE_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html))
- new path getters return `std::filesystem::path` instead of C string
- deprecated old getters, which now just call the new getters underneath
- Python wrappers
- added a unit test for the paths (was untested so far)
- added prefs path unit test for checking reaction to changing
  environment variables (prefs was completely untested)
- Fixed `vmcircbuf_prefs`, fftw wisdom that assumed existence of paths
- Replace deprecated API from in-tree usage
- As some configuration files move to subdirectories of directories not
  guaranteed to exist, create directories as needed

In this new configuration, `gr::paths::userconf()` (and the legacy,
`gr::userconf_path()`) tries to find the user configuration in the
following order:

1. `$GR_PREFS_PATH` if that environment variable is set
2. `$XDG_CONFIG_HOME/gnuradio`; if `$XDG_CONFIG_HOME` is set, and
   `$XDG_CONFIG_HOME/gnuradio` exists and is a directory
3. `appdata()/.config/gnuradio` (`appdata ~= $HOME`) if that exists and
   is a directory
4. `appdata()/.gnuradio` if that exists and is a directory
5. `$XDG_CONFIG_HOME/gnuradio` if `$XDG_CONFIG_HOME` is set
6. `appdata()/.config/gnuradio`

So, in other words: unless explicitly set to something else, try the new
XDG_CONFIG_HOME path, if that doesn't exist, try the old path, and if
neither exists, use the new one.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Supersedes #7073

(but still uses mboersch code, so copyright notices include mboersch)

Closes #3631

Looks at #1010, but makes only minor progress

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

- `gr::userconf_path()`: deprecated
- `gr::tmp_path()`: deprecated
- `gr::appdata_path()`: deprecated
- `gr::fft::fft`: stores wisdom no longer in `~/.gr_fftw_wisdom` but in
  `~/.cache/gnuradio/fftw_wisdom`
- `vmcircbuf_prefs`: instead of hard-coding `appdata()/.gnuradio/prefs/key`,
  uses `userconf()/prefs/key` (which is a bugfix, actually)

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

- wrote a sys path test
- wrote prefs tests (long overdue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.

## TODO

After merge of this: 

- Document on wiki (@duggabe will like that)
