### PR TITLE
Fix MinGW build and std::fs issue

### DIFF
--- a/gnuradio-runtime/include/gnuradio/sys_paths.h
+++ b/gnuradio-runtime/include/gnuradio/sys_paths.h
@@ -46,6 +46,17 @@ GR_RUNTIME_API std::filesystem::path cache();
 /*
 GR_RUNTIME_API std::filesystem::path persistent();
 */
+
+namespace utilities {
+/*
+ * \brief Make sure the specified path exists; create directories recursively if
+ * necessary.
+ *
+ * \return true if the directory existed, false if the directory had to be created
+ *
+ */
+GR_RUNTIME_API bool ensure_directory(const std::filesystem::path& path);
+} // namespace utilities
 } /* namespace  paths */
 
 //! directory to create temporary files

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -90,6 +90,29 @@ std::filesystem::path cache()
     path = getenv("XDG_CACHE_HOME");
     return (path ? fs::path{ path } : appdata() / ".cache") / "gnuradio";
 }
+
+namespace utilities {
+bool ensure_directory(const std::filesystem::path& path)
+{
+    namespace fs = std::filesystem;
+
+    // short-circuit for the common case that the path exists
+    if (fs::is_directory(path)) {
+        return true;
+    }
+
+    bool existed = true;
+    fs::path partial_path;
+    for (const auto& path_component : path) {
+        partial_path /= path_component;
+        if (!(existed && fs::exists(partial_path))) {
+            fs::create_directory(partial_path);
+            existed = false;
+        }
+    }
+    return existed;
+}
+} // namespace utilities
 } // namespace paths
 
 /* windows is peculiar: a path is typically a wstring with a not standard-specified

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -34,22 +34,6 @@ static auto pathname(string_type key)
     return gr::paths::userconf() / "prefs" / key;
 }
 
-static void ensure_dir_path()
-{
-    // recursively make sure the directory exists
-    fs::path path;
-    for (const auto& path_component : gr::paths::userconf()) {
-        path /= path_component;
-        if (!fs::exists(path)) {
-            fs::create_directory(path);
-        }
-    }
-
-    path = path / "prefs";
-    if (!fs::exists(path))
-        fs::create_directory(path);
-}
-
 template <typename stream_t>
 static void
 log_ioerror(const std::string& who, const fs::path& path, const stream_t& stream)
@@ -84,7 +68,8 @@ void vmcircbuf_prefs::set(std::string_view key, std::string_view value)
     logger.set_level(logging::singleton().default_level());
     gr::thread::scoped_lock guard(s_vm_mutex);
 
-    ensure_dir_path();
+    // recursively make sure the directory exists
+    gr::paths::utilities::ensure_directory(gr::paths::userconf() / "prefs");
     auto path = pathname(key);
 
     std::ofstream out_file(path, std::ios::out | std::ios::binary | std::ios::trunc);

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/sys_paths_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/sys_paths_python.cc
@@ -56,4 +56,13 @@ void bind_sys_paths(py::module& m)
         "userconf_path",
         []() { return ::gr::paths::userconf().string(); },
         D(userconf_path));
+
+    // wrap the utilities
+    auto utilities = paths.def_submodule("utilities", "GNU Radio File System Utilities");
+    utilities.def(
+        "ensure_directory",
+        [](const std::string& p) {
+            return gr::paths::utilities::ensure_directory({ p });
+        },
+        py::arg("path"));
 }

--- a/gnuradio-runtime/python/gnuradio/gr/qa_sys_paths.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_sys_paths.py
@@ -11,13 +11,12 @@
 
 from gnuradio import gr, gr_unittest
 import os
+import tempfile
 
 
-class test_prefs (gr_unittest.TestCase):
+class test_prefs(gr_unittest.TestCase):
 
     def _test_env(self, env: str, subdir: [str, None] = None):
-        print(gr.paths.userconf())
-        import tempfile
         oldenv = os.getenv(env, "")
         tmpdir = tempfile.mkdtemp()
         targetdir = tmpdir
@@ -42,6 +41,26 @@ class test_prefs (gr_unittest.TestCase):
     def test_002_react_to_GR_PREFS_PATH(self):
         self._test_env("GR_PREFS_PATH")
 
+    def test_003_ensure_directory(self):
+        import shutil
 
-if __name__ == '__main__':
+        cwd = os.getcwd()
+        self.assertTrue(gr.paths.utilities.ensure_directory(cwd))
+        tmpdir = tempfile.mkdtemp()
+        self.assertTrue(gr.paths.utilities.ensure_directory(tmpdir))
+        components = (
+            tmpdir,
+            "in the jungle the mighty jungle",
+            "the lion sleeps tonight",
+        )
+        target = os.path.join(*components)
+        self.assertFalse(os.path.exists(target))
+        self.assertFalse(gr.paths.utilities.ensure_directory(target))
+        self.assertTrue(gr.paths.utilities.ensure_directory(target))
+        self.assertTrue(os.path.exists(target))
+        shutil.rmtree(tmpdir)
+        self.assertFalse(os.path.exists(target))
+
+
+if __name__ == "__main__":
     gr_unittest.run(test_prefs)

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -70,7 +70,7 @@ static void wisdom_lock_init()
         }
     }
     const auto wisdom_lock_file = path / WISDOM_LOCKFILE;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
     int fd = open(wisdom_lock_file.string().c_str(),
                   O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK,
                   0666);
@@ -104,7 +104,7 @@ static void unlock_wisdom()
 static void import_wisdom()
 {
     auto wisdom_path = gr::paths::cache() / WISDOM_FILENAME;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
     FILE* fp = fopen(wisdom_path.string().c_str(), "r");
 #else
     FILE* fp = fopen(wisdom_path.c_str(), "r");
@@ -136,7 +136,7 @@ static void config_threading(int nthreads)
 static void export_wisdom()
 {
     auto wisdom_path = gr::paths::cache() / WISDOM_FILENAME;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
     FILE* fp = fopen(wisdom_path.string().c_str(), "w");
 #else
     FILE* fp = fopen(wisdom_path.c_str(), "w");

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -61,15 +61,8 @@ static void wisdom_lock_init()
     if (wisdom_lock_init_done)
         return;
 
-    // recursively make sure the directory exists
-    fs::path path;
-    for (const auto& path_component : gr::paths::cache()) {
-        path /= path_component;
-        if (!fs::exists(path)) {
-            fs::create_directory(path);
-        }
-    }
-    const auto wisdom_lock_file = path / WISDOM_LOCKFILE;
+    gr::paths::utilities::ensure_directory(gr::paths::cache());
+    const auto wisdom_lock_file = gr::paths::cache() / WISDOM_LOCKFILE;
 #if defined(_MSC_VER) || defined(_WIN32)
     int fd = open(wisdom_lock_file.string().c_str(),
                   O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK,


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

GNU Radio ain't done if Gqrx ain't run, or so.

- fft: check for _WIN32, not only for _MSC_VER
- runtime/sys_paths: helper function for ensuring paths exist, recursively
- syspaths/ensure directory exists: MinGW Drive Letter workaround

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Closes #7194
Closes #7156

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Needed to centralize the creation of config/storage paths, so introduced new API function `gr::paths::utilities::ensure_directory`. Then, moved the bespoke directory creation out of the circbuf prefs and fft.cc.

So, this affects

- MinGW builds
- fft.cc
- circbuf prefs

but none of that in a way that changes current behaviour

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

added test, coordinated with @argilo to get a Gqrx test build

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
