### PR TITLE
gr-audio: yml file has a comma where there should be a space

### DIFF
--- a/gr-audio/grc/audio_sink.block.yml
+++ b/gr-audio/grc/audio_sink.block.yml
@@ -9,7 +9,7 @@ parameters:
     dtype: int
     default: samp_rate
     options: ['16000', '22050', '24000', '32000', '44100', '48000', '96000', '192000']
-    option_labels: [16 kHz, 22.05 kHz, 24 kHz, 32 kHz, 44.1 kHz, 48 kHz, 96 kHz, 192,kHz]
+    option_labels: [16 kHz, 22.05 kHz, 24 kHz, 32 kHz, 44.1 kHz, 48 kHz, 96 kHz, 192 kHz]
 -   id: device_name
     label: Device Name
     dtype: string


### PR DESCRIPTION
Fix a typo in #7244. Was fixed already in backport #7248.