### PR TITLE
grc_qt: save panel settings

### DIFF
--- a/grc/gui_qt/components/block_library.py
+++ b/grc/gui_qt/components/block_library.py
@@ -106,6 +106,8 @@ class BlockLibrary(QDockWidget, base.Component):
     def __init__(self):
         super(BlockLibrary, self).__init__()
 
+        self.qsettings = self.app.qsettings
+
         self.setObjectName("block_library")
         self.setWindowTitle("Block Library")
 
@@ -204,6 +206,9 @@ class BlockLibrary(QDockWidget, base.Component):
 
         # Dict representing which examples contain various blocks
         self.examples_w_block = {}
+
+        if not self.qsettings.value("appearance/display_blocklibrary", True, type=bool):
+            self.hide()
 
     def createActions(self, actions):
         pass

--- a/grc/gui_qt/components/console.py
+++ b/grc/gui_qt/components/console.py
@@ -82,6 +82,8 @@ class Console(QtWidgets.QDockWidget, base.Component):
     def __init__(self, level):
         super(Console, self).__init__()
 
+        self.qsettings = self.app.qsettings
+
         self.setObjectName('console')
         self.setWindowTitle('Console')
         self.level = level
@@ -116,8 +118,8 @@ class Console(QtWidgets.QDockWidget, base.Component):
 
         # Translation support
 
-        #self.setWindowTitle(_translate("", "Library", None))
-        #library.headerItem().setText(0, _translate("", "Blocks", None))
+        # self.setWindowTitle(_translate("", "Library", None))
+        # library.headerItem().setText(0, _translate("", "Blocks", None))
         # QtCore.QMetaObject.connectSlotsByName(blockLibraryDock)
 
         # Setup actions
@@ -153,6 +155,9 @@ class Console(QtWidgets.QDockWidget, base.Component):
         self.actions['show_level'].setChecked = True
         self.handler.show_level = True
         self.enabled = False
+
+        if not self.qsettings.value("appearance/display_console", True, type=bool):
+            self.hide()
 
     def enable(self):
         self.enabled = True

--- a/grc/gui_qt/components/variable_editor.py
+++ b/grc/gui_qt/components/variable_editor.py
@@ -35,6 +35,8 @@ class VariableEditor(QDockWidget, base.Component):
     def __init__(self):
         super(VariableEditor, self).__init__()
 
+        self.qsettings = self.app.qsettings
+
         self.setObjectName('variable_editor')
         self.setWindowTitle('Variable Editor')
 
@@ -74,7 +76,8 @@ class VariableEditor(QDockWidget, base.Component):
         # before calling the MainWindow Controller to add the widget.
         self.app.registerDockWidget(self, location=self.settings.window.VARIABLE_EDITOR_DOCK_LOCATION)
         self.currently_rebuilding = False
-
+        if not self.qsettings.value("appearance/display_variable_editor", True, type=bool):
+            self.hide()
     # Actions
 
     def createActions(self, actions):

--- a/grc/gui_qt/components/wiki_tab.py
+++ b/grc/gui_qt/components/wiki_tab.py
@@ -30,7 +30,7 @@ log = logging.getLogger(f"grc.application.{__name__}")
 
 
 class WikiTab(QtWidgets.QDockWidget, base.Component):
-    def __init__(self, argv_enabled=False):
+    def __init__(self):
         super(WikiTab, self).__init__()
 
         self.qsettings = self.app.qsettings
@@ -40,27 +40,11 @@ class WikiTab(QtWidgets.QDockWidget, base.Component):
 
         self.setFloating(False)
 
-        active = None
-        if argv_enabled:
-            active = True
-        else:
-            if self.qsettings.value("appearance/display_wiki", False, type=bool) == True:
-                active = True
-            else:
-                active = False
-
-        if active:
-            try:
-                from qtpy.QtWebEngineWidgets import QWebEngineView
-                self.hidden = False
-            except ImportError:
-                log.error("PyQt QWebEngine missing!")
-                self.hide()
-                self.hidden = True
-                return
-        else:
+        try:
+            from qtpy.QtWebEngineWidgets import QWebEngineView
+        except ImportError:
+            log.error("PyQt QWebEngine missing!")
             self.hide()
-            self.hidden = True
             return
 
         # GUI Widgets
@@ -97,9 +81,11 @@ class WikiTab(QtWidgets.QDockWidget, base.Component):
         # The AppController then tries to find a saved dock location from the preferences
         # before calling the MainWindow Controller to add the widget.
         self.app.registerDockWidget(self, location=self.settings.window.WIKI_TAB_DOCK_LOCATION)
+        if not self.qsettings.value("appearance/display_wiki", False, type=bool):
+            self.hide()
 
     def setURL(self, url):
-        if not self.hidden:
+        if not self.isHidden():
             self._text.load(url)
             self._text.show()
 

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -1475,6 +1475,16 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
                 # We cancelled closing a tab. We don't want to close the application
                 return
 
+        # Save the panel settings
+        # Console
+        self.app.qsettings.setValue('appearance/display_console', not self.app.Console.isHidden())
+        # Block Library
+        self.app.qsettings.setValue('appearance/display_blocklibrary', not self.app.BlockLibrary.isHidden())
+        # Wiki
+        self.app.qsettings.setValue('appearance/display_wiki', not self.app.WikiTab.isHidden())
+        # Variable Editor
+        self.app.qsettings.setValue('appearance/display_variable_editor', not self.app.VariableEditor.isHidden())
+
         # Write the leftmost tab to file first
         self.app.qsettings.setValue('window/files_open', reversed(files_open))
         self.app.qsettings.setValue('window/windowState', self.saveState())

--- a/grc/gui_qt/grc.py
+++ b/grc/gui_qt/grc.py
@@ -86,7 +86,7 @@ class Application(QtWidgets.QApplication):
         stopwatch.lap("blocklibrary")
         # self.DocumentationTab = components.DocumentationTab()
         # stopwatch.lap('documentationtab')
-        self.WikiTab = components.WikiTab("--wiki" in settings.argv)
+        self.WikiTab = components.WikiTab()
         stopwatch.lap("wikitab")
         self.VariableEditor = components.VariableEditor()
         stopwatch.lap("variable_editor")

--- a/grc/gui_qt/resources/available_preferences.yml
+++ b/grc/gui_qt/resources/available_preferences.yml
@@ -107,10 +107,6 @@ categories:
         name: Default Qt GUI theme
         dtype: str
         default: ""
-      - key: display_wiki
-        name: Display Wiki tab
-        dtype: bool
-        default: False
 
 # Runtime preferences typically end up in config.conf. They are grouped in a single tab.
 runtime:

--- a/grc/main.py
+++ b/grc/main.py
@@ -209,7 +209,6 @@ def main():
 
     # Logging support
     parser.add_argument('--log', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info')
-    parser.add_argument('--wiki', action='store_true')
     # TODO: parser.add_argument('--log-output')
 
     # Graphics framework (QT or GTK)


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
In View-> Panels four panels can be enabled and disabled. But these settings are not saved and restored.
This is done now


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run grc --qt
View-> Panels
 Disable some panels and restart

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
