### PR TITLE
GRC: when passing arguments to terminal emulator: individually

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -59,7 +59,7 @@ class ExecFlowGraphThread(threading.Thread):
             if ('gnome-terminal' in xterm_executable):
                 run_command_args = [xterm_executable, '--'] + run_command_args
             else:
-                run_command_args = [xterm_executable, '-e', run_command]
+                run_command_args = [xterm_executable, '-e'] + run_command_args
 
         # this does not reproduce a shell executable command string, if a graphical
         # terminal is used. Passing run_command though shlex_quote would do it but

--- a/grc/gui_qt/components/executor.py
+++ b/grc/gui_qt/components/executor.py
@@ -50,7 +50,7 @@ class ExecFlowGraphThread(threading.Thread):
             if ('gnome-terminal' in xterm_executable):
                 run_command_args = [xterm_executable, '--'] + run_command_args
             else:
-                run_command_args = [xterm_executable, '-e', run_command]
+                run_command_args = [xterm_executable, '-e'] + run_command_args
 
         # this does not reproduce a shell executable command string, if a graphical
         # terminal is used. Passing run_command though shlex_quote would do it but


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
The joined argument string is only useful for logging; some terminal
emulators seem to accept it (which probably means they pass their one
argument to a shell), others fail (gnome-terminal, alacritty, …).

By splitting the arguments, this should work on all terminal emulators.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Closes #7289

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

GRC GTK & Qt

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested against xterm and alacritty, the former still works, the latter
now works.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
