### PR TITLE
Replace scipy/numpy.complex128 with cdouble

### DIFF
--- a/gnuradio-runtime/python/pmt/pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/pmt_to_python.py
@@ -67,7 +67,7 @@ numpy_mappings = {
     numpy.dtype(numpy.float32): (pmt.init_f32vector, float, pmt.f32vector_elements, pmt.is_f32vector),
     numpy.dtype(numpy.float64): (pmt.init_f64vector, float, pmt.f64vector_elements, pmt.is_f64vector),
     numpy.dtype(numpy.complex64): (pmt.init_c32vector, complex, pmt.c32vector_elements, pmt.is_c32vector),
-    numpy.dtype(numpy.complex128): (pmt.init_c64vector, complex, pmt.c64vector_elements, pmt.is_c64vector),
+    numpy.dtype(numpy.cdouble): (pmt.init_c64vector, complex, pmt.c64vector_elements, pmt.is_c64vector),
     numpy.dtype(numpy.int8): (pmt.init_s8vector, int, pmt.s8vector_elements, pmt.is_s8vector),
     numpy.dtype(numpy.int16): (pmt.init_s16vector, int, pmt.s16vector_elements, pmt.is_s16vector),
     numpy.dtype(numpy.int32): (pmt.init_s32vector, int, pmt.s32vector_elements, pmt.is_s32vector),

--- a/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
@@ -24,7 +24,7 @@ class test_pmt_to_python(unittest.TestCase):
     def test_numpy_to_uvector_and_reverse(self):
         import numpy as np
         N = 100
-        narr = np.ndarray(N, dtype=np.complex128)
+        narr = np.ndarray(N, dtype=np.cdouble)
         narr.real[:] = np.random.uniform(size=N)
         narr.imag[:] = np.random.uniform(size=N)
         uvector = pmt2py.numpy_to_uvector(narr)

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -1061,7 +1061,7 @@ class gr_plot_filter(QtWidgets.QMainWindow):
             return
 
         # Set Data.
-        if(type(self.taps[0]) == scipy.complex128):
+        if(type(self.taps[0]) == np.cdouble):
             self.rcurve.setData(np.arange(ntaps), self.taps.real)
             self.icurve.setData(np.arange(ntaps), self.taps.imag)
         else:
@@ -1069,7 +1069,7 @@ class gr_plot_filter(QtWidgets.QMainWindow):
             self.icurve.setData([], [])
 
         if self.mttaps:
-            if(type(self.taps[0]) == scipy.complex128):
+            if(type(self.taps[0]) == np.cdouble):
                 self.mtimecurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                               np.dstack((np.zeros(self.taps.real.shape[0], dtype=int),
                                                          self.taps.real)).flatten())
@@ -1115,7 +1115,7 @@ class gr_plot_filter(QtWidgets.QMainWindow):
         else:
             stepres = self.step_response(self.taps)
 
-        if(type(stepres[0]) == np.complex128):
+        if(type(stepres[0]) == np.cdouble):
             self.steprescurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                             np.dstack((np.zeros(stepres.real.shape[0], dtype=int),
                                                        stepres.real)).flatten())
@@ -1137,7 +1137,7 @@ class gr_plot_filter(QtWidgets.QMainWindow):
             self.steprescurve_i.setData([], [])
 
         if self.mtstep:
-            if(type(stepres[0]) == np.complex128):
+            if(type(stepres[0]) == np.cdouble):
                 self.mtimecurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                               np.dstack((np.zeros(stepres.real.shape[0], dtype=int),
                                                          stepres.real)).flatten())
@@ -1182,7 +1182,7 @@ class gr_plot_filter(QtWidgets.QMainWindow):
         else:
             impres = self.impulse_response(self.taps)
 
-        if(type(impres[0]) == np.complex128):
+        if(type(impres[0]) == np.cdouble):
             self.imprescurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                            np.dstack((np.zeros(impres.real.shape[0], dtype=int),
                                                       impres.real)).flatten())
@@ -1200,7 +1200,7 @@ class gr_plot_filter(QtWidgets.QMainWindow):
                                                       impres)).flatten())
 
         if self.mtimpulse:
-            if(type(impres[0]) == np.complex128):
+            if(type(impres[0]) == np.cdouble):
                 self.mtimecurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                               np.dstack((np.zeros(impres.real.shape[0], dtype=int),
                                                          impres.real)).flatten())


### PR DESCRIPTION
## Description
Use the canonical cdouble instead of the platform-depended complex128 in the filter designer and pmt-to-python code.

The same should be done for complex64 (csingle). This is used more widely in the code, and is also used as a string, so we can address it separately.

## Related Issue
Fixes #7227 

## Which blocks/areas does this affect?
Filter designer tool. Also pmt-to-python.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
