### PR TITLE
grc-qt: custom_block_paths set but not used

### DIFF
--- a/grc/gui_qt/Config.py
+++ b/grc/gui_qt/Config.py
@@ -1,6 +1,9 @@
 import os
+from os.path import expanduser, normpath, expandvars, exists
+from collections import OrderedDict
 
 from ..core.Config import Config as CoreConfig
+from qtpy import QtCore
 
 
 class Config(CoreConfig):
@@ -13,7 +16,29 @@ class Config(CoreConfig):
     def __init__(self, install_prefix, *args, **kwargs):
         CoreConfig.__init__(self, *args, **kwargs)
         self.install_prefix = install_prefix
+        self.qsettings = QtCore.QSettings(self.gui_prefs_file, QtCore.QSettings.IniFormat)
 
     @property
     def wiki_block_docs_url_prefix(self):
         return self._gr_prefs.get_string('grc-docs', 'wiki_block_docs_url_prefix', '')
+
+    @property
+    def block_paths(self):
+        paths_sources = (
+            self.hier_block_lib_dir,
+            os.environ.get('GRC_BLOCKS_PATH', ''),
+            self._gr_prefs.get_string('grc', 'local_blocks_path', ''),
+            self._gr_prefs.get_string('grc', 'global_blocks_path', ''),
+            self.qsettings.value('grc/custom_block_paths', ''),
+        )
+
+        collected_paths = sum((paths.split(os.pathsep)
+                               for paths in paths_sources), [])
+
+        valid_paths = [normpath(expanduser(expandvars(path)))
+                       for path in collected_paths if exists(path)]
+        # Deduplicate paths to avoid warnings about finding blocks twice, but
+        # preserve order of paths
+        valid_paths = list(OrderedDict.fromkeys(valid_paths))
+
+        return valid_paths


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Preferences contains a custom_block_paths setting. But this setting is not used to find a block.
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Set the custom_block_paths in preferences. Restart grc and have a look at grc.log to see the block_paths.
