### PR TITLE
audio: Fix compiler warnings

### DIFF
--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -189,7 +189,7 @@ int windows_sink::work(int noutput_items,
         }
 
         short* d_buffer = (short*)chosen_header->lpData;
-        samples_tosend = noutput_items - samples_sent >= d_chunk_size
+        samples_tosend = noutput_items - samples_sent >= (int)d_chunk_size
                              ? d_chunk_size
                              : noutput_items - samples_sent;
 
@@ -231,8 +231,8 @@ MMRESULT windows_sink::is_format_supported(LPWAVEFORMATEX pwfx, UINT uDeviceID)
     return (waveOutOpen(NULL,                // ptr can be NULL for query
                         uDeviceID,           // the device identifier
                         pwfx,                // defines requested format
-                        NULL,                // no callback
-                        NULL,                // no instance data
+                        0,                   // no callback
+                        0,                   // no instance data
                         WAVE_FORMAT_QUERY)); // query only, do not open device
 }
 
@@ -279,7 +279,7 @@ UINT windows_sink::find_device(std::string szDeviceName)
                     d_debug_logger->info("WaveOut Device {:d}: {:s}", i, woc.szPname);
                 }
             }
-            if (result == -1) {
+            if (result == (UINT)-1) {
                 d_logger->warn("waveOut device '{:s}' was not found, "
                                "defaulting to WAVE_MAPPER",
                                szDeviceName);

--- a/gr-audio/lib/windows/windows_sink.h
+++ b/gr-audio/lib/windows/windows_sink.h
@@ -11,8 +11,12 @@
 #ifndef INCLUDED_AUDIO_WINDOWS_SINK_H
 #define INCLUDED_AUDIO_WINDOWS_SINK_H
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX // stops windef.h defining max/min under cygwin
+#endif
 
 #include <mmsystem.h>
 #include <windows.h>

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -167,7 +167,7 @@ int windows_source::work(int noutput_items,
             case 1: // mono output
                 f0 = (float*)output_items[0];
 
-                for (int j = 0; j < buffer_length; j++) {
+                for (DWORD j = 0; j < buffer_length; j++) {
                     f0[dw_items + j] = (float)(lp_buffer[j]) / 32767.0;
                 }
                 dw_items += buffer_length;
@@ -176,7 +176,7 @@ int windows_source::work(int noutput_items,
                 f0 = (float*)output_items[0];
                 f1 = (float*)output_items[1];
 
-                for (int j = 0; j < buffer_length / 2; j++) {
+                for (DWORD j = 0; j < buffer_length / 2; j++) {
                     f0[dw_items + j] = (float)(lp_buffer[2 * j + 0]) / 32767.0;
                     f1[dw_items + j] = (float)(lp_buffer[2 * j + 1]) / 32767.0;
                 }
@@ -208,8 +208,8 @@ MMRESULT windows_source::is_format_supported(LPWAVEFORMATEX pwfx, UINT uDeviceID
     return (waveInOpen(NULL,                // ptr can be NULL for query
                        uDeviceID,           // the device identifier
                        pwfx,                // defines requested format
-                       NULL,                // no callback
-                       NULL,                // no instance data
+                       0,                   // no callback
+                       0,                   // no instance data
                        WAVE_FORMAT_QUERY)); // query only, do not open device
 }
 
@@ -257,7 +257,7 @@ UINT windows_source::find_device(std::string szDeviceName)
                 if (verbose)
                     d_debug_logger->info("WaveIn Device {:d}: {:s}", i, woc.szPname);
             }
-            if (result == -1) {
+            if (result == (UINT)-1) {
                 d_debug_logger->info("Warning: waveIn device '{:s}' was not found, "
                                      "defaulting to WAVE_MAPPER",
                                      szDeviceName);


### PR DESCRIPTION
## Description
MinGW reports several warnings while building `windows_source.cc` and `windows_sink.cc`:
```
[312/403] Building CXX object gr-audio/lib/CMakeFiles/gnuradio-audio.dir/windows/windows_source.cc.obj
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc: In member function 'virtual int gr::audio::windows_source::work(int, gr_vector_const_void_star&, gr_vector_void_star&)':
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc:170:35: warning: comparison of integer expressions of different signedness: 'int' and 'DWORD' {aka 'long unsigned int'} [-Wsign-compare]
  170 |                 for (int j = 0; j < buffer_length; j++) {
      |                                 ~~^~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc:179:35: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  179 |                 for (int j = 0; j < buffer_length / 2; j++) {
      |                                 ~~^~~~~~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc: In member function 'MMRESULT gr::audio::windows_source::is_format_supported(LPWAVEFORMATEX, UINT)':
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc:211:24: warning: passing NULL to non-pointer argument 4 of 'MMRESULT waveInOpen(LPHWAVEIN, UINT, LPCWAVEFORMATEX, DWORD_PTR, DWORD_PTR, DWORD)' [-Wconversion-null]
  211 |                        NULL,                // no callback
      |                        ^~~~
In file included from D:/a/_temp/msys64/mingw64/include/mmsystem.h:29,
                 from D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.h:21,
                 from D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc:16:
D:/a/_temp/msys64/mingw64/include/mmeapi.h:301:101: note:   declared here
  301 | WINMMAPI MMRESULT WINAPI waveInOpen(LPHWAVEIN phwi, UINT uDeviceID, LPCWAVEFORMATEX pwfx, DWORD_PTR dwCallback, DWORD_PTR dwInstance, DWORD fdwOpen);
      |                                                                                           ~~~~~~~~~~^~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc:212:24: warning: passing NULL to non-pointer argument 5 of 'MMRESULT waveInOpen(LPHWAVEIN, UINT, LPCWAVEFORMATEX, DWORD_PTR, DWORD_PTR, DWORD)' [-Wconversion-null]
  212 |                        NULL,                // no instance data
      |                        ^~~~
D:/a/_temp/msys64/mingw64/include/mmeapi.h:301:123: note:   declared here
  301 | WINMMAPI MMRESULT WINAPI waveInOpen(LPHWAVEIN phwi, UINT uDeviceID, LPCWAVEFORMATEX pwfx, DWORD_PTR dwCallback, DWORD_PTR dwInstance, DWORD fdwOpen);
      |                                                                                                                 ~~~~~~~~~~^~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc: In member function 'UINT gr::audio::windows_source::find_device(std::string)':
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_source.cc:260:24: warning: comparison of integer expressions of different signedness: 'UINT' {aka 'unsigned int'} and 'int' [-Wsign-compare]
  260 |             if (result == -1) {
      |                 ~~~~~~~^~~~~
[313/403] Building CXX object gr-audio/lib/CMakeFiles/gnuradio-audio.dir/windows/windows_sink.cc.obj
In file included from D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc:16:
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.h:14: warning: "WIN32_LEAN_AND_MEAN" redefined
   14 | #define WIN32_LEAN_AND_MEAN
      | 
<command-line>: note: this is the location of the previous definition
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.h:15: warning: "NOMINMAX" redefined
   15 | #define NOMINMAX // stops windef.h defining max/min under cygwin
      | 
In file included from D:/a/_temp/msys64/mingw64/include/c++/13.2.0/x86_64-w64-mingw32/bits/c++config.h:679,
                 from D:/a/_temp/msys64/mingw64/include/c++/13.2.0/cstddef:49,
                 from D:/a/_temp/msys64/mingw64/include/fmt/core.h:11,
                 from D:/a/_temp/msys64/mingw64/include/spdlog/fmt/fmt.h:32,
                 from D:/a/_temp/gnuradio/gnuradio-runtime/include/gnuradio/io_signature.h:19,
                 from D:/a/_temp/gnuradio/gnuradio-runtime/include/gnuradio/basic_block.h:15,
                 from D:/a/_temp/gnuradio/gnuradio-runtime/include/gnuradio/hier_block2.h:15,
                 from D:/a/_temp/gnuradio/gnuradio-runtime/include/gnuradio/top_block.h:15,
                 from D:/a/_temp/gnuradio/build/gr-audio/lib/CMakeFiles/gnuradio-audio.dir/cmake_pch.hxx:5,
                 from <command-line>:
D:/a/_temp/msys64/mingw64/include/c++/13.2.0/x86_64-w64-mingw32/bits/os_defines.h:45: note: this is the location of the previous definition
   45 | #define NOMINMAX 1
      | 
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc: In member function 'virtual int gr::audio::windows_sink::work(int, gr_vector_const_void_star&, gr_vector_void_star&)':
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc:192:55: warning: comparison of integer expressions of different signedness: 'int' and 'DWORD' {aka 'long unsigned int'} [-Wsign-compare]
  192 |         samples_tosend = noutput_items - samples_sent >= d_chunk_size
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc: In member function 'MMRESULT gr::audio::windows_sink::is_format_supported(LPWAVEFORMATEX, UINT)':
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc:234:25: warning: passing NULL to non-pointer argument 4 of 'MMRESULT waveOutOpen(LPHWAVEOUT, UINT, LPCWAVEFORMATEX, DWORD_PTR, DWORD_PTR, DWORD)' [-Wconversion-null]
  234 |                         NULL,                // no callback
      |                         ^~~~
In file included from D:/a/_temp/msys64/mingw64/include/mmsystem.h:29,
                 from D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.h:17:
D:/a/_temp/msys64/mingw64/include/mmeapi.h:273:103: note:   declared here
  273 | WINMMAPI MMRESULT WINAPI waveOutOpen(LPHWAVEOUT phwo, UINT uDeviceID, LPCWAVEFORMATEX pwfx, DWORD_PTR dwCallback, DWORD_PTR dwInstance, DWORD fdwOpen);
      |                                                                                             ~~~~~~~~~~^~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc:235:25: warning: passing NULL to non-pointer argument 5 of 'MMRESULT waveOutOpen(LPHWAVEOUT, UINT, LPCWAVEFORMATEX, DWORD_PTR, DWORD_PTR, DWORD)' [-Wconversion-null]
  235 |                         NULL,                // no instance data
      |                         ^~~~
D:/a/_temp/msys64/mingw64/include/mmeapi.h:273:125: note:   declared here
  273 | WINMMAPI MMRESULT WINAPI waveOutOpen(LPHWAVEOUT phwo, UINT uDeviceID, LPCWAVEFORMATEX pwfx, DWORD_PTR dwCallback, DWORD_PTR dwInstance, DWORD fdwOpen);
      |                                                                                                                   ~~~~~~~~~~^~~~~~~~~~
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc: In member function 'UINT gr::audio::windows_sink::find_device(std::string)':
D:/a/_temp/gnuradio/gr-audio/lib/windows/windows_sink.cc:282:24: warning: comparison of integer expressions of different signedness: 'UINT' {aka 'unsigned int'} and 'int' [-Wsign-compare]
  282 |             if (result == -1) {
      |                 ~~~~~~~^~~~~
```
I've fixed those warnings here.

## Which blocks/areas does this affect?
* Audio Sink (Windows)
* Audio Source (Windows)

## Testing Done
I verified that the compiler warnings are gone.

Before: https://github.com/gqrx-sdr/gqrx/actions/runs/8442268322/job/23123313865
After: https://github.com/gqrx-sdr/gqrx/actions/runs/8443334159/job/23126720093

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.