### PR TITLE
grc-qt: fix  Blocks rotated 180° are upside down

### DIFF
--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -284,6 +284,13 @@ class GUIBlock(QGraphicsItem):
             painter.setPen(Qt.black)
         else:
             painter.setPen(Qt.red)
+
+        # Adjust the painter if parent block is 180 degrees rotated
+        if self.rotation() == 180:
+            painter.translate(self.width / 2, self.height / 2)
+            painter.rotate(180)
+            painter.translate(-self.width / 2, -self.height / 2)
+
         painter.drawText(
             QRectF(0, 0 - self.height / 2 + 15, self.width, self.height),
             Qt.AlignCenter,

--- a/grc/gui_qt/components/canvas/port.py
+++ b/grc/gui_qt/components/canvas/port.py
@@ -126,6 +126,13 @@ class GUIPort(QGraphicsItem):
         if self._show_label:
             painter.setPen(QPen(1))
             painter.setFont(self.font)
+
+            # Adjust the painter if parent block is 180 degrees rotated
+            if self.parentItem().rotation() == 180:
+                painter.translate(self.width / 2, self.height / 2)
+                painter.rotate(180)
+                painter.translate(-self.width / 2, -self.height / 2)
+
             if self.core._dir == "sink":
                 painter.drawText(QRectF(-max(0, self.width - 15), 0, self.width,
                                  self.height), Qt.AlignCenter, self.core.name)


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Blocks rotated 180 degrees are visually upside-down, the same for the ports label.
This is fixed by checking whether the parent block is 180 degrees rotated and thus adjusting the painter to draw text.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fix #7203
Minor-Issue of #6957 
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
grc-qt/component/canvas

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Did UI test

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
