### PR TITLE
grc:Notify user when GRC file was last opened in older GNU Radio

### DIFF
--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -263,6 +263,8 @@ class MainWindow(Gtk.ApplicationWindow):
                 flow_graph=flow_graph,
                 file_path=file_path,
             )
+            page.check_grc_version()
+
             if getattr(Messages, 'flowgraph_error') is not None:
                 Messages.send(
                     ">>> Check: {}\n>>> FlowGraph Error: {}\n".format(

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -15,7 +15,7 @@ from . import Actions
 from .StateCache import StateCache
 from .Constants import MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT
 from .DrawingArea import DrawingArea
-
+from .Dialogs import MessageDialogWrapper
 
 log = logging.getLogger(__name__)
 
@@ -89,13 +89,15 @@ class Page(Gtk.HBox):
 
         self.process = None
         self.saved = True
+        self.popup_dialogue = None
+
         if not self.file_path:
             self.saved = False
 
         # import the file
-        initial_state = flow_graph.parent_platform.parse_flow_graph(file_path)
-        flow_graph.import_data(initial_state)
-        self.state_cache = StateCache(initial_state)
+        self.initial_state = flow_graph.parent_platform.parse_flow_graph(file_path)
+        flow_graph.import_data(self.initial_state)
+        self.state_cache = StateCache(self.initial_state)
 
         # tab box to hold label and close button
         self.label = Gtk.Label()
@@ -130,6 +132,62 @@ class Page(Gtk.HBox):
         self.scrolled_window.add(self.viewport)
         self.pack_start(self.scrolled_window, True, True, 0)
         self.show_all()
+
+    def check_grc_version(self):
+        """
+        comparing current gr version from grc file metadata with current gr version,
+        then show message dialog popup to notify if the current grc file use older GNU Radio version
+        """
+        # if the filepath is empty, check nothing
+        if self.file_path == '':
+            return
+
+        grc_version = self.initial_state['metadata'].get('grc_version')
+        if grc_version:
+            a, b, c, d = grc_version.split('.')
+
+            # to handle version number like v3.11.0.0git-684-g2dc3320d
+            # we need read until first alphabet to get version number d
+            tmp = ''
+            for i in d:
+                if i.isnumeric():
+                    tmp += i
+                else:
+                    break
+
+            a = int(a[1:])
+            b = int(b)
+            c = int(c)
+            d = int(tmp)
+
+            current_version = self.main_window._platform.config.version
+            platform_a, platform_b, platform_c, platform_d = current_version.split('.')
+            tmp = ''
+            for i in platform_d:
+                if i.isnumeric():
+                    tmp += i
+                else:
+                    break
+
+            platform_a = int(platform_a[1:])
+            platform_b = int(platform_b)
+            platform_c = int(platform_c)
+            platform_d = int(tmp)
+            if a < platform_a or b < platform_b or c < platform_c or d < platform_d:
+                title = "Old GR Version Detected"
+                msg = "Your GRC file from GNU Radio version {} (current GNU Radio version: {})\n".format(
+                    grc_version, current_version)
+
+                self.popup_dialogue = MessageDialogWrapper(
+                    parent=None,
+                    message_type=Gtk.MessageType.WARNING,
+                    buttons=Gtk.ButtonsType.CLOSE,
+                    title=title,
+                    markup=msg
+                )
+
+        if self.popup_dialogue:
+            self.popup_dialogue.run_and_destroy()
 
     def _handle_scroll_window_key_press(self, widget, event):
         is_ctrl_pg = (

--- a/grc/gui_qt/components/dialogs.py
+++ b/grc/gui_qt/components/dialogs.py
@@ -8,7 +8,7 @@ from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import (QLineEdit, QDialog, QDialogButtonBox, QTreeView,
                             QVBoxLayout, QTabWidget, QGridLayout, QWidget, QLabel,
                             QPushButton, QListWidget, QComboBox, QPlainTextEdit, QHBoxLayout,
-                            QFileDialog, QApplication)
+                            QMessageBox, QFileDialog, QApplication)
 
 
 class ErrorsDialog(QDialog):
@@ -195,3 +195,12 @@ class PropsDialog(QDialog):
             ex = self.example_list.currentItem()
         self._block.parent.gui.app.MainWindow.open_example(ex.text())
         self.close()
+
+
+class MessageDialog(QMessageBox):
+    def __init__(self, parent, title, message):
+        super().__init__(parent)
+        self.setIcon(QMessageBox.Warning)
+        self.setWindowTitle(title)
+        self.setText(message)
+        self.setStandardButtons(QMessageBox.Close)

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -50,7 +50,7 @@ from .undoable_actions import (
 )
 from .preferences import PreferencesDialog
 from .oot_browser import OOTBrowser
-from .dialogs import ErrorsDialog
+from .dialogs import ErrorsDialog, MessageDialog
 from ...core.base import Element
 
 # Logging
@@ -950,6 +950,8 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             self.currentFlowgraphScene.saved = True
             self.currentFlowgraphScene.save_allowed = save_allowed
 
+        self.check_grc_version(initial_state, filename)
+
     def open_example(self, example_path):
         log.debug("open example")
         if example_path:
@@ -1038,7 +1040,8 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         else:
             message = None
             if file_path:
-                message = f"Save changes to {os.path.basename(file_path)} before closing? Your changes will be lost otherwise."
+                message = (f"Save changes to {os.path.basename(file_path)}"
+                           f"before closing? Your changes will be lost otherwise.")
             else:
                 message = "This flowgraph has not been saved"  # TODO: Revise text
 
@@ -1519,3 +1522,50 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         log.info("Stopping profiler")
         stats = pstats.Stats(self.profiler)
         stats.dump_stats('stats.prof')
+
+    def check_grc_version(self, initial_state, filename):
+        """
+        comparing current gr version from grc file metadata with current gr version,
+        then show message dialog popup to notify if the current grc file use older GNU Radio version
+        """
+        # if the filepath is empty, check nothing
+        if filename == '':
+            return
+
+        grc_version = initial_state['metadata'].get('grc_version')
+        if grc_version:
+            a, b, c, d = grc_version.split('.')
+            # to handle version number like v3.11.0.0git-684-g2dc3320d
+            # we need read until first alphabet to get version number d
+            tmp = ''
+            for i in d:
+                if i.isnumeric():
+                    tmp += i
+                else:
+                    break
+
+            a = int(a[1:])
+            b = int(b)
+            c = int(c)
+            d = int(tmp)
+
+            current_version = self.platform.config.version
+            platform_a, platform_b, platform_c, platform_d = current_version.split('.')
+            tmp = ''
+            for i in platform_d:
+                if i.isnumeric():
+                    tmp += i
+                else:
+                    break
+
+            platform_a = int(platform_a[1:])
+            platform_b = int(platform_b)
+            platform_c = int(platform_c)
+            platform_d = int(tmp)
+            if a < platform_a or b < platform_b or c < platform_c or d < platform_d:
+                title = "Old GR Version Detected"
+                msg = "Your GRC file from GNU Radio version {} (current GNU Radio version: {})\n".format(
+                    grc_version, current_version)
+
+                popup_dialogue = MessageDialog(parent=None, title=title, message=msg)
+                popup_dialogue.exec()


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Newer versions of GNU Radio might introduce potential behavioral changes compared to older versions.
This PR will make grc notify user if the grc file was last opened in older GNU Radio Version

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes [#5561](https://github.com/gnuradio/gnuradio/issues/5561)

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gtk gui MainWindow: call function to check grc version
gtk gui Notebook: implement grc version checker here
qt gui dialogs component: implement MessageDialog class
qt gui window: implement grc version checker here

note: also refactor few lines in function close_triggered on qt gui window file due to fix python autoformatter problem

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
UI Test on gtk and qt gui
how testing is done: 
1. Change grc_version on metadata grc file
2. try to open this file
3. do this on both gui library (gtk and qt)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
