### PR TITLE
qtgui: remove num_inputs from qtgui_sink_x.block.yml

### DIFF
--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -93,7 +93,6 @@ parameters:
 inputs:
 -   domain: stream
     dtype: ${ type }
-    multiplicity: ${ num_inputs }
 -   domain: message
     id: freq
     optional: true


### PR DESCRIPTION
## Description
Remove num_inputs from Qt GUI Sink block yml file as the sink does not allow multiple inputs and doesn't have num_inputs defined, causing an error when opening a flowgraph that contains the Qt GUI Sink block.

## Related Issue
https://github.com/gnuradio/gnuradio/issues/7157

## Which blocks/areas does this affect?
Qt GUI Sink

## Testing Done
Error is not seen again after reopening the .grc
Trying to assign a second input to Qt GUI Sink now returns the expected error `Domain "stream" can have only one upstream block`

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. (Only 1 commit)
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. (Small change, I don't think any documentation needs to be added?)
- [x] I have added tests to cover my changes, and all previous tests pass. (No additional tests)
