### PR TITLE
modtool: replace pkg_resources with import.metadata when available

### DIFF
--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -14,8 +14,15 @@ import sys
 import logging
 import functools
 from importlib import import_module
-from pkg_resources import iter_entry_points
-from logging import Formatter, StreamHandler
+try:
+    from importlib.metadata import entry_points
+
+    def entries(group: str):
+        return entry_points().select(group=group)
+except ImportError:
+    from pkg_resources import iter_entry_points as entries
+
+from logging import StreamHandler
 
 import click
 from click import ClickException
@@ -140,10 +147,10 @@ block_name = click.argument(
     'blockname', nargs=1, required=False, metavar="BLOCK_NAME")
 
 
-@with_plugins(iter_entry_points('gnuradio.modtool.cli.plugins'))
+@with_plugins(entries('gnuradio.modtool.cli.plugins'))
 @click.command(cls=CommandCLI,
-               epilog='Manipulate with GNU Radio modules source code tree. ' +
-               'Call it without options to run specified command interactively')
+               epilog='Manipulate the source code tree of a GNU Radio module. ' +
+               'Call without options to run specified command interactively')
 def cli():
     """A tool for editing GNU Radio out-of-tree modules."""
     pass


### PR DESCRIPTION
## Description

Relevant, since pkg_resources has been deprecated.

Used only for click_plugins, which has not been actively maintained
since 2019.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #7129

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

modtool only

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

ran gr_modtool, still lists all commands.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
