### PR TITLE
grc-qt: Make more robust for to missing manifest dir and example paths

### DIFF
--- a/grc/gui_qt/components/example_browser.py
+++ b/grc/gui_qt/components/example_browser.py
@@ -253,8 +253,8 @@ class ExampleBrowser(QWidget, base.Component):
         with Cache(Constants.EXAMPLE_CACHE_FILE, log=False) as cache:
             for entry in self.platform.config.example_paths:
                 if entry == '':
-                    log.error("Empty example path!")
-                    break
+                    log.info("Empty example path!")
+                    continue
                 examples_dict[entry] = []
                 if os.path.isdir(entry):
                     subdirs = 0

--- a/grc/gui_qt/components/oot_browser.py
+++ b/grc/gui_qt/components/oot_browser.py
@@ -31,6 +31,9 @@ class OOTBrowser(QtWidgets.QDialog, base.Component):
 
         self.manifest_dir = os.path.join(Paths.RESOURCES, "manifests")
 
+        if not os.path.exists(self.manifest_dir):
+            return
+
         for f in os.listdir(self.manifest_dir):
             with open(os.path.join(self.manifest_dir, f), 'r', encoding='utf8') as manifest:
                 text = manifest.read()


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Don't error or stop when a manifest directory or example directory is missing.

In the case of a missing manifest directory, this currently happens with the conda package because the build doesn't install any files into that directory and so conda skips including an empty directory in the package.

In the case of a missing example directory, the current behavior just stops processing example directories when one specified doesn't exist. That includes valid directories that may appear later in the list! This change simply skips the missing directory and continues to process what remains in the list. A missing directory can easily occur if the one specified in the config file is invalid or empty.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
grc-qt

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I added these patches into my latest conda-forge package and confirmed that they fix an error that prevented grc-qt running with a missing manifest directory and enable the example browser to load the distributed examples when the path in the config file is empty.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- ~[ ] I have added tests to cover my changes, and all previous tests pass.~
