### PR TITLE
fec/polar decoder: replaced cout/printf with fmt::print (backport to maint-3.10)

### DIFF
--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -16,8 +16,7 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 
-#include <cstdio>
-#include <iostream>
+#include <spdlog/fmt/fmt.h>
 
 namespace gr {
 namespace fec {
@@ -167,12 +166,11 @@ void polar_decoder_common::extract_info_bits(unsigned char* output,
 void polar_decoder_common::print_pretty_llr_vector(const float* llr_vec) const
 {
     for (int row = 0; row < block_size(); row++) {
-        // FIXME this is an interesting mixture of iostream and stdio
-        std::cout << row << "->" << int(bit_reverse(row, block_power())) << ":\t";
+        fmt::print("{}->{}:\t", row, static_cast<int>(bit_reverse(row, block_power())));
         for (int stage = 0; stage < block_power() + 1; stage++) {
-            printf("%+4.2f, ", llr_vec[(stage * block_size()) + row]);
+            fmt::print("{:+4.2f}, ", llr_vec[(stage * block_size()) + row]);
         }
-        std::cout << std::endl;
+        fmt::print("{}\n", "");
     }
 }
 


### PR DESCRIPTION
Backport #7188