### PR TITLE
grc-qt: Keep block rotation in [0.0, 360)

### DIFF
--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -402,7 +402,7 @@ class GUIBlock(QGraphicsItem):
 
     def rotate(self, rotation):
         log.debug(f"Rotating {self.core.name}")
-        new_rotation = self.rotation() + rotation
+        new_rotation = (self.rotation() + rotation) % 360
         self.setRotation(new_rotation)
         self.core.states["rotation"] = new_rotation
         self.create_shapes_and_labels()


### PR DESCRIPTION
Use modulo 360 for block rotation in Qt GRC

Fixes #7200 