### PR TITLE
runtime: Fix compiler warnings

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
@@ -28,7 +28,7 @@ namespace gr {
 
 #ifdef HAVE_CREATEFILEMAPPING
 // Print Windows error (could/should be global?)
-static void werror(char* where, DWORD last_error)
+static void werror(const char* where, DWORD last_error)
 {
     char buf[1024];
 


### PR DESCRIPTION
## Description
MinGW reports several warnings while building `vmcircbuf_createfilemapping.cc`:
```
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc: In constructor 'gr::vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(size_t)':
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc:91:16: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
   91 |         werror("gr::vmcircbuf_mmap_createfilemapping: VirtualAlloc", GetLastError());
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc:97:16: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
   97 |         werror("gr::vmcircbuf_mmap_createfilemapping: VirtualFree", GetLastError());
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc:109:16: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  109 |         werror("gr::vmcircbuf_mmap_createfilemapping: MapViewOfFileEx(1)",
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc:124:16: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  124 |         werror("gr::vmcircbuf_mmap_createfilemapping: MapViewOfFileEx(2)",
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc: In destructor 'virtual gr::vmcircbuf_createfilemapping::~vmcircbuf_createfilemapping()':
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc:151:16: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  151 |         werror("gr::vmcircbuf_createfilemapping: UnmapViewOfFile(d_first_copy)",
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc:156:16: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  156 |         werror("gr::vmcircbuf_createfilemapping: UnmapViewOfFile(d_second_copy)",
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Changing the type of the offending argument to `const char*` solves the problem.

## Which blocks/areas does this affect?
* Double-mapped buffers

## Testing Done
I verified that the compiler warnings are gone.

Before: https://github.com/gqrx-sdr/gqrx/actions/runs/8442268322/job/23123313865
After: https://github.com/gqrx-sdr/gqrx/actions/runs/8442471326/job/23123942113

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
