### PR TITLE
grc-qt: fix sink ports labels alignment after 180 rotation

### DIFF
--- a/grc/gui_qt/components/canvas/port.py
+++ b/grc/gui_qt/components/canvas/port.py
@@ -118,25 +118,32 @@ class GUIPort(QGraphicsItem):
         painter.setPen(pen)
         painter.setBrush(QBrush(self._bg_color))
 
+        # TODO: should boundingRect() be used here ?
         if self.core._dir == "sink":
             rect = QRectF(-max(0, self.width - 15), 0, self.width, self.height)
         else:
             rect = QRectF(0, 0, self.width, self.height)
         painter.drawRect(rect)
 
+        # TODO: Adjustments for finer rotation values if required (eg. 15, 30)
+        block_rotation = self.parentItem().rotation()
+
         if self._show_label:
             painter.setPen(QPen(1))
             painter.setFont(self.font)
 
             # Adjust the painter if parent block is 180 degrees rotated
-            if self.parentItem().rotation() == 180:
-                painter.translate(self.width / 2, self.height / 2)
+            if block_rotation == 180:
+                painter.translate(self.width, self.height)
                 painter.rotate(180)
-                painter.translate(-self.width / 2, -self.height / 2)
 
             if self.core._dir == "sink":
-                painter.drawText(QRectF(-max(0, self.width - 15), 0, self.width,
-                                 self.height), Qt.AlignCenter, self.core.name)
+                if block_rotation == 180:
+                    painter.drawText(QRectF(max(0, self.width - 15), 0, self.width,
+                                     self.height), Qt.AlignCenter, self.core.name)
+                else:
+                    painter.drawText(QRectF(-max(0, self.width - 15), 0, self.width,
+                                     self.height), Qt.AlignCenter, self.core.name)
             else:
                 painter.drawText(QRectF(0, 0, self.width, self.height), Qt.AlignCenter, self.core.name)
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
The PR  #7206 fixes the upside issue and port labels in blocks with only one sink (in) port. 
Unexpectedly, for multiple sinks (in) ports, the port labels are not aligned properly.

Check the left image (before) and right (after) of this PR's commits.

![Screenshot from 2024-03-23 04-47-51](https://github.com/gnuradio/gnuradio/assets/96142751/c785b3bb-8289-49be-b762-4a57240f117a)

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
 #7203

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gui_qt/components/canvas

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Did UI Test

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
