### PR TITLE
grcqt: add missing xterm_executable to qsettings

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -1314,7 +1314,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         if self.currentView.process_is_done():
             self.generate_triggered()
             if self.currentView.generator:
-                xterm = self.platform.config.xterm_executable
+                xterm = self.app.qsettings.value("grc/xterm_executable","")
                 '''if self.config.xterm_missing() != xterm:
                     if not os.path.exists(xterm):
                         Dialogs.show_missing_xterm(main, xterm)

--- a/grc/gui_qt/resources/available_preferences.yml
+++ b/grc/gui_qt/resources/available_preferences.yml
@@ -10,6 +10,11 @@ categories:
         tooltip: Choose the editor
         dtype: str
         default: /usr/bin/gedit
+      - key: xterm_executable
+        name: Terminal
+        tooltip: Choose the Terminal app
+        dtype: str
+        default: /usr/bin/xterm
       - key: hide_variables
         name: Hide variables
         dtype: bool


### PR DESCRIPTION
The xterm_executable variable was part of Config.py and was removed with #https://github.com/gnuradio/gnuradio/commit/e10de5c71d473a29cb296348165eab2edf3c9c1e.

Replaces #7142