### PR TITLE
qtgui: remove num_inputs from qtgui_sink_x.block.yml (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -93,7 +93,6 @@ parameters:
 inputs:
 -   domain: stream
     dtype: ${ type }
-    multiplicity: ${ num_inputs }
 -   domain: message
     id: freq
     optional: true


### PR DESCRIPTION
Backport  #7159