### PR TITLE
grc-qt: Don't throw error when missing blocks have connections

### DIFF
--- a/grc/gui_qt/components/canvas/port.py
+++ b/grc/gui_qt/components/canvas/port.py
@@ -65,6 +65,10 @@ class GUIPort(QGraphicsItem):
         # TODO: Move somewhere else? Not necessarily
         self.core.parent_flowgraph.gui.addItem(self)
 
+        """ Dummy blocks instantiate ports only when a connection to them is created. """
+        if self.core.parent_block.is_dummy_block:
+            self.setParentItem(self.core.parent_block.gui)
+
     def update_connections(self):
         if self.core._dir == "sink":
             self.connection_point = self.mapToScene(QPointF(-10.0, self.height / 2.0))
@@ -84,6 +88,10 @@ class GUIPort(QGraphicsItem):
     def create_shapes_and_labels(self):
         self.auto_hide_port_labels = self.core.parent.parent.gui.app.qsettings.value(
             'grc/auto_hide_port_labels', type=bool)
+        """
+        The GUI port is instantiated before its parent block. Therefore we set the parent here,
+        not in the constructor. Exception: dummy block ports, see __init__() above
+        """
         if not self.parentItem():
             self.setParentItem(self.core.parent_block.gui)
 

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -951,6 +951,11 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
                 self.connect_fg_signals(self.currentFlowgraphScene)
                 self.currentFlowgraphScene.saved = True
                 self.currentFlowgraphScene.save_allowed = save_allowed
+                self.currentFlowgraphScene.core.rewrite()
+                self.currentFlowgraphScene.core.validate()
+                for block in self.currentFlowgraphScene.core.blocks:
+                    block.gui.create_shapes_and_labels()
+                self.currentFlowgraphScene.update_elements_to_draw()
             else:
                 self.tabWidget.setCurrentIndex(open_fgs.index(filename))
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
See https://github.com/gnuradio/gnuradio/issues/7295. Ports of missing blocks are instantiated after the actual block: https://github.com/gnuradio/gnuradio/blob/72e21b54c44c360d511371420e74be4a6b2bfda6/grc/core/FlowGraph.py#L494

Missing blocks that do not have connections are not affected. 

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
https://github.com/gnuradio/gnuradio/issues/7295

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
GRC Qt ports

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
