### PR TITLE
runtime: Fix conditional compilation of rescale_virtual_pri

### DIFF
--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -27,7 +27,8 @@
 #include <cstring>
 
 
-#if defined(HAVE_PTHREAD_SETSCHEDPARAM) || defined(HAVE_SCHED_SETSCHEDULER)
+#if !(defined(_WIN32) || defined(__WIN32__) || defined(WIN32)) && \
+    (defined(HAVE_PTHREAD_SETSCHEDPARAM) || defined(HAVE_SCHED_SETSCHEDULER))
 #include <pthread.h>
 
 namespace gr {


### PR DESCRIPTION
## Description
MinGW reports the following warning in `realtime_impl.cc`:
```
D:/a/_temp/gnuradio/gnuradio-runtime/lib/realtime_impl.cc:40:12: warning: 'int gr::realtime::rescale_virtual_pri(int, int, int)' defined but not used [-Wunused-function]
   40 | static int rescale_virtual_pri(int virtual_pri, int min_real_pri, int max_real_pri)
      |            ^~~~~~~~~~~~~~~~~~~
```
This happens because the `#if` condition that determines whether `rescale_virtual_pri` is compiled does not match the subsequent `#if` / `#elseif` conditions that determine whether it is used. When building with MinGW, both Windows threads and POSIX threads are available, exposing the mismatch.

Here I've fixed the first `#if` condition to match.

## Which blocks/areas does this affect?
Realtime scheduling

## Testing Done
I verified that the compiler warnings are gone.

Before: https://github.com/gqrx-sdr/gqrx/actions/runs/8442268322/job/23123313865
After: https://github.com/gqrx-sdr/gqrx/actions/runs/8443513781/job/23127298811

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.