### PR TITLE
gr-modtool: Handle regex in get_block_names for OOT API Post-3.8

### DIFF
--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -11,6 +11,7 @@
 
 import re
 import sys
+import os
 try:
     import readline
     have_readline = True
@@ -132,17 +133,14 @@ def get_modname():
 
 
 def get_block_names(pattern, modname):
-    """ Return a list of block names belonging to modname that matches the regex pattern. """
+    """ Return a list of cpp block names matches the regex pattern. """
     blocknames = []
     reg = re.compile(pattern)
-    fname_re = re.compile(r'[a-zA-Z]\w+\.\w{1,5}$')
-    with open(f'include/gnuradio/{modname}/CMakeLists.txt', 'r') as f:
-        for line in f.read().splitlines():
-            if len(line.strip()) == 0 or line.strip()[0] == '#':
-                continue
-            for word in re.split('[ /)(\t\n\r\f\v]', line):
-                if fname_re.match(word) and reg.search(word):
-                    blocknames.append(word.strip('.h'))
+    filename_re = re.compile(r'^(?!api)[a-zA-Z]\w+\.h$')
+    for _, _, filenames in os.walk('include/'):
+        for filename in filenames:
+            if filename_re.search(filename) and reg.search(filename):
+                blocknames.append(re.sub(r'.h$', '', filename))
     return blocknames
 
 


### PR DESCRIPTION
## Description
For OOT modules create with API Post-3.8, when using GR v3.10, will fail to find blocks using regex due to an invalid file path.  This is due to the header files moving from `/include/modname/...` to `/include/gnuradio/modname`.

This pr modifies the `get_block_names` function to search the  folder which has not changed between API Post-3.8 and Post-3.10.

## Related Issue
Fixes #7169

## Which blocks/areas does this affect?
- gr-modtool

## Testing Done

Tested various functions in gr_modtool:

- newmod
- add
- bind
- rm 

Specifically the functions that call `get_block_names` are `bind` and `rm`

These were tested on modules created using API Post-3.8 (GR v3.9) and using API Post-3.10 (GR v3.10).  

The program works as expected in all of these cases for both API versions. The bind command with no arguments properly parses the existing blocks and generates the bindings.  A build, install, and load into grc was run, which completed with no errors, to ensure the bindings were created successfully.  The rm command also successfully detected and removed blocks using the regex in `get_block_names`.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
