### PR TITLE
fix failed testcase on test_rotate_block

### DIFF
--- a/grc/tests/test_qtbot.py
+++ b/grc/tests/test_qtbot.py
@@ -315,7 +315,7 @@ def test_rotate_block(qtbot, qapp_cls_):
 
     keystroke(qtbot, qapp_cls_, QtCore.Qt.Key_Left)
     new_rotation = opts.states["rotation"]
-    assert new_rotation == old_rotation - 90
+    assert new_rotation == (old_rotation - 90) % 360
 
     undo(qtbot, qapp_cls_)
     new_rotation = opts.states["rotation"]


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Fix failed testcase on test_qtbot.py

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
grc/tests/test_qtbot.py

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Before:
![image](https://github.com/gnuradio/gnuradio/assets/44158147/68816a07-4539-465b-9dcc-9feb06c7be14)

After:
![image](https://github.com/gnuradio/gnuradio/assets/44158147/8f340026-dcfc-4316-8982-85d952ec78e9)

command: `pytest grc/tests/test_qtbot.py`
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
