### PR TITLE
PMT: remove wrapping of C++-specific types (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1447,9 +1447,6 @@ void bind_pmt(py::module& m)
           D(assoc));
 
 
-    m.def("map", &::pmt::map, py::arg("proc"), py::arg("list").none(false), D(map));
-
-
     m.def("reverse", &::pmt::reverse, py::arg("list").none(false), D(reverse));
 
 

--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1570,12 +1570,6 @@ void bind_pmt(py::module& m)
           D(is_eof_object));
 
 
-    m.def("read", &::pmt::read, py::arg("port"), D(read));
-
-
-    m.def("write", &::pmt::write, py::arg("obj").none(false), py::arg("port"), D(write));
-
-
     m.def("write_string",
           &::pmt::write_string,
           py::arg("obj").none(false),
@@ -1583,17 +1577,6 @@ void bind_pmt(py::module& m)
 
 
     m.def("print", &::pmt::print, py::arg("v").none(false), D(print));
-
-
-    m.def("serialize",
-          &::pmt::serialize,
-          py::arg("obj").none(false),
-          py::arg("sink"),
-          D(serialize));
-
-
-    m.def("deserialize", &::pmt::deserialize, py::arg("source"), D(deserialize));
-
 
     m.def("dump_sizeof", &::pmt::dump_sizeof, D(dump_sizeof));
 

--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1401,19 +1401,6 @@ void bind_pmt(py::module& m)
 
     m.def("is_any", &::pmt::is_any, py::arg("obj").none(false), D(is_any));
 
-
-    m.def("make_any", &::pmt::make_any, py::arg("any"), D(make_any));
-
-
-    m.def("any_ref", &::pmt::any_ref, py::arg("obj").none(false), D(any_ref));
-
-
-    m.def("any_set",
-          &::pmt::any_set,
-          py::arg("obj").none(false),
-          py::arg("any"),
-          D(any_set));
-
     // m.def("is_msg_accepter",&pmt::is_msg_accepter,
     //     py::arg("obj")
     // );

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -836,9 +836,6 @@ class test_pmt(unittest.TestCase):
             pmt.assoc(pmt.PMT_NIL, None)
 
         with self.assertRaises(TypeError):
-            pmt.map(None, None)
-
-        with self.assertRaises(TypeError):
             pmt.reverse(None)
 
         with self.assertRaises(TypeError):

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -909,16 +909,10 @@ class test_pmt(unittest.TestCase):
             pmt.is_eof_object(None)
 
         with self.assertRaises(TypeError):
-            pmt.write(None, None)
-
-        with self.assertRaises(TypeError):
             pmt.write_string(None)
 
         with self.assertRaises(TypeError):
             pmt.print(None)
-
-        with self.assertRaises(TypeError):
-            pmt.serialize(None, None)
 
         with self.assertRaises(TypeError):
             pmt.length(None)

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -117,7 +117,7 @@ class test_pmt(unittest.TestCase):
         self.assertEqual(const, pmt.to_long(deser))
 
     def test15(self):
-        if(self.sizeof_long <= 4):
+        if (self.sizeof_long <= 4):
             return
         const = self.MAXINT32 + 1
         x_pmt = pmt.from_long(const)
@@ -144,7 +144,7 @@ class test_pmt(unittest.TestCase):
         self.assertEqual(const, x_long)
 
     def test18(self):
-        if(self.sizeof_long <= 4):
+        if (self.sizeof_long <= 4):
             return
         const = self.MININT32 - 1
         x_pmt = pmt.from_long(const)
@@ -795,12 +795,6 @@ class test_pmt(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             pmt.is_any(None)
-
-        with self.assertRaises(TypeError):
-            pmt.any_ref(None)
-
-        with self.assertRaises(TypeError):
-            pmt.any_set(None, None)
 
         with self.assertRaises(TypeError):
             pmt.is_pdu(None)


### PR DESCRIPTION
Backport #7111