### PR TITLE
Remove ignored qualifiers

### DIFF
--- a/cmake/Modules/GrCompilerSettings.cmake
+++ b/cmake/Modules/GrCompilerSettings.cmake
@@ -99,6 +99,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     gr_add_cxx_compiler_flag_if_available(-Wsign-compare HAVE_WARN_SIGN_COMPARE)
     gr_add_cxx_compiler_flag_if_available(-Wall HAVE_WARN_ALL)
     gr_add_cxx_compiler_flag_if_available(-Wno-uninitialized HAVE_WARN_NO_UNINITIALIZED)
+    gr_add_cxx_compiler_flag_if_available(-Wignored-qualifiers HAVE_WARN_IGNORED_QUALIFIERS)
 endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
 if(MSVC)

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -134,15 +134,11 @@ bool to_bool(pmt_t val)
 //                             Symbols
 ////////////////////////////////////////////////////////////////////////////
 
-static const unsigned int get_symbol_hash_table_size()
-{
-    static const unsigned int SYMBOL_HASH_TABLE_SIZE = 8192;
-    return SYMBOL_HASH_TABLE_SIZE;
-}
+constexpr size_t SYMBOL_HASH_TABLE_SIZE = 8192;
 
 static std::vector<pmt_t>* get_symbol_hash_table()
 {
-    static std::vector<pmt_t> s_symbol_hash_table(get_symbol_hash_table_size());
+    static std::vector<pmt_t> s_symbol_hash_table(SYMBOL_HASH_TABLE_SIZE);
     return &s_symbol_hash_table;
 }
 
@@ -153,7 +149,7 @@ bool is_symbol(const pmt_t& obj) { return obj->is_symbol(); }
 
 pmt_t string_to_symbol(std::string_view name)
 {
-    unsigned hash = std::hash<std::string_view>{}(name) % get_symbol_hash_table_size();
+    unsigned hash = std::hash<std::string_view>{}(name) % SYMBOL_HASH_TABLE_SIZE;
 
     // Does a symbol with this name already exist?
     for (pmt_t sym = (*get_symbol_hash_table())[hash]; sym; sym = _symbol(sym)->next()) {

--- a/gr-channels/lib/sincostable.h
+++ b/gr-channels/lib/sincostable.h
@@ -19,17 +19,17 @@ public:
             d_cos[i] = ::cos(2 * GR_M_PI * i / tbl_size);
         }
     }
-    const float sin(float x)
+    float sin(float x) const
     {
         int idx = (((int)(x * d_scale)) + d_sz - d_sz / 4) % d_sz;
         return d_cos[idx];
     }
-    const float cos(float x)
+    float cos(float x) const
     {
         int idx = (((int)(x * d_scale)) + d_sz) % d_sz;
         return d_cos[idx];
     }
-    const float sinc(float x) { return x == 0 ? 1 : sin(x) / x; }
+    float sinc(float x) const { return x == 0 ? 1 : sin(x) / x; }
 };
 
 #endif

--- a/gr-digital/include/gnuradio/digital/ofdm_carrier_allocator_cvc.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_carrier_allocator_cvc.h
@@ -62,7 +62,7 @@ public:
     typedef std::shared_ptr<ofdm_carrier_allocator_cvc> sptr;
 
     virtual std::string len_tag_key() = 0;
-    virtual const int fft_len() = 0;
+    virtual int fft_len() const = 0;
     virtual std::vector<std::vector<int>> occupied_carriers() = 0;
 
     /*

--- a/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.h
+++ b/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.h
@@ -48,7 +48,7 @@ public:
 
     std::string len_tag_key() override { return d_length_tag_key_str; };
 
-    const int fft_len() override { return d_fft_len; };
+    int fft_len() const override { return d_fft_len; };
     std::vector<std::vector<int>> occupied_carriers() override
     {
         return d_occupied_carriers;

--- a/gr-digital/python/digital/bindings/ofdm_carrier_allocator_cvc_python.cc
+++ b/gr-digital/python/digital/bindings/ofdm_carrier_allocator_cvc_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(ofdm_carrier_allocator_cvc.h) */
-/* BINDTOOL_HEADER_FILE_HASH(eaa22bce0f02bc731048983fe56966a4)                     */
+/* BINDTOOL_HEADER_FILE(ofdm_carrier_allocator_cvc.h)                              */
+/* BINDTOOL_HEADER_FILE_HASH(63912f69c0e850221be1aa7d19ef675d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/include/gnuradio/fec/polar_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_common.h
@@ -69,9 +69,9 @@ public:
     ~polar_common();
 
 protected:
-    const int block_size() const { return d_block_size; };
-    const int block_power() const { return d_block_power; };
-    const int num_info_bits() const { return d_num_info_bits; };
+    int block_size() const { return d_block_size; };
+    int block_power() const { return d_block_power; };
+    int num_info_bits() const { return d_num_info_bits; };
 
     // helper functions
     long bit_reverse(long value, int active_bits) const;

--- a/gr-fec/include/gnuradio/fec/polar_decoder_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_common.h
@@ -66,8 +66,8 @@ protected:
     };
 
     // control retrieval of frozen bits.
-    const bool is_frozen_bit(const int u_num) const;
-    const unsigned char next_frozen_bit();
+    bool is_frozen_bit(const int u_num) const;
+    unsigned char next_frozen_bit();
 
     // preparation for decoding
     void initialize_decoder(unsigned char* u, float* llrs, const float* input);

--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -136,14 +136,14 @@ void polar_decoder_common::odd_xor_even_values(unsigned char* u_xor,
     }
 }
 
-const bool polar_decoder_common::is_frozen_bit(const int u_num) const
+bool polar_decoder_common::is_frozen_bit(const int u_num) const
 {
     return d_frozen_bit_counter < d_frozen_bit_positions.size() &&
            u_num == d_frozen_bit_positions.at(d_frozen_bit_counter);
 }
 
 
-const unsigned char polar_decoder_common::next_frozen_bit()
+unsigned char polar_decoder_common::next_frozen_bit()
 {
     return d_frozen_bit_values[d_frozen_bit_counter++];
 }

--- a/gr-fec/lib/scl_list.h
+++ b/gr-fec/lib/scl_list.h
@@ -65,8 +65,8 @@ public:
     scl_list& operator=(const scl_list&) = delete;
 
     virtual ~scl_list();
-    const unsigned int size() const { return d_list_size; };
-    const unsigned int active_size() const { return d_active_path_counter; };
+    unsigned int size() const { return d_list_size; };
+    unsigned int active_size() const { return d_active_path_counter; };
 
     path* initial_path() const { return d_path_list[0]; };
     path* next_active_path() { return d_path_list[d_active_pos++]; };

--- a/gr-fec/python/fec/bindings/polar_common_python.cc
+++ b/gr-fec/python/fec/bindings/polar_common_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(polar_common.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9ebf708c1ab88b66055a5aa54159d6b1)                     */
+/* BINDTOOL_HEADER_FILE(polar_common.h)                                            */
+/* BINDTOOL_HEADER_FILE_HASH(187708e909af207fc760cef61c2f4b64)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_decoder_common_python.cc
+++ b/gr-fec/python/fec/bindings/polar_decoder_common_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(polar_decoder_common.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2044106c875be27e2ae14be78a41f9cc)                     */
+/* BINDTOOL_HEADER_FILE(polar_decoder_common.h)                                    */
+/* BINDTOOL_HEADER_FILE_HASH(218d7a62038392c8e14b6411861fdd41)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -130,25 +130,25 @@ public:
     int getLineWidth8() const;
     int getLineWidth9() const;
 
-    const Qt::PenStyle getLineStyle1() const;
-    const Qt::PenStyle getLineStyle2() const;
-    const Qt::PenStyle getLineStyle3() const;
-    const Qt::PenStyle getLineStyle4() const;
-    const Qt::PenStyle getLineStyle5() const;
-    const Qt::PenStyle getLineStyle6() const;
-    const Qt::PenStyle getLineStyle7() const;
-    const Qt::PenStyle getLineStyle8() const;
-    const Qt::PenStyle getLineStyle9() const;
+    Qt::PenStyle getLineStyle1() const;
+    Qt::PenStyle getLineStyle2() const;
+    Qt::PenStyle getLineStyle3() const;
+    Qt::PenStyle getLineStyle4() const;
+    Qt::PenStyle getLineStyle5() const;
+    Qt::PenStyle getLineStyle6() const;
+    Qt::PenStyle getLineStyle7() const;
+    Qt::PenStyle getLineStyle8() const;
+    Qt::PenStyle getLineStyle9() const;
 
-    const QwtSymbol::Style getLineMarker1() const;
-    const QwtSymbol::Style getLineMarker2() const;
-    const QwtSymbol::Style getLineMarker3() const;
-    const QwtSymbol::Style getLineMarker4() const;
-    const QwtSymbol::Style getLineMarker5() const;
-    const QwtSymbol::Style getLineMarker6() const;
-    const QwtSymbol::Style getLineMarker7() const;
-    const QwtSymbol::Style getLineMarker8() const;
-    const QwtSymbol::Style getLineMarker9() const;
+    QwtSymbol::Style getLineMarker1() const;
+    QwtSymbol::Style getLineMarker2() const;
+    QwtSymbol::Style getLineMarker3() const;
+    QwtSymbol::Style getLineMarker4() const;
+    QwtSymbol::Style getLineMarker5() const;
+    QwtSymbol::Style getLineMarker6() const;
+    QwtSymbol::Style getLineMarker7() const;
+    QwtSymbol::Style getLineMarker8() const;
+    QwtSymbol::Style getLineMarker9() const;
 
     int getMarkerAlpha1() const;
     int getMarkerAlpha2() const;
@@ -183,9 +183,9 @@ public slots:
     virtual void setLineWidth(unsigned int which, int width);
     virtual int getLineWidth(unsigned int which) const;
     virtual void setLineStyle(unsigned int which, Qt::PenStyle style);
-    virtual const Qt::PenStyle getLineStyle(unsigned int which) const;
+    virtual Qt::PenStyle getLineStyle(unsigned int which) const;
     virtual void setLineMarker(unsigned int which, QwtSymbol::Style marker);
-    virtual const QwtSymbol::Style getLineMarker(unsigned int which) const;
+    virtual QwtSymbol::Style getLineMarker(unsigned int which) const;
     virtual void setMarkerAlpha(unsigned int which, int alpha);
     virtual int getMarkerAlpha(unsigned int which) const;
 

--- a/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
@@ -53,9 +53,9 @@ public:
 
     double sampleRate() const;
 
-    const QColor getTagTextColor();
-    const QColor getTagBackgroundColor();
-    const Qt::BrushStyle getTagBackgroundStyle();
+    const QColor getTagTextColor() const;
+    const QColor getTagBackgroundColor() const;
+    Qt::BrushStyle getTagBackgroundStyle() const;
     void setLineColor(unsigned int which, QColor color) override;
     void setLineWidth(unsigned int which, int width) override;
     void setLineMarker(unsigned int which, QwtSymbol::Style marker) override;

--- a/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
@@ -82,16 +82,16 @@ public:
     void setBGColour(QColor c);
     void showCFMarker(const bool);
 
-    const bool getMaxFFTVisible() const;
-    const bool getMinFFTVisible() const;
+    bool getMaxFFTVisible() const;
+    bool getMinFFTVisible() const;
     const QColor getMinFFTColor() const;
     const QColor getMaxFFTColor() const;
     const QColor getMarkerLowerIntensityColor() const;
-    const bool getMarkerLowerIntensityVisible() const;
+    bool getMarkerLowerIntensityVisible() const;
     const QColor getMarkerUpperIntensityColor() const;
-    const bool getMarkerUpperIntensityVisible() const;
+    bool getMarkerUpperIntensityVisible() const;
     const QColor getMarkerPeakAmplitudeColor() const;
-    const bool getMarkerNoiseFloorAmplitudeVisible() const;
+    bool getMarkerNoiseFloorAmplitudeVisible() const;
     const QColor getMarkerNoiseFloorAmplitudeColor() const;
     const QColor getMarkerCFColor() const;
 

--- a/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
@@ -53,9 +53,9 @@ public:
 
     double sampleRate() const;
 
-    const QColor getTagTextColor();
-    const QColor getTagBackgroundColor();
-    const Qt::BrushStyle getTagBackgroundStyle();
+    const QColor getTagTextColor() const;
+    const QColor getTagBackgroundColor() const;
+    Qt::BrushStyle getTagBackgroundStyle() const;
 
 public slots:
     void setSampleRate(double sr, double units, const std::string& strunits);

--- a/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
@@ -76,15 +76,15 @@ public:
     void setTraceColour(QColor);
     void setBGColour(QColor c);
 
-    const bool getMaxVecVisible() const;
-    const bool getMinVecVisible() const;
+    bool getMaxVecVisible() const;
+    bool getMinVecVisible() const;
     const QColor getMinVecColor() const;
     const QColor getMaxVecColor() const;
     const QColor getMarkerLowerIntensityColor() const;
-    const bool getMarkerLowerIntensityVisible() const;
+    bool getMarkerLowerIntensityVisible() const;
     const QColor getMarkerUpperIntensityColor() const;
-    const bool getMarkerUpperIntensityVisible() const;
-    const bool getMarkerRefLevelAmplitudeVisible() const;
+    bool getMarkerUpperIntensityVisible() const;
+    bool getMarkerRefLevelAmplitudeVisible() const;
     const QColor getMarkerRefLevelAmplitudeColor() const;
 
 public slots:

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -141,12 +141,9 @@ QColor DisplayPlot::getLineColor(unsigned int which) const
     void DisplayPlot::setLineWidth##i(int width) { setLineWidth(im1, width); }          \
     int DisplayPlot::getLineWidth##i() const { return getLineWidth(im1); }              \
     void DisplayPlot::setLineStyle##i(Qt::PenStyle ps) { setLineStyle(im1, ps); }       \
-    const Qt::PenStyle DisplayPlot::getLineStyle##i() const                             \
-    {                                                                                   \
-        return getLineStyle(im1);                                                       \
-    }                                                                                   \
+    Qt::PenStyle DisplayPlot::getLineStyle##i() const { return getLineStyle(im1); }     \
     void DisplayPlot::setLineMarker##i(QwtSymbol::Style ms) { setLineMarker(im1, ms); } \
-    const QwtSymbol::Style DisplayPlot::getLineMarker##i() const                        \
+    QwtSymbol::Style DisplayPlot::getLineMarker##i() const                              \
     {                                                                                   \
         return getLineMarker(im1);                                                      \
     }                                                                                   \
@@ -268,7 +265,7 @@ void DisplayPlot::setLineStyle(unsigned int which, Qt::PenStyle style)
     }
 }
 
-const Qt::PenStyle DisplayPlot::getLineStyle(unsigned int which) const
+Qt::PenStyle DisplayPlot::getLineStyle(unsigned int which) const
 {
     if (which < d_nplots) {
         return d_plot_curve[which]->pen().style();
@@ -288,7 +285,7 @@ void DisplayPlot::setLineMarker(unsigned int which, QwtSymbol::Style marker)
     }
 }
 
-const QwtSymbol::Style DisplayPlot::getLineMarker(unsigned int which) const
+QwtSymbol::Style DisplayPlot::getLineMarker(unsigned int which) const
 {
     if (which < d_nplots) {
         QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();

--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -450,11 +450,14 @@ void EyeDisplayPlot::enableTagMarker(unsigned int which, bool en)
             "TimeDomainDisplayPlot: enabled tag marker does not exist.");
 }
 
-const QColor EyeDisplayPlot::getTagTextColor() { return d_tag_text_color; }
+const QColor EyeDisplayPlot::getTagTextColor() const { return d_tag_text_color; }
 
-const QColor EyeDisplayPlot::getTagBackgroundColor() { return d_tag_background_color; }
+const QColor EyeDisplayPlot::getTagBackgroundColor() const
+{
+    return d_tag_background_color;
+}
 
-const Qt::BrushStyle EyeDisplayPlot::getTagBackgroundStyle()
+Qt::BrushStyle EyeDisplayPlot::getTagBackgroundStyle() const
 {
     return d_tag_background_style;
 }

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -411,7 +411,7 @@ void FrequencyDisplayPlot::setMaxFFTVisible(const bool visibleFlag)
     d_max_fft_plot_curve->setVisible(visibleFlag);
 }
 
-const bool FrequencyDisplayPlot::getMaxFFTVisible() const { return d_max_fft_visible; }
+bool FrequencyDisplayPlot::getMaxFFTVisible() const { return d_max_fft_visible; }
 
 void FrequencyDisplayPlot::setMinFFTVisible(const bool visibleFlag)
 {
@@ -419,7 +419,7 @@ void FrequencyDisplayPlot::setMinFFTVisible(const bool visibleFlag)
     d_min_fft_plot_curve->setVisible(visibleFlag);
 }
 
-const bool FrequencyDisplayPlot::getMinFFTVisible() const { return d_min_fft_visible; }
+bool FrequencyDisplayPlot::getMinFFTVisible() const { return d_min_fft_visible; }
 
 void FrequencyDisplayPlot::_resetXAxisPoints()
 {
@@ -520,7 +520,7 @@ void FrequencyDisplayPlot::setMarkerLowerIntensityVisible(bool visible)
     else
         d_lower_intensity_marker->setLineStyle(QwtPlotMarker::NoLine);
 }
-const bool FrequencyDisplayPlot::getMarkerLowerIntensityVisible() const
+bool FrequencyDisplayPlot::getMarkerLowerIntensityVisible() const
 {
     return d_marker_lower_intensity_visible;
 }
@@ -545,7 +545,7 @@ void FrequencyDisplayPlot::setMarkerUpperIntensityVisible(bool visible)
         d_upper_intensity_marker->setLineStyle(QwtPlotMarker::NoLine);
 }
 
-const bool FrequencyDisplayPlot::getMarkerUpperIntensityVisible() const
+bool FrequencyDisplayPlot::getMarkerUpperIntensityVisible() const
 {
     return d_marker_upper_intensity_visible;
 }
@@ -586,7 +586,7 @@ void FrequencyDisplayPlot::setMarkerNoiseFloorAmplitudeVisible(bool visible)
         d_marker_noise_floor_amplitude->setLineStyle(QwtPlotMarker::NoLine);
 }
 
-const bool FrequencyDisplayPlot::getMarkerNoiseFloorAmplitudeVisible() const
+bool FrequencyDisplayPlot::getMarkerNoiseFloorAmplitudeVisible() const
 {
     return d_marker_noise_floor_amplitude_visible;
 }

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -488,14 +488,14 @@ void TimeDomainDisplayPlot::enableTagMarker(unsigned int which, bool en)
             "TimeDomainDisplayPlot: enabled tag marker does not exist.");
 }
 
-const QColor TimeDomainDisplayPlot::getTagTextColor() { return d_tag_text_color; }
+const QColor TimeDomainDisplayPlot::getTagTextColor() const { return d_tag_text_color; }
 
-const QColor TimeDomainDisplayPlot::getTagBackgroundColor()
+const QColor TimeDomainDisplayPlot::getTagBackgroundColor() const
 {
     return d_tag_background_color;
 }
 
-const Qt::BrushStyle TimeDomainDisplayPlot::getTagBackgroundStyle()
+Qt::BrushStyle TimeDomainDisplayPlot::getTagBackgroundStyle() const
 {
     return d_tag_background_style;
 }

--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -339,7 +339,7 @@ void VectorDisplayPlot::setMaxVecVisible(const bool visibleFlag)
     d_max_vec_plot_curve->setVisible(visibleFlag);
 }
 
-const bool VectorDisplayPlot::getMaxVecVisible() const { return d_max_vec_visible; }
+bool VectorDisplayPlot::getMaxVecVisible() const { return d_max_vec_visible; }
 
 void VectorDisplayPlot::setMinVecVisible(const bool visibleFlag)
 {
@@ -347,7 +347,7 @@ void VectorDisplayPlot::setMinVecVisible(const bool visibleFlag)
     d_min_vec_plot_curve->setVisible(visibleFlag);
 }
 
-const bool VectorDisplayPlot::getMinVecVisible() const { return d_min_vec_visible; }
+bool VectorDisplayPlot::getMinVecVisible() const { return d_min_vec_visible; }
 
 void VectorDisplayPlot::_resetXAxisPoints()
 {
@@ -428,7 +428,7 @@ void VectorDisplayPlot::setMarkerLowerIntensityVisible(bool visible)
     else
         d_lower_intensity_marker->setLineStyle(QwtPlotMarker::NoLine);
 }
-const bool VectorDisplayPlot::getMarkerLowerIntensityVisible() const
+bool VectorDisplayPlot::getMarkerLowerIntensityVisible() const
 {
     return d_marker_lower_intensity_visible;
 }
@@ -453,7 +453,7 @@ void VectorDisplayPlot::setMarkerUpperIntensityVisible(bool visible)
         d_upper_intensity_marker->setLineStyle(QwtPlotMarker::NoLine);
 }
 
-const bool VectorDisplayPlot::getMarkerUpperIntensityVisible() const
+bool VectorDisplayPlot::getMarkerUpperIntensityVisible() const
 {
     return d_marker_upper_intensity_visible;
 }
@@ -478,7 +478,7 @@ void VectorDisplayPlot::setMarkerRefLevelAmplitudeVisible(bool visible)
         d_marker_ref_level->setLineStyle(QwtPlotMarker::NoLine);
 }
 
-const bool VectorDisplayPlot::getMarkerRefLevelAmplitudeVisible() const
+bool VectorDisplayPlot::getMarkerRefLevelAmplitudeVisible() const
 {
     return d_marker_ref_level_visible;
 }


### PR DESCRIPTION
## Description
Don't const-qualify POD return types; doing so is ignored and may lead to user confusion. This fixes `-Wignored-qualifiers` warnings.

Also, turn on `-Wignored-qualifiers` by default to try to stave off regressions.

## Which blocks/areas does this affect?
None (code generation is unchanged).

## Testing Done
Compiled locally with `-Werror=ignored-qualifiers` on Fedora 39.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. (Not applicable.)
- [x] I have added tests to cover my changes, and all previous tests pass. (No new tests as no code was added.)
