### PR TITLE
Fix broken IIO attribute updater

### DIFF
--- a/gr-iio/python/iio/bindings/attr_updater_python.cc
+++ b/gr-iio/python/iio/bindings/attr_updater_python.cc
@@ -42,7 +42,7 @@ void bind_attr_updater(py::module& m)
              py::arg("interval_ms"),
              D(attr_updater, make))
 
-        .def("set_params",
+        .def("set_value",
              &attr_updater::set_value,
              py::arg("value"),
              D(attr_updater, make))


### PR DESCRIPTION
## Description
IIO attr updater is broken - flowgraph crashes if callback is called

## Related Issue
This fixes https://ez.analog.com/linux-software-drivers/f/q-a/558818/adrv9009-rx-to-tx

## Which blocks/areas does this affect?
gr-iio
## Testing Done
Flowgraph doesn't crash anymore, IIO attribute is changed correctly.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [n/a] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
