### PR TITLE
grcqt: avoid FileNotFoundError on grc startup

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -161,10 +161,13 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.setCentralWidget(self.tabWidget)
 
         files_open = list(self.app.qsettings.value('window/files_open', []))
+        grc_file_found = False
         if files_open:
             for file in files_open:
-                self.open_triggered(file)
-        else:
+                if os.path.isfile(file):
+                    self.open_triggered(file)
+                    grc_file_found = True
+        if not grc_file_found:
             self.new_triggered()
 
         self.clipboard = None


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
If a recently used grc file was deleted, grc does not start anymore.

```
  File "/usr/local/gnuradio/lib64/python3.11/site-packages/gnuradio/grc/gui_qt/components/window.py", line 166, in __init__
    self.open_triggered(file)
  File "/usr/local/gnuradio/lib64/python3.11/site-packages/gnuradio/grc/gui_qt/components/window.py", line 940, in open_triggered
    initial_state = self.platform.parse_flow_graph(filename)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/gnuradio/lib64/python3.11/site-packages/gnuradio/grc/core/platform.py", line 337, in parse_flow_graph
    with open(filename, encoding='utf-8') as fp:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 918, in open
FileNotFoundError: [Errno 2] Datei oder Verzeichnis nicht gefunden: '/tmp/missingtest.grc'
```