### PR TITLE
grc-qt: Fixing incorrect error display

### DIFF
--- a/grc/gui_qt/components/canvas/connection.py
+++ b/grc/gui_qt/components/canvas/connection.py
@@ -199,5 +199,6 @@ class GUIConnection(QGraphicsPathItem, StyledConnection):
 
     def mouseDoubleClickEvent(self, e):
         connection = self.core
+        self.core.parent.gui.set_saved(False)
         connection.parent.connections.remove(connection)
         self.scene().removeItem(self)

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -1047,6 +1047,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         """
         log.debug(f"Switching to tab (index {tab_index})")
         self.tabWidget.setCurrentIndex(tab_index)
+        self.app.VariableEditor.set_scene(self.currentFlowgraphScene)
         self.updateActions()
 
     def close_triggered(self, tab_index=None) -> Union[str, bool]:

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -159,7 +159,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.tabWidget.tabCloseRequested.connect(
             lambda index: self.close_triggered(index)
         )
-        self.tabWidget.tabBarClicked.connect(
+        self.tabWidget.currentChanged.connect(
             lambda index: self.tab_triggered(index)
         )
         self.setCentralWidget(self.tabWidget)
@@ -961,6 +961,9 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
                 for block in self.currentFlowgraphScene.core.blocks:
                     block.gui.create_shapes_and_labels()
                 self.currentFlowgraphScene.update_elements_to_draw()
+                if hasattr(self.app, 'VariableEditor'):
+                    self.app.VariableEditor.set_scene(self.currentFlowgraphScene)
+                #self.updateActions()
             else:
                 self.tabWidget.setCurrentIndex(open_fgs.index(filename))
 
@@ -1046,8 +1049,11 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             tab_index: switches to tab(tab_index)
         """
         log.debug(f"Switching to tab (index {tab_index})")
+        if tab_index < 0:
+            return
         self.tabWidget.setCurrentIndex(tab_index)
-        self.app.VariableEditor.set_scene(self.currentFlowgraphScene)
+        if hasattr(self.app, 'VariableEditor'):
+            self.app.VariableEditor.set_scene(self.currentFlowgraphScene)
         self.updateActions()
 
     def close_triggered(self, tab_index=None) -> Union[str, bool]:


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Fixes #7284

In addition:

If on startup grc loads an invalid flowgraph, the fg is shown as valid, that is the error button is disabled.

If there are several tabs ar open that contain a mixture of valid and invalid fg's the error button is not adopted to the status of the selected tab.

This pr calculates  the status of the buttons individually for each tab depending on it's fg.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7284
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Build a simple fg, save it, delete a connection. Save the fg again.
Restart grc --qt 
The fg should  display an error as a connection is missing.

Open several tabs with an mixture of  correct and incorrect fg's and switch between the different tabs.
Watch the status of the 'errors' button

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
