### PR TITLE
ci: conda: Fix missing pkg_resources during modtool test (backport to maint-3.10)

### DIFF
--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -96,6 +96,7 @@ requirements:
   # below needed only to run tests in host environment
     - pytest
     - pyzmq
+    - setuptools
   run:
     - alsa-plugins  # [linux]
     - click


### PR DESCRIPTION
Backport #7128