### PR TITLE
blocks/blockinterleaving: rework permutation check to suppress warning

### DIFF
--- a/gr-blocks/lib/blockinterleaving.cc
+++ b/gr-blocks/lib/blockinterleaving.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2022 Johannes Demel.
+ * Copyright 2024 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -11,12 +12,12 @@
 #include <gnuradio/blocks/blockinterleaving.h>
 
 /* ensure that tweakme.h is included before the bundled spdlog/fmt header, see
- * https://github.com/gabime/spdlog/issues/2922 */
+ * https://github.com/gabime/spdlog/issues/2922 ; fixed upstream in spdlog v1.13.0 */
 #include <spdlog/tweakme.h>
 
 #include <spdlog/fmt/fmt.h>
-#include <algorithm>
-#include <numeric>
+
+#include <stdexcept>
 #include <vector>
 
 namespace gr {
@@ -32,33 +33,61 @@ block_interleaving::block_interleaving(std::vector<size_t> interleaver_indices)
 void block_interleaving::set_interleaver_indices(
     const std::vector<size_t>& interleaver_indices)
 {
-    std::vector<size_t> test(interleaver_indices);
-    std::sort(test.begin(), test.end());
-    std::unique(test.begin(), test.end());
-    const auto [min, max] = std::minmax_element(test.begin(), test.end());
-    if (test.size() != interleaver_indices.size() || *min != 0 ||
-        *max != interleaver_indices.size() - 1) {
-        throw std::invalid_argument(
-            fmt::format("Incorrect interleaver indices! Expected {} unique elements in "
-                        "the range[0, {}) "
-                        "in random order, but got {} elements in range [{}, {})!",
-                        interleaver_indices.size(),
-                        interleaver_indices.size(),
-                        test.size(),
-                        *min,
-                        *max + 1));
+    if (interleaver_indices.empty()) {
+        throw std::invalid_argument("Incorrect interleaver indices! Can't be empty.");
     }
 
-    _interleaver_indices = std::vector<size_t>(interleaver_indices);
+    std::vector<size_t> deinterleaver_indices(interleaver_indices.size(), 0);
+    bool zero_seen = false;
+    for (size_t counter = 0; counter < interleaver_indices.size(); ++counter) {
+        const auto index = interleaver_indices[counter];
 
-    _deinterleaver_indices.resize(_interleaver_indices.size());
-    std::iota(_deinterleaver_indices.begin(), _deinterleaver_indices.end(), 0);
-    // sort indexes based on comparing values in v
-    std::sort(_deinterleaver_indices.begin(),
-              _deinterleaver_indices.end(),
-              [&interleaver_indices](size_t i1, size_t i2) {
-                  return interleaver_indices[i1] < interleaver_indices[i2];
-              });
+        // check bounds
+        if (index >= interleaver_indices.size()) {
+            throw std::invalid_argument(fmt::format(
+                "Incorrect interleaver indices! Expected {0} unique elements in the "
+                "range[0, {0}) in random order, but element {1} >= {0}!",
+                interleaver_indices.size(),
+                index));
+        }
+
+        // check for duplicate zero
+        if (index == 0) {
+            if (zero_seen) {
+                throw std::invalid_argument(fmt::format(
+                    "Incorrect interleaver indices! Expected {0} unique elements in the "
+                    "range[0, {0}) in random order, but element {1} appears twice, at "
+                    "positions {2} and {3}!",
+                    interleaver_indices.size(),
+                    index,
+                    deinterleaver_indices[index],
+                    counter));
+            }
+            zero_seen = true;
+            deinterleaver_indices[0] = counter;
+        }
+
+        // put into deinterleaver, check duplicity while doing that
+        else if (deinterleaver_indices[index] == 0) { // not yet used
+            deinterleaver_indices[index] = counter;
+        } else {
+            throw std::invalid_argument(fmt::format(
+                "Incorrect interleaver indices! Expected {0} unique elements in the "
+                "range[0, {0}) in random order, but element {1} appears twice, at "
+                "positions {2} and {3}!",
+                interleaver_indices.size(),
+                index,
+                deinterleaver_indices[index],
+                counter));
+        }
+    }
+
+    /* At this point, we have inserted all N elements from interleaver_indices into our
+     * deinterleaver_indices, no duplicates occurred during processing of N elements, and
+     * none was >= N, which implies the range is unique and consecutive from 0 to N-1.
+     */
+    _interleaver_indices = interleaver_indices;
+    _deinterleaver_indices = std::move(deinterleaver_indices);
 }
 
 } /* namespace kernel */

--- a/gr-blocks/python/blocks/qa_blockinterleaver_xx.py
+++ b/gr-blocks/python/blocks/qa_blockinterleaver_xx.py
@@ -15,6 +15,7 @@ import numpy as np
 class test_blockinterleaver_xx(gr_unittest.TestCase):
     def setUp(self):
         self.tb = gr.top_block()
+        np.random.seed(0x13375eed)
 
     def tearDown(self):
         self.tb = None


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This was noticed because of what is probably a stdlib bug that warns
about the result of `[[nodiscard]] std::unique` being discarded.
(`std::unique` has no business being `nodiscard`, imho.)

Looked at the code, it does a sort on a permutation vector just to check
whether it's unique and covers $\{0, …, N-1\}$, and then finally, it does
another sort to construct the deinterleaver taps.

Since this is mathematically simple, the deinterleaver tap at position i
simply being the interleaver position of i, and vice versa, the check
for uniqueness and the deinterleaver construction can be done in one
fell swoop. No sorting required!

Made the tests seeded, so that we don't get flaky tests when the random
generator asked to permute $(0, …, 15)$ happens to emit the first $K$
sorted, i.e., $(0, 1, …, K-1 , ×, …)$, which it does in $\frac{1}{N} \cdot  \frac{1}{N-1} … \frac{1}{N-K} = \frac{K!}{N!}$ cases.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

CI failing since update of the Fedora 40 container made it warn about the
`nodiscard` when building with `clang++`, and we have `-Werror` for that
platform.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
blockinterleaver

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

improved the existing tests, still pass
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
