### PR TITLE
gr-gtqui: Fixed Qt GUI Dial - weird behaviour

### DIFF
--- a/gr-qtgui/python/qtgui/dialcontrol.py
+++ b/gr-qtgui/python/qtgui/dialcontrol.py
@@ -23,7 +23,7 @@ class LabeledDialControl(QFrame):
                  minsize=100, isFloat=False, scaleFactor=1, showvalue=False,
                  outputmsgname='value'):
         QFrame.__init__(self, parent)
-        self.numberControl = DialControl(minimum, maximum, defaultvalue, backgroundColor,
+        self.numberControl = DialControl(minimum, maximum, defaultvalue / scaleFactor, backgroundColor,
                                          self.valChanged, changedCallback, minsize)
 
         layout = QVBoxLayout()
@@ -37,7 +37,7 @@ class LabeledDialControl(QFrame):
         self.lblcontrol.setAlignment(Qtc.AlignCenter)
 
         if self.showvalue:
-            textstr = self.buildTextStr(defaultvalue * self.scaleFactor)
+            textstr = self.buildTextStr(defaultvalue)
             self.lblcontrol.setText(textstr)
 
         if len or self.showvalue:


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
In issue #5107 the Qt GUI dial default seems to be the exact value returned, if the default value is interpreted as the initial knob position, the returned value does not account for the scale factor - until the knob is moved.
Check the issue for more explaination

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
This PR will fix #5107 
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Only the QT GUI Dial is affected. There is no effect on the performance. 
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I built and ran the example provided by the issue
previous results are explained in detail here:
https://github.com/gnuradio/gnuradio/issues/5107#issuecomment-932992531

New results:
https://github.com/gnuradio/gnuradio/assets/118675709/9f595841-ce4f-4cae-a21c-1cfd16786aeb



testing case file: 
[qt_gui_dialweirdness.grc.zip](https://github.com/gnuradio/gnuradio/files/7274174/qt_gui_dial_weirdness.grc.zip)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
