### PR TITLE
runtime and fft: use create_directories() instead of iterating

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -37,17 +37,8 @@ static auto pathname(string_type key)
 static void ensure_dir_path()
 {
     // recursively make sure the directory exists
-    fs::path path;
-    for (const auto& path_component : gr::paths::userconf()) {
-        path /= path_component;
-        if (!fs::exists(path)) {
-            fs::create_directory(path);
-        }
-    }
-
-    path = path / "prefs";
-    if (!fs::exists(path))
-        fs::create_directory(path);
+    fs::path path = gr::paths::userconf() / "prefs";
+    fs::create_directories(path);
 }
 
 template <typename stream_t>

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -62,22 +62,12 @@ static void wisdom_lock_init()
         return;
 
     // recursively make sure the directory exists
-    fs::path path;
-    for (const auto& path_component : gr::paths::cache()) {
-        path /= path_component;
-        if (!fs::exists(path)) {
-            fs::create_directory(path);
-        }
-    }
+    fs::path path = gr::paths::cache();
+    fs::create_directories(path);
     const auto wisdom_lock_file = path / WISDOM_LOCKFILE;
-#ifdef _MSC_VER
     int fd = open(wisdom_lock_file.string().c_str(),
                   O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK,
                   0666);
-#else
-    int fd =
-        open(wisdom_lock_file.c_str(), O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK, 0666);
-#endif
     if (fd < 0) {
         throw std::runtime_error("Failed to create FFTW wisdom lockfile: " +
                                  wisdom_lock_file.string());
@@ -104,11 +94,7 @@ static void unlock_wisdom()
 static void import_wisdom()
 {
     auto wisdom_path = gr::paths::cache() / WISDOM_FILENAME;
-#ifdef _MSC_VER
     FILE* fp = fopen(wisdom_path.string().c_str(), "r");
-#else
-    FILE* fp = fopen(wisdom_path.c_str(), "r");
-#endif
     if (fp != 0) {
         int r = fftwf_import_wisdom_from_file(fp);
         fclose(fp);
@@ -136,11 +122,7 @@ static void config_threading(int nthreads)
 static void export_wisdom()
 {
     auto wisdom_path = gr::paths::cache() / WISDOM_FILENAME;
-#ifdef _MSC_VER
     FILE* fp = fopen(wisdom_path.string().c_str(), "w");
-#else
-    FILE* fp = fopen(wisdom_path.c_str(), "w");
-#endif
     if (fp != 0) {
         fftwf_export_wisdom_to_file(fp);
         fclose(fp);


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Iterating while creating subdirs in a path was causing problems for MinGW, an is not necessary. Replace with `create_directories()`.

Also use the same fopen() parameters with or without _MSC_VER.

## Related Issue
Fixes #7156

## Which blocks/areas does this affect?
- runtime vmcircbuf config
- fft

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
