### PR TITLE
ctrlport probes: only pybind if ctrlport enabled

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/bindings/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/CMakeLists.txt
@@ -51,19 +51,6 @@ list(
     # pycallback_object_python.cc
     random_python.cc
     realtime_python.cc
-    # rpcbufferedget_python.cc
-    rpccallbackregister_base_python.cc
-    rpcmanager_python.cc
-    # rpcmanager_base_python.cc
-    # rpcpmtconverters_thrift_python.cc
-    # rpcregisterhelpers_python.cc
-    # rpcserver_aggregator_python.cc
-    # rpcserver_base_python.cc
-    # rpcserver_booter_aggregator_python.cc
-    rpcserver_booter_base_python.cc
-    # rpcserver_booter_thrift_python.cc
-    # rpcserver_selector_python.cc
-    # rpcserver_thrift_python.cc
     runtime_types_python.cc
     sincos_python.cc
     sptr_magic_python.cc
@@ -76,8 +63,6 @@ list(
     # thread_python.cc
     # thread_body_wrapper_python.cc
     # thread_group_python.cc
-    # thrift_application_base_python.cc
-    # thrift_server_template_python.cc
     top_block_python.cc
     tpb_detail_python.cc
     # types_python.cc
@@ -85,7 +70,31 @@ list(
     # xoroshiro128p_python.cc
     python_bindings.cc)
 
+if(ENABLE_GR_CTRLPORT)
+    list(APPEND gr_python_files 
+        # rpcbufferedget_python.cc
+        # rpcmanager_base_python.cc
+        # rpcpmtconverters_thrift_python.cc
+        # rpcregisterhelpers_python.cc
+        # rpcserver_aggregator_python.cc
+        # rpcserver_base_python.cc
+        # rpcserver_booter_aggregator_python.cc
+        # rpcserver_booter_thrift_python.cc
+        # rpcserver_selector_python.cc
+        # rpcserver_thrift_python.cc
+        # thrift_application_base_python.cc
+        # thrift_server_template_python.cc
+        rpccallbackregister_base_python.cc
+        rpcmanager_python.cc
+        rpcserver_booter_base_python.cc
+        )
+endif()
+
 gr_pybind_make_check_hash(gr ../../../.. gr::gr "${gr_python_files}")
+
+if(ENABLE_GR_CTRLPORT)
+    target_compile_definitions(gr_python PUBLIC GR_HAVE_CTRLPORT)
+endif()
 
 install(
     TARGETS gr_python

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/python_bindings.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/python_bindings.cc
@@ -59,6 +59,25 @@ void bind_prefs(py::module&);
 // void bind_pycallback_object(py::module&);
 void bind_random(py::module&);
 void bind_realtime(py::module&);
+void bind_runtime_types(py::module&);
+void bind_sincos(py::module&);
+void bind_sptr_magic(py::module&);
+void bind_sync_block(py::module&);
+void bind_sync_decimator(py::module&);
+void bind_sync_interpolator(py::module&);
+void bind_sys_paths(py::module&);
+void bind_tagged_stream_block(py::module&);
+void bind_tags(py::module&);
+// void bind_thread(py::module&);
+// void bind_thread_body_wrapper(py::module&);
+// void bind_thread_group(py::module&);
+void bind_top_block(py::module&);
+void bind_tpb_detail(py::module&);
+// void bind_types(py::module&);
+// void bind_unittests(py::module&);
+// void bind_xoroshiro128p(py::module&);
+//
+#ifdef GR_HAVE_CTRLPORT
 // void bind_rpcbufferedget(py::module&);
 void bind_rpccallbackregister_base(py::module&);
 void bind_rpcmanager(py::module&);
@@ -72,25 +91,9 @@ void bind_rpcserver_booter_base(py::module&);
 // void bind_rpcserver_booter_thrift(py::module&);
 // void bind_rpcserver_selector(py::module&);
 // void bind_rpcserver_thrift(py::module&);
-void bind_runtime_types(py::module&);
-void bind_sincos(py::module&);
-void bind_sptr_magic(py::module&);
-void bind_sync_block(py::module&);
-void bind_sync_decimator(py::module&);
-void bind_sync_interpolator(py::module&);
-void bind_sys_paths(py::module&);
-void bind_tagged_stream_block(py::module&);
-void bind_tags(py::module&);
-// void bind_thread(py::module&);
-// void bind_thread_body_wrapper(py::module&);
-// void bind_thread_group(py::module&);
 // void bind_thrift_application_base(py::module&);
 // void bind_thrift_server_template(py::module&);
-void bind_top_block(py::module&);
-void bind_tpb_detail(py::module&);
-// void bind_types(py::module&);
-// void bind_unittests(py::module&);
-// void bind_xoroshiro128p(py::module&);
+#endif
 
 // We need this hack because import_array() returns NULL
 // for newer Python versions.
@@ -161,6 +164,7 @@ PYBIND11_MODULE(gr_python, m)
     // // bind_pycallback_object(m);
     bind_random(m);
     bind_realtime(m);
+#ifdef GR_HAVE_CTRLPORT
     // // bind_rpcbufferedget(m);
     bind_rpccallbackregister_base(m);
     bind_rpcmanager(m);
@@ -174,6 +178,7 @@ PYBIND11_MODULE(gr_python, m)
     // // bind_rpcserver_booter_thrift(m);
     // // bind_rpcserver_selector(m);
     // // bind_rpcserver_thrift(m);
+#endif
     bind_runtime_types(m);
     bind_sincos(m);
     bind_sptr_magic(m);

--- a/gr-blocks/python/blocks/bindings/CMakeLists.txt
+++ b/gr-blocks/python/blocks/bindings/CMakeLists.txt
@@ -49,12 +49,6 @@ list(
     correctiq_man_python.cc
     correctiq_swapiq_python.cc
     count_bits_python.cc
-    ctrlport_probe2_b_python.cc
-    ctrlport_probe2_c_python.cc
-    ctrlport_probe2_f_python.cc
-    ctrlport_probe2_i_python.cc
-    ctrlport_probe2_s_python.cc
-    ctrlport_probe_c_python.cc
     deinterleave_python.cc
     delay_python.cc
     divide_python.cc
@@ -169,7 +163,22 @@ if(SNDFILE_FOUND)
          wavfile_source_python.cc)
 endif()
 
+if(ENABLE_GR_CTRLPORT)
+    list(APPEND blocks_python_files 
+        ctrlport_probe2_b_python.cc
+        ctrlport_probe2_c_python.cc
+        ctrlport_probe2_f_python.cc
+        ctrlport_probe2_i_python.cc
+        ctrlport_probe2_s_python.cc
+        ctrlport_probe_c_python.cc
+        )
+endif()
+
 gr_pybind_make_check_hash(blocks ../../.. gr::blocks "${blocks_python_files}")
+
+if(ENABLE_GR_CTRLPORT)
+    target_compile_definitions(blocks_python PUBLIC GR_HAVE_CTRLPORT)
+endif()
 
 install(
     TARGETS blocks_python

--- a/gr-blocks/python/blocks/bindings/python_bindings.cc
+++ b/gr-blocks/python/blocks/bindings/python_bindings.cc
@@ -51,12 +51,14 @@ void bind_correctiq_auto(py::module&);
 void bind_correctiq_man(py::module&);
 void bind_correctiq_swapiq(py::module&);
 void bind_count_bits(py::module&);
+#ifdef GR_HAVE_CTRLPORT
 void bind_ctrlport_probe2_b(py::module&);
 void bind_ctrlport_probe2_c(py::module&);
 void bind_ctrlport_probe2_f(py::module&);
 void bind_ctrlport_probe2_i(py::module&);
 void bind_ctrlport_probe2_s(py::module&);
 void bind_ctrlport_probe_c(py::module&);
+#endif
 void bind_deinterleave(py::module&);
 void bind_delay(py::module&);
 void bind_divide(py::module&);
@@ -225,12 +227,14 @@ PYBIND11_MODULE(blocks_python, m)
     bind_correctiq_man(m);
     bind_correctiq_swapiq(m);
     bind_count_bits(m);
+#ifdef GR_HAVE_CTRLPORT
     bind_ctrlport_probe2_b(m);
     bind_ctrlport_probe2_c(m);
     bind_ctrlport_probe2_f(m);
     bind_ctrlport_probe2_i(m);
     bind_ctrlport_probe2_s(m);
     bind_ctrlport_probe_c(m);
+#endif
     bind_deinterleave(m);
     bind_delay(m);
     bind_divide(m);

--- a/gr-fft/python/fft/bindings/CMakeLists.txt
+++ b/gr-fft/python/fft/bindings/CMakeLists.txt
@@ -7,7 +7,6 @@ include(GrPybind)
 list(
     APPEND
     fft_python_files
-    ctrlport_probe_psd_python.cc
     fft_shift_python.cc
     fft_v_python.cc
     goertzel_python.cc
@@ -15,7 +14,18 @@ list(
     window_python.cc
     python_bindings.cc)
 
+if(ENABLE_GR_CTRLPORT)
+    list(APPEND fft_python_files
+    ctrlport_probe_psd_python.cc
+        )
+endif()
+
 gr_pybind_make_check_hash(fft ../../.. gr::fft "${fft_python_files}")
+
+if(ENABLE_GR_CTRLPORT)
+    target_compile_definitions(fft_python PUBLIC GR_HAVE_CTRLPORT)
+endif()
+
 
 install(
     TARGETS fft_python

--- a/gr-fft/python/fft/bindings/python_bindings.cc
+++ b/gr-fft/python/fft/bindings/python_bindings.cc
@@ -15,7 +15,9 @@
 
 namespace py = pybind11;
 
+#ifdef GR_HAVE_CTRLPORT
 void bind_ctrlport_probe_psd(py::module&);
+#endif
 void bind_fft_shift(py::module&);
 void bind_fft_v(py::module&);
 void bind_goertzel(py::module&);
@@ -41,7 +43,9 @@ PYBIND11_MODULE(fft_python, m)
     // Allow access to base block methods
     py::module::import("gnuradio.gr");
 
+#ifdef GR_HAVE_CTRLPORT
     bind_ctrlport_probe_psd(m);
+#endif
     bind_fft_shift(m);
     bind_fft_v(m);
     bind_goertzel(m);


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Previously, the python bindings would be built even if ctrlport was disabled, which leads to missing symbols at python module load time

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

@balister reported test failures in his (presumably OE) build, https://matrix.to/#/!UHlAIKBoAIYHCdpjhE:gnuradio.org/$5y-GtVnb-osx1HDJbaylVVuEf_guIxbiQHrul3zHlNc?via=gnuradio.org&via=t2bot.io&via=matrix.org

```
Python 3.10.13 (main, Aug 24 2023, 12:59:26) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from gnuradio import gr
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/gnuradio/gr/__init__.py", line 26, in <module>
    from .gr_python import *
ImportError: /usr/lib/python3.10/site-packages/gnuradio/gr/gr_python.cpython-310-aarch64-linux-gnu.so: undefined symbol: _ZN10rpcmanager3getEv

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/gnuradio/gr/__init__.py", line 30, in <module>
    from .gr_python import *
ImportError: /usr/lib/python3.10/site-packages/gnuradio/gr/gr_python.cpython-310-aarch64-linux-gnu.so: undefined symbol: _ZN10rpcmanager3getEv
>>> 
```
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

runtime, where the rpcmanager bindings are done, fft and blocks, where probes are bound

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
