### PR TITLE
blocks: fix C++ non-vector add const block include error (backport to maint-3.10)

### DIFF
--- a/gr-blocks/grc/blocks_add_const_vxx.block.yml
+++ b/gr-blocks/grc/blocks_add_const_vxx.block.yml
@@ -43,7 +43,7 @@ templates:
     - set_k(${const})
 
 cpp_templates:
-    includes: ['#include <gnuradio/blocks/add_const_${"v" if context.get("vlen")() > 1 else ""}.h>']
+    includes: ['#include <gnuradio/blocks/add_const_${"v" if context.get("vlen")() > 1 else type.fcn}.h>']
     declarations: 'blocks::add_const_${"v" if context.get("vlen")() > 1 else ""}${type.fcn}::sptr ${id};'
     make: 'this->${id} = blocks::add_const_${"v" if context.get("vlen")() > 1 else ""}${type.fcn}::make(${const});'
     callbacks:


### PR DESCRIPTION
Backport #7229