### PR TITLE
runtime/gnuradio-config-info: print unquoted path for userconfdir (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
         std::cout << gr::prefsdir() << std::endl;
 
     if (vm.count("userprefsdir") || print_all)
-        std::cout << gr::paths::userconf() << std::endl;
+        std::cout << gr::paths::userconf().string() << std::endl;
 
     // Not included in print all due to verbosity
     if (vm.count("prefs"))


### PR DESCRIPTION
Backport #7285