### PR TITLE
gr_modtool: remove colon in block yaml label

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -566,7 +566,7 @@ templates:
 #     * default
 parameters:
 - id: parametername_replace_me
-  label: FIX ME:
+  label: FIX ME
   dtype: string
   default: You need to fill in your grc/${modname}_${blockname}.block.yaml
 #- id: ...


### PR DESCRIPTION
## Description
Removes the colon in the default block yaml parameter label.  
The presence of this colon causes the default generated block to throw an obscure error: "FlowGraph Error: mapping values are not allowed in this context"

With the colon removed, the FIX ME message renders correctly. Note that the colon itself is unnecessary, since grc renders parameter labels with a colon after it automatically. If you quote the label, then grc shows "FIX ME::".

## Testing Done
Default behavior:
```
gr_modtool add test
<compile the block>
<open grc>
```
And you get `FlowGraph Error: mapping values are not allowed in this context` and the block fails to appear.

After removing the colon it works fine.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
