### PR TITLE
fix double click connection to delete for qt gui

### DIFF
--- a/grc/gui_qt/components/canvas/connection.py
+++ b/grc/gui_qt/components/canvas/connection.py
@@ -159,5 +159,6 @@ class GUIConnection(QGraphicsPathItem):
         painter.drawPath(self._arrowhead)
 
     def mouseDoubleClickEvent(self, e):
-        self.parent.connections.remove(self)
+        connection = self.core
+        connection.parent.connections.remove(connection)
         self.scene().removeItem(self)

--- a/grc/tests/test_qtbot.py
+++ b/grc/tests/test_qtbot.py
@@ -424,6 +424,22 @@ def test_connection(qtbot, qapp_cls_):
     redo(qtbot, qapp_cls_)
     assert len(fg.connections) == 1
 
+    connection = next(iter(fg.connections))  # get a connection without removing it
+
+    # delete connection with delete key press event
+    assert len(fg.connections) == 1
+    click_on(qtbot, qapp_cls_, connection)
+    keystroke(qtbot, qapp_cls_, QtCore.Qt.Key_Delete)
+    assert len(fg.connections) == 0
+    qtbot.wait(100)
+    undo(qtbot, qapp_cls_)
+
+    # delete connection with double click
+    click_on(qtbot, qapp_cls_, connection)
+    click_on(qtbot, qapp_cls_, connection)
+    assert len(fg.connections) == 0
+    qtbot.wait(100)
+
     for block in [n_src, n_sink]:
         delete_block(qtbot, qapp_cls_, block)
 
@@ -487,7 +503,7 @@ def test_num_inputs(qtbot, qapp_cls_):
     assert len(fg.connections) == 1
 
     # I think loses focus makes delete_fail the first time. This makes it work, but is a hack
-    #click_on(qtbot, qapp_cls_, n_src)
+    # click_on(qtbot, qapp_cls_, n_src)
     pag.click(click_pos.x() + 50, click_pos.y() + 50, button="left")
 
     for block in [n_src, n_sink]:


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Fix AttributeError while deleting connection with double click

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes https://github.com/gnuradio/gnuradio/issues/7269

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
`grc/gui_qt/components/canvas/connection.py`

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
- Manual gui test
- Automated gui testing with `pytest grc/tests/test_qtbot.py`

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
