### PR TITLE
runtime/gnuradio-config-info: print unquoted path for userconfdir

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
         std::cout << gr::prefsdir() << std::endl;
 
     if (vm.count("userprefsdir") || print_all)
-        std::cout << gr::paths::userconf() << std::endl;
+        std::cout << gr::paths::userconf().string() << std::endl;
 
     // Not included in print all due to verbosity
     if (vm.count("prefs"))


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

For some reason, std::cout::operator<< decides to put
std::filesystem::path into ""; this breaks applications that try to use
the output of gnuradio-config-info --userprefsdir directly.

Using .string() seems to solve that. Strange, but not worth
investigating much.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #7267

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

only gnuradio-config-info

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Tests still run through.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
