### PR TITLE
modtool: appending to CMake lists should respect closing `)`

### DIFF
--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -9,9 +9,8 @@
 """ Utility functions for gr_modtool """
 
 
-import re
-import sys
 import os
+import re
 try:
     import readline
     have_readline = True
@@ -21,10 +20,17 @@ except ImportError:
 # None of these must depend on other modtool stuff!
 
 
-def append_re_line_sequence(filename, linepattern, newline):
-    """ Detects the re 'linepattern' in the file. After its last occurrence,
+def append_re_line_sequence(filename: str, linepattern: str, newline: str, closing_parentheses: str = ')') -> None:
+    """
+    Detects the re 'linepattern' in the file. After its last occurrence (and any other identical occurrences),
     paste 'newline'. If the pattern does not exist, append the new line
-    to the file. Then, write. """
+    to the file.
+
+    If 'closing_parentheses' is not None, e.g. ")", remove it from end of the matched line, paste the 'newline',
+    followed by a line containing the 'closing_parentheses'.
+
+    Finally, write the modified file.
+    """
     with open(filename, 'r') as f:
         oldfile = f.read()
     lines = re.findall(linepattern, oldfile, flags=re.MULTILINE)
@@ -33,7 +39,11 @@ def append_re_line_sequence(filename, linepattern, newline):
             f.write(newline)
         return
     last_line = lines[-1]
-    newfile = oldfile.replace(last_line, last_line + newline + '\n')
+    if closing_parentheses is not None and last_line.rstrip().endswith(closing_parentheses):
+        modified_last = f'\n{last_line.rstrip()[:-len(closing_parentheses)]}\n{closing_parentheses}\n'
+    else:
+        modified_last = last_line + '\n'
+    newfile = oldfile.replace(last_line, modified_last)
     with open(filename, 'w') as f:
         f.write(newfile)
 


### PR DESCRIPTION
## Description
When in commit 1e276f165ea7fd482102ca10a80076c61ad5ac07 unnecessary line
breaks were removed, appending to the C++ QA sources list in the
lib/CMakeLists.txt, failed, and thus, adding of C++ unit testing broke
the build.

The quick fix would have been to add the line breaks back to the
template. However, this cannot change existing OOTs; thus, the parsing
function needed to be amended to allow for working with existing OOTs.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7131

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

modtool

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

https://gist.github.com/marcusmueller/9280bc7482d4cb616d2e303c8afcf430

Runs through; need to add fully automated unit tests once that's possible.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
