### PR TITLE
cmake: Stop installing byte-compiled Python modules (backport to maint-3.10)

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -213,58 +213,50 @@ function(GR_PYTHON_INSTALL)
             DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
             ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS})
 
-        #create a list of all generated files
-        unset(pysrcfiles)
-        unset(pycfiles)
-        unset(pyofiles)
-        foreach(pyfile ${GR_PYTHON_INSTALL_FILES})
-            get_filename_component(pyfile ${pyfile} ABSOLUTE)
-            list(APPEND pysrcfiles ${pyfile})
+        if(ENABLE_TESTING)
+            # pyc files are generated in the build directory to support testing
 
-            #determine if this file is in the source or binary directory
-            file(RELATIVE_PATH source_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${pyfile})
-            string(LENGTH "${source_rel_path}" source_rel_path_len)
-            file(RELATIVE_PATH binary_rel_path ${CMAKE_CURRENT_BINARY_DIR} ${pyfile})
-            string(LENGTH "${binary_rel_path}" binary_rel_path_len)
+            #create a list of all generated files
+            unset(pysrcfiles)
+            unset(pycfiles)
+            foreach(pyfile ${GR_PYTHON_INSTALL_FILES})
+                get_filename_component(pyfile ${pyfile} ABSOLUTE)
+                list(APPEND pysrcfiles ${pyfile})
 
-            #and set the generated path appropriately
-            if(${source_rel_path_len} GREATER ${binary_rel_path_len})
-                set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${binary_rel_path})
-            else()
-                set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${source_rel_path})
+                #determine if this file is in the source or binary directory
+                file(RELATIVE_PATH source_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${pyfile})
+                string(LENGTH "${source_rel_path}" source_rel_path_len)
+                file(RELATIVE_PATH binary_rel_path ${CMAKE_CURRENT_BINARY_DIR} ${pyfile})
+                string(LENGTH "${binary_rel_path}" binary_rel_path_len)
+
+                #and set the generated path appropriately
+                if(${source_rel_path_len} GREATER ${binary_rel_path_len})
+                    set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${binary_rel_path})
+                else()
+                    set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${source_rel_path})
+                endif()
+                list(APPEND pycfiles ${pygenfile}c)
+
+                #ensure generation path exists
+                get_filename_component(pygen_path ${pygenfile} PATH)
+                file(MAKE_DIRECTORY ${pygen_path})
+
+            endforeach(pyfile)
+
+            if(NOT GR_PYTHON_INSTALL_DEPENDS)
+                set(GR_PYTHON_INSTALL_DEPENDS ${pysrcfiles})
             endif()
-            list(APPEND pycfiles ${pygenfile}c)
-            list(APPEND pyofiles ${pygenfile}o)
 
-            #ensure generation path exists
-            get_filename_component(pygen_path ${pygenfile} PATH)
-            file(MAKE_DIRECTORY ${pygen_path})
+            #the command to generate the pyc files
+            add_custom_command(
+                DEPENDS ${GR_PYTHON_INSTALL_DEPENDS}
+                OUTPUT ${pycfiles}
+                COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python_compile_helper.py
+                        ${pysrcfiles} ${pycfiles})
+            set(python_install_gen_targets ${pycfiles})
 
-        endforeach(pyfile)
-
-        if(NOT GR_PYTHON_INSTALL_DEPENDS)
-            set(GR_PYTHON_INSTALL_DEPENDS ${pysrcfiles})
-        endif()
-
-        #the command to generate the pyc files
-        add_custom_command(
-            DEPENDS ${GR_PYTHON_INSTALL_DEPENDS}
-            OUTPUT ${pycfiles}
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python_compile_helper.py
-                    ${pysrcfiles} ${pycfiles})
-
-        #the command to generate the pyo files
-        add_custom_command(
-            DEPENDS ${pysrcfiles}
-            OUTPUT ${pyofiles}
-            COMMAND
-                ${PYTHON_EXECUTABLE} -O ${PROJECT_BINARY_DIR}/python_compile_helper.py
-                ${pysrcfiles} ${pyofiles})
-
-        #create install rule and add generated files to target list
-        set(python_install_gen_targets ${pycfiles} ${pyofiles})
-        install(FILES ${python_install_gen_targets}
-                DESTINATION ${GR_PYTHON_INSTALL_DESTINATION})
+            gr_unique_target("pygen" ${python_install_gen_targets})
+        endif(ENABLE_TESTING)
 
         ####################################################################
     elseif(GR_PYTHON_INSTALL_DIRECTORY)
@@ -274,76 +266,72 @@ function(GR_PYTHON_INSTALL)
             DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
             ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS})
 
-        # collect all python files in given directories
-        # #############################################
-        unset(pysrcfiles)
-        foreach(pydir ${GR_PYTHON_INSTALL_DIRECTORY})
-            file(GLOB_RECURSE pysrcfiles_tmp "${pydir}/*.py")
-            list(APPEND pysrcfiles ${pysrcfiles_tmp})
-        endforeach(pydir)
+        if(ENABLE_TESTING)
+            # pyc files are generated in the build directory to support testing
 
-        # build target lists
-        # ##################
-        unset(pycfiles) # pyc targets
-        unset(pyofiles) # pyo targets
-        unset(pygen_paths) # all paths of py[oc] targets
-        foreach(pyfile ${pysrcfiles})
-            # determine if this file is in the source or binary directory
-            file(RELATIVE_PATH source_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${pyfile})
-            string(LENGTH "${source_rel_path}" source_rel_path_len)
-            file(RELATIVE_PATH binary_rel_path ${CMAKE_CURRENT_BINARY_DIR} ${pyfile})
-            string(LENGTH "${binary_rel_path}" binary_rel_path_len)
+            # collect all python files in given directories
+            # #############################################
+            unset(pysrcfiles)
+            foreach(pydir ${GR_PYTHON_INSTALL_DIRECTORY})
+                file(GLOB_RECURSE pysrcfiles_tmp "${pydir}/*.py")
+                list(APPEND pysrcfiles ${pysrcfiles_tmp})
+            endforeach(pydir)
 
-            # and set the generated path appropriately
-            if(${source_rel_path_len} GREATER ${binary_rel_path_len})
-                set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${binary_rel_path})
-            else()
-                set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${source_rel_path})
-            endif()
-            list(APPEND pycfiles "${pygenfile}c")
-            list(APPEND pyofiles "${pygenfile}o")
+            # build target lists
+            # ##################
+            unset(pycfiles) # pyc targets
+            unset(pygen_paths) # all paths of pyc targets
+            foreach(pyfile ${pysrcfiles})
+                # determine if this file is in the source or binary directory
+                file(RELATIVE_PATH source_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${pyfile})
+                string(LENGTH "${source_rel_path}" source_rel_path_len)
+                file(RELATIVE_PATH binary_rel_path ${CMAKE_CURRENT_BINARY_DIR} ${pyfile})
+                string(LENGTH "${binary_rel_path}" binary_rel_path_len)
 
-            get_filename_component(pygen_path "${pygenfile}" DIRECTORY)
-            list(APPEND pygen_paths "${pygen_path}")
-            file(MAKE_DIRECTORY "${pygen_path}")
-        endforeach(pyfile)
-        list(REMOVE_DUPLICATES pygen_paths)
-        list(SORT pygen_paths)
-
-        # generate the py[oc] files
-        # #########################
-        add_custom_command(
-            DEPENDS ${pysrcfiles}
-            OUTPUT ${pycfiles}
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python_compile_helper.py
-                    ${pysrcfiles} ${pycfiles})
-        add_custom_command(
-            DEPENDS ${pysrcfiles}
-            OUTPUT ${pyofiles}
-            COMMAND
-                ${PYTHON_EXECUTABLE} -O ${PROJECT_BINARY_DIR}/python_compile_helper.py
-                ${pysrcfiles} ${pyofiles})
-        set(python_install_gen_targets ${pycfiles} ${pyofiles})
-
-        # per-directory install rules
-        # ###########################
-        foreach(pygen_path ${pygen_paths})
-            # find all targets in that directory (no "list(FILTER ...)")
-            unset(pygen_path_targets)
-            foreach(pyget_target ${python_install_gen_targets})
-                get_filename_component(pyget_target_path "${pyget_target}" PATH)
-                if(pygen_path STREQUAL pyget_target_path)
-                    list(APPEND pygen_path_targets "${pyget_target}")
+                # and set the generated path appropriately
+                if(${source_rel_path_len} GREATER ${binary_rel_path_len})
+                    set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${binary_rel_path})
+                else()
+                    set(pygenfile ${CMAKE_CURRENT_BINARY_DIR}/${source_rel_path})
                 endif()
-            endforeach(pyget_target)
+                list(APPEND pycfiles "${pygenfile}c")
 
-            # install relative to current binary dir
-            file(RELATIVE_PATH pygen_path_rel "${CMAKE_CURRENT_BINARY_DIR}"
-                 "${pygen_path}")
-            list(SORT pygen_path_targets)
-            install(FILES ${pygen_path_targets}
-                    DESTINATION "${GR_PYTHON_INSTALL_DESTINATION}/${pygen_path_rel}")
-        endforeach(pygen_path)
+                get_filename_component(pygen_path "${pygenfile}" DIRECTORY)
+                list(APPEND pygen_paths "${pygen_path}")
+                file(MAKE_DIRECTORY "${pygen_path}")
+            endforeach(pyfile)
+            list(REMOVE_DUPLICATES pygen_paths)
+            list(SORT pygen_paths)
+
+            # generate the pyc files
+            # #########################
+            add_custom_command(
+                DEPENDS ${pysrcfiles}
+                OUTPUT ${pycfiles}
+                COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python_compile_helper.py
+                        ${pysrcfiles} ${pycfiles})
+            set(python_install_gen_targets ${pycfiles})
+
+            # per-directory install rules
+            # ###########################
+            foreach(pygen_path ${pygen_paths})
+                # find all targets in that directory (no "list(FILTER ...)")
+                unset(pygen_path_targets)
+                foreach(pyget_target ${python_install_gen_targets})
+                    get_filename_component(pyget_target_path "${pyget_target}" PATH)
+                    if(pygen_path STREQUAL pyget_target_path)
+                        list(APPEND pygen_path_targets "${pyget_target}")
+                    endif()
+                endforeach(pyget_target)
+
+                # install relative to current binary dir
+                file(RELATIVE_PATH pygen_path_rel "${CMAKE_CURRENT_BINARY_DIR}"
+                     "${pygen_path}")
+                list(SORT pygen_path_targets)
+            endforeach(pygen_path)
+
+            gr_unique_target("pygen" ${python_install_gen_targets})
+        endif(ENABLE_TESTING)
 
         ####################################################################
     elseif(GR_PYTHON_INSTALL_PROGRAMS)
@@ -386,9 +374,9 @@ function(GR_PYTHON_INSTALL)
                 ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS})
         endforeach(pyfile)
 
-    endif()
+        gr_unique_target("pygen" ${python_install_gen_targets})
 
-    gr_unique_target("pygen" ${python_install_gen_targets})
+    endif()
 
 endfunction(GR_PYTHON_INSTALL)
 


### PR DESCRIPTION
Backport #7078