### PR TITLE
Reduce const-related warnings

### DIFF
--- a/cmake/Modules/GrCompilerSettings.cmake
+++ b/cmake/Modules/GrCompilerSettings.cmake
@@ -100,6 +100,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     gr_add_cxx_compiler_flag_if_available(-Wall HAVE_WARN_ALL)
     gr_add_cxx_compiler_flag_if_available(-Wno-uninitialized HAVE_WARN_NO_UNINITIALIZED)
     gr_add_cxx_compiler_flag_if_available(-Wignored-qualifiers HAVE_WARN_IGNORED_QUALIFIERS)
+    gr_add_cxx_compiler_flag_if_available(-Wcast-qual HAVE_WARN_CAST_QUAL)
 endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
 if(MSVC)

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -361,7 +361,7 @@ void flat_flowgraph::setup_buffer_alignment(block_sptr block)
 {
     const int alignment = volk_get_alignment();
     for (int i = 0; i < block->detail()->ninputs(); i++) {
-        void* r = (void*)block->detail()->input(i)->read_pointer();
+        const void* r = (const void*)block->detail()->input(i)->read_pointer();
         uintptr_t ri = (uintptr_t)r % alignment;
         // std::cerr << "reader: " << r << "  alignment: " << ri << std::endl;
         if (ri != 0) {

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -99,7 +99,7 @@ static bool serialize_untagged_u64(uint64_t i, std::streambuf& sb)
 static bool
 serialize_untagged_u8_array(const uint8_t* data, size_t length, std::streambuf& sb)
 {
-    return sb.sputn((char*)data, length) != std::streambuf::traits_type::eof();
+    return sb.sputn((const char*)data, length) != std::streambuf::traits_type::eof();
 }
 
 static bool
@@ -109,7 +109,7 @@ serialize_untagged_u16_array(const uint16_t* data, size_t length, std::streambuf
     for (size_t i = 0; i < length; i++) {
         native_to_big_u16(data[i], &bedata[sizeof(uint16_t) * i]);
     }
-    return sb.sputn((char*)&bedata[0], length * sizeof(uint16_t)) !=
+    return sb.sputn((const char*)&bedata[0], length * sizeof(uint16_t)) !=
            std::streambuf::traits_type::eof();
 }
 
@@ -120,7 +120,7 @@ serialize_untagged_u32_array(const uint32_t* data, size_t length, std::streambuf
     for (size_t i = 0; i < length; i++) {
         native_to_big_u32(data[i], &bedata[sizeof(uint32_t) * i]);
     }
-    return sb.sputn((char*)&bedata[0], length * sizeof(uint32_t)) !=
+    return sb.sputn((const char*)&bedata[0], length * sizeof(uint32_t)) !=
            std::streambuf::traits_type::eof();
 }
 
@@ -131,7 +131,7 @@ serialize_untagged_u64_array(const uint64_t* data, size_t length, std::streambuf
     for (size_t i = 0; i < length; i++) {
         native_to_big_u64(data[i], &bedata[sizeof(uint64_t) * i]);
     }
-    return sb.sputn((char*)&bedata[0], length * sizeof(uint64_t)) !=
+    return sb.sputn((const char*)&bedata[0], length * sizeof(uint64_t)) !=
            std::streambuf::traits_type::eof();
 }
 
@@ -415,7 +415,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u8_array(
-                (uint8_t*)&s8vector_elements(obj)[0], vec_len, sb);
+                (const uint8_t*)&s8vector_elements(obj)[0], vec_len, sb);
 
             return ok;
         }
@@ -441,7 +441,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u16_array(
-                (uint16_t*)&s16vector_elements(obj)[0], vec_len, sb);
+                (const uint16_t*)&s16vector_elements(obj)[0], vec_len, sb);
             return ok;
         }
 
@@ -466,7 +466,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u32_array(
-                (uint32_t*)&s32vector_elements(obj)[0], vec_len, sb);
+                (const uint32_t*)&s32vector_elements(obj)[0], vec_len, sb);
             return ok;
         }
 
@@ -491,7 +491,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u64_array(
-                (uint64_t*)&s64vector_elements(obj)[0], vec_len, sb);
+                (const uint64_t*)&s64vector_elements(obj)[0], vec_len, sb);
             return ok;
         }
 
@@ -504,7 +504,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u32_array(
-                (uint32_t*)&f32vector_elements(obj)[0], vec_len, sb);
+                (const uint32_t*)&f32vector_elements(obj)[0], vec_len, sb);
             return ok;
         }
 
@@ -517,7 +517,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u64_array(
-                (uint64_t*)&f64vector_elements(obj)[0], vec_len, sb);
+                (const uint64_t*)&f64vector_elements(obj)[0], vec_len, sb);
             return ok;
         }
 
@@ -530,7 +530,7 @@ tail_recursion:
                 ok &= serialize_untagged_u8(0, sb);
             }
             ok &= serialize_untagged_u32_array(
-                (uint32_t*)&c32vector_elements(obj)[0], vec_len * 2, sb);
+                (const uint32_t*)&c32vector_elements(obj)[0], vec_len * 2, sb);
             return ok;
         }
 
@@ -544,7 +544,7 @@ tail_recursion:
             }
             // No known portable 128 bit swap function, so double the length
             ok &= serialize_untagged_u64_array(
-                (uint64_t*)&c64vector_elements(obj)[0], vec_len * 2, sb);
+                (const uint64_t*)&c64vector_elements(obj)[0], vec_len * 2, sb);
             return ok;
         }
     }

--- a/gnuradio-runtime/lib/qa_buffer.cc
+++ b/gnuradio-runtime/lib/qa_buffer.cc
@@ -114,7 +114,7 @@ static void t1_body()
     int ia = r1->items_available();
     BOOST_CHECK_EQUAL(write_counter, ia);
 
-    int* rp = (int*)r1->read_pointer();
+    const int* rp = (const int*)r1->read_pointer();
     BOOST_CHECK(rp != 0);
 
     for (int i = 0; i < ia / 2; i++) {
@@ -127,7 +127,7 @@ static void t1_body()
     // read the rest
 
     ia = r1->items_available();
-    rp = (int*)r1->read_pointer();
+    rp = (const int*)r1->read_pointer();
     BOOST_CHECK(rp != 0);
 
     for (int i = 0; i < ia; i++) {
@@ -157,7 +157,7 @@ static void t2_body()
     int write_counter = 0;
     int n;
     int* wp = 0;
-    int* rp = 0;
+    const int* rp = 0;
 
     // Write 3/4 of buffer
 
@@ -172,7 +172,7 @@ static void t2_body()
 
     int m = r1->items_available();
     BOOST_CHECK_EQUAL(n, m);
-    rp = (int*)r1->read_pointer();
+    rp = (const int*)r1->read_pointer();
 
     for (int i = 0; i < m; i++) {
         BOOST_CHECK_EQUAL(read_counter, *rp);
@@ -196,7 +196,7 @@ static void t2_body()
 
     m = r1->items_available();
     BOOST_CHECK_EQUAL(n, m);
-    rp = (int*)r1->read_pointer();
+    rp = (const int*)r1->read_pointer();
 
     for (int i = 0; i < m; i++) {
         BOOST_CHECK_EQUAL(read_counter, *rp);
@@ -244,7 +244,7 @@ static void t3_body()
         int r = (int)(N * random.ran1());
 
         int m = reader[r]->items_available();
-        int* rp = (int*)reader[r]->read_pointer();
+        const int* rp = (const int*)reader[r]->read_pointer();
 
         for (int i = 0; i < m; i++) {
             BOOST_CHECK_EQUAL(read_counter[r], *rp);

--- a/gr-analog/lib/fmdet_cf_impl.cc
+++ b/gr-analog/lib/fmdet_cf_impl.cc
@@ -60,7 +60,7 @@ int fmdet_cf_impl::work(int noutput_items,
                         gr_vector_const_void_star& input_items,
                         gr_vector_void_star& output_items)
 {
-    const gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     float* optr = (float*)output_items[0];
 
     int size = noutput_items;

--- a/gr-analog/lib/pll_carriertracking_cc_impl.cc
+++ b/gr-analog/lib/pll_carriertracking_cc_impl.cc
@@ -57,7 +57,7 @@ int pll_carriertracking_cc_impl::work(int noutput_items,
                                       gr_vector_const_void_star& input_items,
                                       gr_vector_void_star& output_items)
 {
-    const gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     gr_complex* optr = (gr_complex*)output_items[0];
 
     float error;

--- a/gr-analog/lib/pll_freqdet_cf_impl.cc
+++ b/gr-analog/lib/pll_freqdet_cf_impl.cc
@@ -56,7 +56,7 @@ int pll_freqdet_cf_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    const gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     float* optr = (float*)output_items[0];
 
     float error;

--- a/gr-analog/lib/pll_refout_cc_impl.cc
+++ b/gr-analog/lib/pll_refout_cc_impl.cc
@@ -39,7 +39,7 @@ int pll_refout_cc_impl::work(int noutput_items,
                              gr_vector_const_void_star& input_items,
                              gr_vector_void_star& output_items)
 {
-    const gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     gr_complex* optr = (gr_complex*)output_items[0];
 
     float error;

--- a/gr-analog/lib/quadrature_demod_cf_impl.cc
+++ b/gr-analog/lib/quadrature_demod_cf_impl.cc
@@ -43,7 +43,7 @@ int quadrature_demod_cf_impl::work(int noutput_items,
                                    gr_vector_const_void_star& input_items,
                                    gr_vector_void_star& output_items)
 {
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     float* out = (float*)output_items[0];
 
     std::vector<gr_complex> tmp(noutput_items);

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -217,8 +217,8 @@ int jack_sink::work(int noutput_items,
             write_space -= write_space % (d_jack_buffer_size * sizeof(sample_t));
             write_size = std::min(write_space, (unsigned int)work_size);
 
-            if (jack_ringbuffer_write(d_ringbuffer[i], (char*)&(in[i][k]), write_size) <
-                write_size) {
+            if (jack_ringbuffer_write(
+                    d_ringbuffer[i], (const char*)&(in[i][k]), write_size) < write_size) {
                 bail("jack_ringbuffer_write failed", 0);
             }
             work_size -= write_size;

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -181,7 +181,7 @@ int jack_source::work(int noutput_items,
                       gr_vector_void_star& output_items)
 {
 
-    const float** out = (const float**)&output_items[0];
+    float** out = (float**)&output_items[0];
 
     // Minimize latency
     noutput_items = std::min(noutput_items, (int)d_jack_buffer_size);

--- a/gr-blocks/lib/abs_blk_impl.cc
+++ b/gr-blocks/lib/abs_blk_impl.cc
@@ -39,7 +39,7 @@ int abs_blk_impl<T>::work(int noutput_items,
                           gr_vector_const_void_star& input_items,
                           gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     T* optr = (T*)output_items[0];
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {

--- a/gr-blocks/lib/add_blk_impl.cc
+++ b/gr-blocks/lib/add_blk_impl.cc
@@ -89,7 +89,7 @@ int add_blk_impl<T>::work(int noutput_items,
 
     memcpy(out, input_items[0], noi * sizeof(T));
     for (size_t i = 1; i < input_items.size(); i++) {
-        volk_add(out, (T*)input_items[i], noi);
+        volk_add(out, (const T*)input_items[i], noi);
     }
 
     return noutput_items;

--- a/gr-blocks/lib/add_const_v_impl.cc
+++ b/gr-blocks/lib/add_const_v_impl.cc
@@ -38,7 +38,7 @@ int add_const_v_impl<T>::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     T* optr = (T*)output_items[0];
 
     int nitems_per_block = this->output_signature()->sizeof_stream_item(0) / sizeof(T);

--- a/gr-blocks/lib/and_blk_impl.cc
+++ b/gr-blocks/lib/and_blk_impl.cc
@@ -44,9 +44,9 @@ int and_blk_impl<T>::work(int noutput_items,
     int ninputs = input_items.size();
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {
-        T acc = ((T*)input_items[0])[i];
+        T acc = ((const T*)input_items[0])[i];
         for (int j = 1; j < ninputs; j++)
-            acc &= ((T*)input_items[j])[i];
+            acc &= ((const T*)input_items[j])[i];
 
         *optr++ = (T)acc;
     }

--- a/gr-blocks/lib/and_const_impl.cc
+++ b/gr-blocks/lib/and_const_impl.cc
@@ -39,7 +39,7 @@ int and_const_impl<T>::work(int noutput_items,
                             gr_vector_const_void_star& input_items,
                             gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     T* optr = (T*)output_items[0];
 
     int size = noutput_items;

--- a/gr-blocks/lib/argmax_impl.cc
+++ b/gr-blocks/lib/argmax_impl.cc
@@ -49,14 +49,14 @@ int argmax_impl<T>::work(int noutput_items,
     std::int16_t* y_optr = (std::int16_t*)output_items[1];
 
     for (int i = 0; i < noutput_items; i++) {
-        T max = ((T*)input_items[0])[i * d_vlen];
+        T max = ((const T*)input_items[0])[i * d_vlen];
         int x = 0;
         int y = 0;
 
         for (int j = 0; j < (int)d_vlen; j++) {
             for (int k = 0; k < ninputs; k++) {
-                if (((T*)input_items[k])[i * d_vlen + j] > max) {
-                    max = ((T*)input_items[k])[i * d_vlen + j];
+                if (((const T*)input_items[k])[i * d_vlen + j] > max) {
+                    max = ((const T*)input_items[k])[i * d_vlen + j];
                     x = j;
                     y = k;
                 }

--- a/gr-blocks/lib/check_lfsr_32k_s_impl.cc
+++ b/gr-blocks/lib/check_lfsr_32k_s_impl.cc
@@ -50,7 +50,7 @@ int check_lfsr_32k_s_impl::work(int noutput_items,
                                 gr_vector_const_void_star& input_items,
                                 gr_vector_void_star& output_items)
 {
-    unsigned short* in = (unsigned short*)input_items[0];
+    const unsigned short* in = (const unsigned short*)input_items[0];
 
     for (int i = 0; i < noutput_items; i++) {
         unsigned short x = in[i];

--- a/gr-blocks/lib/conjugate_cc_impl.cc
+++ b/gr-blocks/lib/conjugate_cc_impl.cc
@@ -37,7 +37,7 @@ int conjugate_cc_impl::work(int noutput_items,
                             gr_vector_const_void_star& input_items,
                             gr_vector_void_star& output_items)
 {
-    gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     gr_complex* optr = (gr_complex*)output_items[0];
 
     volk_32fc_conjugate_32fc(optr, iptr, noutput_items);

--- a/gr-blocks/lib/divide_impl.cc
+++ b/gr-blocks/lib/divide_impl.cc
@@ -42,10 +42,10 @@ int divide_impl<float>::work(int noutput_items,
 {
     float* optr = (float*)output_items[0];
     size_t ninputs = input_items.size();
-    float* numerator = (float*)input_items[0];
+    const float* numerator = (const float*)input_items[0];
     for (size_t inp = 1; inp < ninputs; ++inp) {
         volk_32f_x2_divide_32f(
-            optr, numerator, (float*)input_items[inp], noutput_items * d_vlen);
+            optr, numerator, (const float*)input_items[inp], noutput_items * d_vlen);
         numerator = optr;
     }
 
@@ -68,10 +68,10 @@ int divide_impl<gr_complex>::work(int noutput_items,
 {
     gr_complex* optr = (gr_complex*)output_items[0];
     size_t ninputs = input_items.size();
-    gr_complex* numerator = (gr_complex*)input_items[0];
+    const gr_complex* numerator = (const gr_complex*)input_items[0];
     for (size_t inp = 1; inp < ninputs; ++inp) {
         volk_32fc_x2_divide_32fc(
-            optr, numerator, (gr_complex*)input_items[inp], noutput_items * d_vlen);
+            optr, numerator, (const gr_complex*)input_items[inp], noutput_items * d_vlen);
         numerator = optr;
     }
 
@@ -97,9 +97,9 @@ int divide_impl<T>::work(int noutput_items,
     int ninputs = input_items.size();
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {
-        T acc = ((T*)input_items[0])[i];
+        T acc = ((const T*)input_items[0])[i];
         for (int j = 1; j < ninputs; j++)
-            acc /= ((T*)input_items[j])[i];
+            acc /= ((const T*)input_items[j])[i];
 
         *optr++ = (T)acc;
     }

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -371,7 +371,7 @@ int file_meta_sink_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    char* inbuf = (char*)input_items[0];
+    const char* inbuf = (const char*)input_items[0];
     int nwritten = 0;
 
     do_update(); // update d_fp is reqd

--- a/gr-blocks/lib/float_to_complex_impl.cc
+++ b/gr-blocks/lib/float_to_complex_impl.cc
@@ -38,7 +38,7 @@ int float_to_complex_impl::work(int noutput_items,
                                 gr_vector_const_void_star& input_items,
                                 gr_vector_void_star& output_items)
 {
-    float* r = (float*)input_items[0];
+    const float* r = (const float*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     switch (input_items.size()) {
@@ -50,7 +50,7 @@ int float_to_complex_impl::work(int noutput_items,
     case 2: {
         // for (size_t j = 0; j < noutput_items*d_vlen; j++)
         //  out[j] = gr_complex (r[j], i[j]);
-        float* i = (float*)input_items[1];
+        const float* i = (const float*)input_items[1];
         volk_32f_x2_interleave_32fc(out, r, i, noutput_items * d_vlen);
         break;
     }

--- a/gr-blocks/lib/magphase_to_complex_impl.cc
+++ b/gr-blocks/lib/magphase_to_complex_impl.cc
@@ -38,8 +38,8 @@ int magphase_to_complex_impl::work(int noutput_items,
                                    gr_vector_const_void_star& input_items,
                                    gr_vector_void_star& output_items)
 {
-    float* mag = (float*)input_items[0];
-    float* phase = (float*)input_items[1];
+    const float* mag = (const float*)input_items[0];
+    const float* phase = (const float*)input_items[1];
     gr_complex* out = (gr_complex*)output_items[0];
 
     for (size_t j = 0; j < noutput_items * d_vlen; j++)

--- a/gr-blocks/lib/max_blk_impl.cc
+++ b/gr-blocks/lib/max_blk_impl.cc
@@ -52,12 +52,12 @@ int max_blk_impl<T>::work(int noutput_items,
 
     if (d_vlen_out == 1)
         for (int i = 0; i < noutput_items; i++) {
-            T max = ((T*)input_items[0])[i * d_vlen];
+            T max = ((const T*)input_items[0])[i * d_vlen];
 
             for (int j = 0; j < (int)d_vlen; j++) {
                 for (int k = 0; k < ninputs; k++) {
-                    if (((T*)input_items[k])[i * d_vlen + j] > max) {
-                        max = ((T*)input_items[k])[i * d_vlen + j];
+                    if (((const T*)input_items[k])[i * d_vlen + j] > max) {
+                        max = ((const T*)input_items[k])[i * d_vlen + j];
                     }
                 }
             }
@@ -67,11 +67,11 @@ int max_blk_impl<T>::work(int noutput_items,
 
     else // vector mode output
         for (size_t i = 0; i < (size_t)noutput_items * d_vlen_out; i++) {
-            T max = ((T*)input_items[0])[i];
+            T max = ((const T*)input_items[0])[i];
 
             for (int k = 1; k < ninputs; k++) {
-                if (((T*)input_items[k])[i] > max) {
-                    max = ((T*)input_items[k])[i];
+                if (((const T*)input_items[k])[i] > max) {
+                    max = ((const T*)input_items[k])[i];
                 }
             }
 

--- a/gr-blocks/lib/min_blk_impl.cc
+++ b/gr-blocks/lib/min_blk_impl.cc
@@ -52,11 +52,11 @@ int min_blk_impl<T>::work(int noutput_items,
 
     if (d_vlen_out == 1)
         for (int i = 0; i < noutput_items; i++) {
-            T min = ((T*)input_items[0])[i * d_vlen];
+            T min = ((const T*)input_items[0])[i * d_vlen];
             for (int j = 0; j < (int)d_vlen; j++) {
                 for (int k = 0; k < ninputs; k++) {
-                    if (((T*)input_items[k])[i * d_vlen + j] < min) {
-                        min = ((T*)input_items[k])[i * d_vlen + j];
+                    if (((const T*)input_items[k])[i * d_vlen + j] < min) {
+                        min = ((const T*)input_items[k])[i * d_vlen + j];
                     }
                 }
             }
@@ -65,10 +65,10 @@ int min_blk_impl<T>::work(int noutput_items,
 
     else // vector mode output
         for (size_t i = 0; i < noutput_items * d_vlen_out; i++) {
-            T min = ((T*)input_items[0])[i];
+            T min = ((const T*)input_items[0])[i];
             for (int k = 1; k < ninputs; k++) {
-                if (((T*)input_items[k])[i] < min) {
-                    min = ((T*)input_items[k])[i];
+                if (((const T*)input_items[k])[i] < min) {
+                    min = ((const T*)input_items[k])[i];
                 }
             }
             *optr++ = (T)min;

--- a/gr-blocks/lib/multiply_conjugate_cc_impl.cc
+++ b/gr-blocks/lib/multiply_conjugate_cc_impl.cc
@@ -38,8 +38,8 @@ int multiply_conjugate_cc_impl::work(int noutput_items,
                                      gr_vector_const_void_star& input_items,
                                      gr_vector_void_star& output_items)
 {
-    gr_complex* in0 = (gr_complex*)input_items[0];
-    gr_complex* in1 = (gr_complex*)input_items[1];
+    const gr_complex* in0 = (const gr_complex*)input_items[0];
+    const gr_complex* in1 = (const gr_complex*)input_items[1];
     gr_complex* out = (gr_complex*)output_items[0];
     int noi = d_vlen * noutput_items;
 

--- a/gr-blocks/lib/multiply_const_impl.cc
+++ b/gr-blocks/lib/multiply_const_impl.cc
@@ -98,7 +98,7 @@ int multiply_const_impl<T>::work(int noutput_items,
                                  gr_vector_const_void_star& input_items,
                                  gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     T* optr = (T*)output_items[0];
 
     int size = noutput_items * d_vlen;

--- a/gr-blocks/lib/multiply_const_v_impl.cc
+++ b/gr-blocks/lib/multiply_const_v_impl.cc
@@ -41,7 +41,7 @@ int multiply_const_v_impl<float>::work(int noutput_items,
                                        gr_vector_const_void_star& input_items,
                                        gr_vector_void_star& output_items)
 {
-    float* iptr = (float*)input_items[0];
+    const float* iptr = (const float*)input_items[0];
     float* optr = (float*)output_items[0];
 
     int nitems_per_block =
@@ -72,7 +72,7 @@ int multiply_const_v_impl<gr_complex>::work(int noutput_items,
                                             gr_vector_const_void_star& input_items,
                                             gr_vector_void_star& output_items)
 {
-    gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     gr_complex* optr = (gr_complex*)output_items[0];
 
     int nitems_per_block =
@@ -102,7 +102,7 @@ int multiply_const_v_impl<T>::work(int noutput_items,
                                    gr_vector_const_void_star& input_items,
                                    gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     T* optr = (T*)output_items[0];
 
     int nitems_per_block = this->output_signature()->sizeof_stream_item(0) / sizeof(T);

--- a/gr-blocks/lib/multiply_impl.cc
+++ b/gr-blocks/lib/multiply_impl.cc
@@ -47,7 +47,7 @@ int multiply_impl<float>::work(int noutput_items,
 
     memcpy(out, input_items[0], noi * sizeof(float));
     for (size_t i = 1; i < input_items.size(); i++)
-        volk_32f_x2_multiply_32f(out, out, (float*)input_items[i], noi);
+        volk_32f_x2_multiply_32f(out, out, (const float*)input_items[i], noi);
 
     return noutput_items;
 }
@@ -73,7 +73,7 @@ int multiply_impl<gr_complex>::work(int noutput_items,
 
     memcpy(out, input_items[0], noi * sizeof(gr_complex));
     for (size_t i = 1; i < input_items.size(); i++)
-        volk_32fc_x2_multiply_32fc(out, out, (gr_complex*)input_items[i], noi);
+        volk_32fc_x2_multiply_32fc(out, out, (const gr_complex*)input_items[i], noi);
 
     return noutput_items;
 }
@@ -97,9 +97,9 @@ int multiply_impl<T>::work(int noutput_items,
     int ninputs = input_items.size();
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {
-        T acc = ((T*)input_items[0])[i];
+        T acc = ((const T*)input_items[0])[i];
         for (int j = 1; j < ninputs; j++)
-            acc *= ((T*)input_items[j])[i];
+            acc *= ((const T*)input_items[j])[i];
 
         *optr++ = (T)acc;
     }

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -49,7 +49,7 @@ int mute_impl<T>::work(int noutput_items,
                        gr_vector_const_void_star& input_items,
                        gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     T* optr = (T*)output_items[0];
 
     int size = noutput_items;

--- a/gr-blocks/lib/or_blk_impl.cc
+++ b/gr-blocks/lib/or_blk_impl.cc
@@ -43,9 +43,9 @@ int or_blk_impl<T>::work(int noutput_items,
     int ninputs = input_items.size();
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {
-        T acc = ((T*)input_items[0])[i];
+        T acc = ((const T*)input_items[0])[i];
         for (int j = 1; j < ninputs; j++)
-            acc |= ((T*)input_items[j])[i];
+            acc |= ((const T*)input_items[j])[i];
 
         *optr++ = (T)acc;
     }

--- a/gr-blocks/lib/packed_to_unpacked_impl.cc
+++ b/gr-blocks/lib/packed_to_unpacked_impl.cc
@@ -109,7 +109,7 @@ int packed_to_unpacked_impl<T>::general_work(int noutput_items,
     const int nstreams = input_items.size();
 
     for (int m = 0; m < nstreams; m++) {
-        const T* in = (T*)input_items[m];
+        const T* in = (const T*)input_items[m];
         T* out = (T*)output_items[m];
         index_tmp = d_index;
 

--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -69,7 +69,7 @@ int peak_detector2_fb_impl::work(int noutput_items,
                                  gr_vector_const_void_star& input_items,
                                  gr_vector_void_star& output_items)
 {
-    float* iptr = (float*)input_items[0];
+    const float* iptr = (const float*)input_items[0];
     char* optr = (char*)output_items[0];
     float* sigout;
 

--- a/gr-blocks/lib/peak_detector_impl.cc
+++ b/gr-blocks/lib/peak_detector_impl.cc
@@ -79,7 +79,7 @@ int peak_detector_impl<T>::work(int noutput_items,
                                 gr_vector_const_void_star& input_items,
                                 gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     char* optr = (char*)output_items[0];
 
     memset(optr, 0, noutput_items * sizeof(char));

--- a/gr-blocks/lib/sample_and_hold_impl.cc
+++ b/gr-blocks/lib/sample_and_hold_impl.cc
@@ -44,7 +44,7 @@ int sample_and_hold_impl<T>::work(int noutput_items,
                                   gr_vector_const_void_star& input_items,
                                   gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
     const char* ctrl = (const char*)input_items[1];
     T* optr = (T*)output_items[0];
 

--- a/gr-blocks/lib/sub_impl.cc
+++ b/gr-blocks/lib/sub_impl.cc
@@ -76,9 +76,9 @@ int sub_impl<T>::work(int noutput_items,
     int ninputs = input_items.size();
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {
-        T acc = ((T*)input_items[0])[i];
+        T acc = ((const T*)input_items[0])[i];
         for (int j = 1; j < ninputs; j++)
-            acc -= ((T*)input_items[j])[i];
+            acc -= ((const T*)input_items[j])[i];
 
         *optr++ = (T)acc;
     }

--- a/gr-blocks/lib/tag_gate_impl.cc
+++ b/gr-blocks/lib/tag_gate_impl.cc
@@ -78,7 +78,7 @@ int tag_gate_impl::work(int noutput_items,
     unsigned char* out = (unsigned char*)output_items[0];
     std::vector<tag_t> tags;
 
-    memcpy((void*)out, (void*)in, d_item_size * noutput_items);
+    memcpy((void*)out, (const void*)in, d_item_size * noutput_items);
 
     if (d_single_key_set && (!d_propagate_tags)) {
         get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0) + noutput_items);

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -65,7 +65,7 @@ int tagged_file_sink_impl::work(int noutput_items,
                                 gr_vector_const_void_star& input_items,
                                 gr_vector_void_star& output_items)
 {
-    char* inbuf = (char*)input_items[0];
+    const char* inbuf = (const char*)input_items[0];
 
     uint64_t start_N = nitems_read(0);
     uint64_t end_N = start_N + (uint64_t)(noutput_items);

--- a/gr-blocks/lib/unpacked_to_packed_impl.cc
+++ b/gr-blocks/lib/unpacked_to_packed_impl.cc
@@ -89,7 +89,7 @@ int unpacked_to_packed_impl<T>::general_work(int noutput_items,
     const int nstreams = input_items.size();
 
     for (int m = 0; m < nstreams; m++) {
-        const T* in = (T*)input_items[m];
+        const T* in = (const T*)input_items[m];
         T* out = (T*)output_items[m];
         index_tmp = d_index;
 

--- a/gr-blocks/lib/vector_sink_impl.cc
+++ b/gr-blocks/lib/vector_sink_impl.cc
@@ -72,7 +72,7 @@ int vector_sink_impl<T>::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    T* iptr = (T*)input_items[0];
+    const T* iptr = (const T*)input_items[0];
 
     // can't touch this (as long as work() is working, the accessors shall not
     // read the data

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -264,7 +264,7 @@ int wavfile_sink_impl::work(int noutput_items,
                             gr_vector_const_void_star& input_items,
                             gr_vector_void_star& output_items)
 {
-    auto in = (float**)&input_items[0];
+    auto in = (const float**)&input_items[0];
     int n_in_chans = input_items.size();
     int nwritten;
     int errnum;

--- a/gr-blocks/lib/xor_blk_impl.cc
+++ b/gr-blocks/lib/xor_blk_impl.cc
@@ -43,9 +43,9 @@ int xor_blk_impl<T>::work(int noutput_items,
     int ninputs = input_items.size();
 
     for (size_t i = 0; i < noutput_items * d_vlen; i++) {
-        T acc = ((T*)input_items[0])[i];
+        T acc = ((const T*)input_items[0])[i];
         for (int j = 1; j < ninputs; j++)
-            acc ^= ((T*)input_items[j])[i];
+            acc ^= ((const T*)input_items[j])[i];
 
         *optr++ = (T)acc;
     }

--- a/gr-digital/lib/corr_est_cc_impl.cc
+++ b/gr-digital/lib/corr_est_cc_impl.cc
@@ -187,7 +187,7 @@ int corr_est_cc_impl::work(int noutput_items,
 {
     gr::thread::scoped_lock lock(d_setlock);
 
-    const gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
     gr_complex* corr;
     if (output_items.size() > 1)
@@ -282,7 +282,8 @@ int corr_est_cc_impl::work(int noutput_items,
         // Estimated scaling factor for the input stream to normalize
         // the output to +/-1.
         uint32_t maxi;
-        volk_32fc_index_max_32u_manual(&maxi, (gr_complex*)in, noutput_items, "generic");
+        volk_32fc_index_max_32u_manual(
+            &maxi, const_cast<gr_complex*>(in), noutput_items, "generic");
         d_scale = 1 / std::abs(in[maxi]);
 
         // Calculate the phase offset of the incoming signal.

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -58,7 +58,7 @@ int costas_loop_cc_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    const gr_complex* iptr = (gr_complex*)input_items[0];
+    const gr_complex* iptr = (const gr_complex*)input_items[0];
     gr_complex* optr = (gr_complex*)output_items[0];
     float* freq_optr = output_items.size() >= 2 ? (float*)output_items[1] : NULL;
     float* phase_optr = output_items.size() >= 3 ? (float*)output_items[2] : NULL;

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -458,14 +458,14 @@ void header_payload_demux_impl::copy_n_symbols(const unsigned char* in,
         // because all padding items will be part of n_symbols
         for (int i = 0; i < n_symbols; i++) {
             memcpy((void*)out,
-                   (void*)(in + d_gi * d_itemsize),
+                   (const void*)(in + d_gi * d_itemsize),
                    d_items_per_symbol * d_itemsize);
             in += d_itemsize * (d_items_per_symbol + d_gi);
             out += d_itemsize * d_items_per_symbol;
         }
     } else {
         memcpy((void*)out,
-               (void*)in,
+               (const void*)in,
                (n_symbols * d_items_per_symbol + n_padding_items) * d_itemsize);
     }
     // Copy tags

--- a/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.cc
+++ b/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.cc
@@ -144,7 +144,8 @@ int ofdm_carrier_allocator_cvc_impl::work(int noutput_items,
     memset((void*)out, 0x00, sizeof(gr_complex) * d_fft_len * noutput_items);
     // Copy Sync word
     for (unsigned i = 0; i < d_sync_words.size(); i++) {
-        memcpy((void*)out, (void*)&d_sync_words[i][0], sizeof(gr_complex) * d_fft_len);
+        memcpy(
+            (void*)out, (const void*)&d_sync_words[i][0], sizeof(gr_complex) * d_fft_len);
         out += d_fft_len;
     }
 

--- a/gr-digital/lib/ofdm_chanest_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_chanest_vcvc_impl.cc
@@ -246,7 +246,7 @@ int ofdm_chanest_vcvc_impl::general_work(int noutput_items,
         produce(1, 1);
     }
     memcpy((void*)out,
-           (void*)&in[d_n_sync_syms * d_fft_len],
+           (const void*)&in[d_n_sync_syms * d_fft_len],
            sizeof(gr_complex) * d_fft_len * d_n_data_syms);
 
     // Propagate tags

--- a/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
+++ b/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
@@ -140,7 +140,7 @@ int ofdm_cyclic_prefixer_impl::work(int noutput_items,
                                     gr_vector_const_void_star& input_items,
                                     gr_vector_void_star& output_items)
 {
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
     int symbols_to_read = 0;
     // 1) Figure out if we're in freewheeling or packet mode.
@@ -154,10 +154,10 @@ int ofdm_cyclic_prefixer_impl::work(int noutput_items,
     // 2) Do the cyclic prefixing and, optionally, the pulse shaping.
     for (int sym_idx = 0; sym_idx < symbols_to_read; sym_idx++) {
         memcpy(static_cast<void*>(out + d_cp_lengths[d_state]),
-               static_cast<void*>(in),
+               static_cast<const void*>(in),
                d_fft_len * sizeof(gr_complex));
         memcpy(static_cast<void*>(out),
-               static_cast<void*>(in + d_fft_len - d_cp_lengths[d_state]),
+               static_cast<const void*>(in + d_fft_len - d_cp_lengths[d_state]),
                d_cp_lengths[d_state] * sizeof(gr_complex));
         if (d_rolloff_len) {
             for (int i = 0; i < d_rolloff_len - 1; i++) {

--- a/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
@@ -113,14 +113,14 @@ int ofdm_frame_equalizer_vcvc_impl::work(int noutput_items,
     if (carrier_offset < 0) {
         memset((void*)out, 0x00, sizeof(gr_complex) * (-carrier_offset));
         memcpy((void*)&out[-carrier_offset],
-               (void*)in,
+               (const void*)in,
                sizeof(gr_complex) * (d_fft_len * frame_len + carrier_offset));
     } else {
         memset((void*)(out + d_fft_len * frame_len - carrier_offset),
                0x00,
                sizeof(gr_complex) * carrier_offset);
         memcpy((void*)out,
-               (void*)(in + carrier_offset),
+               (const void*)(in + carrier_offset),
                sizeof(gr_complex) * (d_fft_len * frame_len - carrier_offset));
     }
 

--- a/gr-digital/lib/packet_sink_impl.cc
+++ b/gr-digital/lib/packet_sink_impl.cc
@@ -89,7 +89,7 @@ int packet_sink_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)
 {
-    float* inbuf = (float*)input_items[0];
+    const float* inbuf = (const float*)input_items[0];
     int count = 0;
 
     if (VERBOSE) {

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -331,7 +331,7 @@ int pfb_clock_sync_ccf_impl::general_work(int noutput_items,
                                           gr_vector_const_void_star& input_items,
                                           gr_vector_void_star& output_items)
 {
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -320,7 +320,7 @@ int pfb_clock_sync_fff_impl::general_work(int noutput_items,
                                           gr_vector_const_void_star& input_items,
                                           gr_vector_void_star& output_items)
 {
-    float* in = (float*)input_items[0];
+    const float* in = (const float*)input_items[0];
     float* out = (float*)output_items[0];
 
     if (d_updated) {

--- a/gr-dtv/lib/dvbt/dvbt_symbol_inner_interleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_symbol_inner_interleaver_impl.cc
@@ -137,7 +137,7 @@ int dvbt_symbol_inner_interleaver_impl::general_work(
     gr_vector_const_void_star& input_items,
     gr_vector_void_star& output_items)
 {
-    const unsigned char* in = (unsigned char*)input_items[0];
+    const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
     // Demod reference signals sends a tag per OFDM frame

--- a/gr-dtv/lib/dvbt2/dvbt2_paprtr_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_paprtr_cc_impl.cc
@@ -680,7 +680,7 @@ int dvbt2_paprtr_cc_impl::work(int noutput_items,
                     for (int k = 1; k <= num_iterations; k++) {
                         y = 0.0;
                         volk_32f_x2_add_32f((float*)ctemp.data(),
-                                            (float*)in,
+                                            (const float*)in,
                                             (float*)c.data(),
                                             papr_fft_size * 2);
                         volk_32fc_magnitude_32f(
@@ -765,8 +765,10 @@ int dvbt2_paprtr_cc_impl::work(int noutput_items,
                                                  papr_fft_size * 2);
                         std::copy(std::begin(rNew), std::end(rNew), std::begin(r));
                     }
-                    volk_32f_x2_add_32f(
-                        (float*)out, (float*)in, (float*)c.data(), papr_fft_size * 2);
+                    volk_32f_x2_add_32f((float*)out,
+                                        (const float*)in,
+                                        (float*)c.data(),
+                                        papr_fft_size * 2);
                     in = in + papr_fft_size;
                     out = out + papr_fft_size;
                 } else {

--- a/gr-fec/include/gnuradio/fec/generic_decoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_decoder.h
@@ -51,7 +51,7 @@ protected:
 
 public:
     friend class decoder;
-    virtual void generic_work(void* inbuffer, void* outbuffer) = 0;
+    virtual void generic_work(const void* inbuffer, void* outbuffer) = 0;
     static int base_unique_id;
     int my_id;
     int unique_id();

--- a/gr-fec/include/gnuradio/fec/generic_encoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_encoder.h
@@ -26,7 +26,7 @@ protected:
 
 public:
     friend class encoder;
-    virtual void generic_work(void* in_buffer, void* out_buffer) = 0;
+    virtual void generic_work(const void* in_buffer, void* out_buffer) = 0;
     static int base_unique_id;
     int my_id;
     int unique_id();

--- a/gr-fec/include/gnuradio/fec/ldpc_decoder.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_decoder.h
@@ -39,7 +39,7 @@ private:
     int get_history() override;
     float get_shift() override;
     const char* get_conversion();
-    void generic_work(void* inBuffer, void* outbuffer) override;
+    void generic_work(const void* inBuffer, void* outbuffer) override;
     float d_iterations;
     int d_input_size, d_output_size;
     double d_rate;

--- a/gr-fec/include/gnuradio/fec/polar_decoder_sc.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_sc.h
@@ -51,7 +51,7 @@ public:
     ~polar_decoder_sc() override;
 
     // FECAPI
-    void generic_work(void* in_buffer, void* out_buffer) override;
+    void generic_work(const void* in_buffer, void* out_buffer) override;
 
 private:
     polar_decoder_sc(int block_size,

--- a/gr-fec/include/gnuradio/fec/polar_decoder_sc_list.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_sc_list.h
@@ -60,7 +60,7 @@ public:
     ~polar_decoder_sc_list() override;
 
     // FECAPI
-    void generic_work(void* in_buffer, void* out_buffer) override;
+    void generic_work(const void* in_buffer, void* out_buffer) override;
 
 private:
     polar_decoder_sc_list(int max_list_size,

--- a/gr-fec/include/gnuradio/fec/polar_decoder_sc_systematic.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_sc_systematic.h
@@ -51,7 +51,7 @@ public:
     ~polar_decoder_sc_systematic() override;
 
     // FECAPI
-    void generic_work(void* in_buffer, void* out_buffer) override;
+    void generic_work(const void* in_buffer, void* out_buffer) override;
 
 private:
     polar_decoder_sc_systematic(int block_size,

--- a/gr-fec/include/gnuradio/fec/polar_encoder.h
+++ b/gr-fec/include/gnuradio/fec/polar_encoder.h
@@ -58,7 +58,7 @@ public:
     ~polar_encoder() override;
 
     // FECAPI
-    void generic_work(void* in_buffer, void* out_buffer) override;
+    void generic_work(const void* in_buffer, void* out_buffer) override;
     double rate() override { return (1.0 * get_input_size() / get_output_size()); };
     int get_input_size() override { return num_info_bits() / (d_is_packed ? 8 : 1); };
     int get_output_size() override { return block_size() / (d_is_packed ? 8 : 1); };

--- a/gr-fec/include/gnuradio/fec/polar_encoder_systematic.h
+++ b/gr-fec/include/gnuradio/fec/polar_encoder_systematic.h
@@ -55,7 +55,7 @@ public:
     make(int block_size, int num_info_bits, std::vector<int> frozen_bit_positions);
 
     // FECAPI
-    void generic_work(void* in_buffer, void* out_buffer) override;
+    void generic_work(const void* in_buffer, void* out_buffer) override;
     double rate() override { return (1.0 * get_input_size() / get_output_size()); };
     int get_input_size() override { return num_info_bits(); };
     int get_output_size() override { return block_size(); };

--- a/gr-fec/include/gnuradio/fec/tpc_decoder.h
+++ b/gr-fec/include/gnuradio/fec/tpc_decoder.h
@@ -43,7 +43,7 @@ class FEC_API tpc_decoder : public generic_decoder
     int get_input_item_size() override;
     int get_output_item_size() override;
     const char* get_conversion();
-    void generic_work(void* inBuffer, void* outbuffer) override;
+    void generic_work(const void* inBuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
 

--- a/gr-fec/include/gnuradio/fec/tpc_encoder.h
+++ b/gr-fec/include/gnuradio/fec/tpc_encoder.h
@@ -33,7 +33,7 @@ class FEC_API tpc_encoder : public generic_encoder
                 int qval);
 
     // plug into the generic fec api
-    void generic_work(void* inBuffer, void* outbuffer) override;
+    void generic_work(const void* inBuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
 

--- a/gr-fec/include/gnuradio/fec/viterbi.h
+++ b/gr-fec/include/gnuradio/fec/viterbi.h
@@ -33,7 +33,7 @@ void gen_met(int mettab[2][256], /* Metric table */
              int scale);         /* Scale factor */
 
 FEC_API unsigned char encode(unsigned char* symbols,
-                             unsigned char* data,
+                             const unsigned char* data,
                              unsigned int nbytes,
                              unsigned char encstate);
 

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -114,8 +114,9 @@ void async_encoder_impl::encode_unpacked(pmt::pmt_t msg)
         d_encoder->generic_work((void*)d_bits_in.data(), (void*)bits_out);
     } else {
         for (int i = 0; i < nblocks; i++) {
-            d_encoder->generic_work((void*)&bits_in[i * d_encoder->get_input_size()],
-                                    (void*)&bits_out[i * d_encoder->get_output_size()]);
+            d_encoder->generic_work(
+                (const void*)&bits_in[i * d_encoder->get_input_size()],
+                (void*)&bits_out[i * d_encoder->get_output_size()]);
         }
     }
 

--- a/gr-fec/lib/ber_bf_impl.cc
+++ b/gr-fec/lib/ber_bf_impl.cc
@@ -61,8 +61,8 @@ int ber_bf_impl::general_work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    unsigned char* inbuffer0 = (unsigned char*)input_items[0];
-    unsigned char* inbuffer1 = (unsigned char*)input_items[1];
+    const unsigned char* inbuffer0 = (const unsigned char*)input_items[0];
+    const unsigned char* inbuffer1 = (const unsigned char*)input_items[1];
     float* outbuffer = (float*)output_items[0];
 
     int items = ninput_items[0] <= ninput_items[1] ? ninput_items[0] : ninput_items[1];

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -239,7 +239,7 @@ int cc_decoder_impl::find_endstate()
     return state;
 }
 
-int cc_decoder_impl::update_viterbi_blk(unsigned char* syms, int nbits)
+int cc_decoder_impl::update_viterbi_blk(const unsigned char* syms, int nbits)
 {
     unsigned char* d = d_vp.decisions.data();
 
@@ -247,7 +247,7 @@ int cc_decoder_impl::update_viterbi_blk(unsigned char* syms, int nbits)
 
     volk_8u_x4_conv_k7_r2_8u(d_vp.new_metrics.t,
                              d_vp.old_metrics.t,
-                             syms,
+                             const_cast<unsigned char*>(syms),
                              d,
                              nbits - (s_k - 1),
                              s_k - 1,
@@ -350,7 +350,7 @@ bool cc_decoder_impl::set_frame_size(unsigned int frame_size)
 
 double cc_decoder_impl::rate() { return 1.0 / static_cast<double>(s_rate); }
 
-void cc_decoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void cc_decoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     const unsigned char* in = (const unsigned char*)inbuffer;
     unsigned char* out = (unsigned char*)outbuffer;
@@ -370,7 +370,7 @@ void cc_decoder_impl::generic_work(void* inbuffer, void* outbuffer)
 
 
     case (CC_TRUNCATED):
-        update_viterbi_blk((unsigned char*)(&in[0]), d_veclen);
+        update_viterbi_blk((const unsigned char*)(&in[0]), d_veclen);
         d_end_state_chaining = find_endstate();
         for (unsigned int i = 0; i < s_k - 1; ++i) {
             out[d_veclen - 1 - i] = ((*d_end_state) >> i) & 1;
@@ -382,7 +382,7 @@ void cc_decoder_impl::generic_work(void* inbuffer, void* outbuffer)
 
     case (CC_STREAMING):
     case (CC_TERMINATED):
-        update_viterbi_blk((unsigned char*)(&in[0]), d_veclen);
+        update_viterbi_blk((const unsigned char*)(&in[0]), d_veclen);
         d_end_state_chaining = find_endstate();
         d_start_state_chaining = chainback_viterbi(
             &out[0], d_frame_size, *d_end_state, d_veclen - d_frame_size);

--- a/gr-fec/lib/cc_decoder_impl.h
+++ b/gr-fec/lib/cc_decoder_impl.h
@@ -47,7 +47,7 @@ private:
     void create_viterbi();
     int init_viterbi(v* vp, int starting_state);
     int init_viterbi_unbiased(v* vp);
-    int update_viterbi_blk(unsigned char* syms, int nbits);
+    int update_viterbi_blk(const unsigned char* syms, int nbits);
     int chainback_viterbi(unsigned char* data,
                           unsigned int nbits,
                           unsigned int endstate,
@@ -97,7 +97,7 @@ public:
     cc_decoder_impl(const cc_decoder_impl&) = delete;
     cc_decoder_impl& operator=(const cc_decoder_impl&) = delete;
 
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     bool set_frame_size(unsigned int frame_size) override;
     double rate() override;
 };

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -162,7 +162,7 @@ void cc_encoder_impl::partab_init(void)
     }
 }
 
-void cc_encoder_impl::generic_work(void* in_buffer, void* out_buffer)
+void cc_encoder_impl::generic_work(const void* in_buffer, void* out_buffer)
 {
     const unsigned char* in = (const unsigned char*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;

--- a/gr-fec/lib/cc_encoder_impl.h
+++ b/gr-fec/lib/cc_encoder_impl.h
@@ -23,7 +23,7 @@ class FEC_API cc_encoder_impl : public cc_encoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
 

--- a/gr-fec/lib/ccsds_encoder_impl.cc
+++ b/gr-fec/lib/ccsds_encoder_impl.cc
@@ -75,9 +75,9 @@ bool ccsds_encoder_impl::set_frame_size(unsigned int frame_size)
 
 double ccsds_encoder_impl::rate() { return 0.5; }
 
-void ccsds_encoder_impl::generic_work(void* in_buffer, void* out_buffer)
+void ccsds_encoder_impl::generic_work(const void* in_buffer, void* out_buffer)
 {
-    unsigned char* in = (unsigned char*)in_buffer;
+    const unsigned char* in = (const unsigned char*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;
 
     unsigned char my_state = d_start_state;

--- a/gr-fec/lib/ccsds_encoder_impl.h
+++ b/gr-fec/lib/ccsds_encoder_impl.h
@@ -23,7 +23,7 @@ class FEC_API ccsds_encoder_impl : public ccsds_encoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
     const char* get_input_conversion() override;

--- a/gr-fec/lib/conv_bit_corr_bb_impl.cc
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.cc
@@ -124,7 +124,7 @@ int conv_bit_corr_bb_impl::general_work(int noutput_items,
     }
 
     const uint8_t* in = (const uint8_t*)input_items[0];
-    uint8_t* score_in = (uint8_t*)input_items[0];
+    const uint8_t* score_in = (const uint8_t*)input_items[0];
 
     // counting on  1:1 forecast + history to provide enough ninput_items... may need to
     // insert check printf("%d, %d, %d", ninput_items[0], noutput_items, d_counter);

--- a/gr-fec/lib/decoder_impl.cc
+++ b/gr-fec/lib/decoder_impl.cc
@@ -69,7 +69,7 @@ int decoder_impl::general_work(int noutput_items,
                                gr_vector_const_void_star& input_items,
                                gr_vector_void_star& output_items)
 {
-    const unsigned char* in = (unsigned char*)input_items[0];
+    const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
     int outnum = std::lround((1.0 / relative_rate()) * noutput_items);
@@ -83,7 +83,7 @@ int decoder_impl::general_work(int noutput_items,
 
     for (int i = 0; i < items; ++i) {
         d_decoder->generic_work(
-            (void*)(in + (i * d_decoder->get_input_size() * d_input_item_size)),
+            (const void*)(in + (i * d_decoder->get_input_size() * d_input_item_size)),
             (void*)(out + (i * d_decoder->get_output_size() * d_output_item_size)));
 
         add_item_tag(0,

--- a/gr-fec/lib/dummy_decoder_impl.cc
+++ b/gr-fec/lib/dummy_decoder_impl.cc
@@ -68,7 +68,7 @@ bool dummy_decoder_impl::set_frame_size(unsigned int frame_size)
 
 double dummy_decoder_impl::rate() { return 1.0; }
 
-void dummy_decoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void dummy_decoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     const float* in = (const float*)inbuffer;
     int8_t* out = (int8_t*)outbuffer;

--- a/gr-fec/lib/dummy_decoder_impl.h
+++ b/gr-fec/lib/dummy_decoder_impl.h
@@ -23,7 +23,7 @@ class FEC_API dummy_decoder_impl : public dummy_decoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
     int get_input_item_size() override;

--- a/gr-fec/lib/dummy_encoder_impl.cc
+++ b/gr-fec/lib/dummy_encoder_impl.cc
@@ -69,7 +69,7 @@ bool dummy_encoder_impl::set_frame_size(unsigned int frame_size)
 
 double dummy_encoder_impl::rate() { return 1.0; }
 
-void dummy_encoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void dummy_encoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     const unsigned char* in = (const unsigned char*)inbuffer;
     unsigned char* out = (unsigned char*)outbuffer;

--- a/gr-fec/lib/dummy_encoder_impl.h
+++ b/gr-fec/lib/dummy_encoder_impl.h
@@ -23,7 +23,7 @@ class FEC_API dummy_encoder_impl : public dummy_encoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
     const char* get_input_conversion() override;

--- a/gr-fec/lib/encode_ccsds_27_bb_impl.cc
+++ b/gr-fec/lib/encode_ccsds_27_bb_impl.cc
@@ -38,7 +38,7 @@ int encode_ccsds_27_bb_impl::work(int noutput_items,
                                   gr_vector_const_void_star& input_items,
                                   gr_vector_void_star& output_items)
 {
-    unsigned char* in = (unsigned char*)input_items[0];
+    const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
     d_encstate = encode(out, in, noutput_items / 16, d_encstate);

--- a/gr-fec/lib/encoder_impl.cc
+++ b/gr-fec/lib/encoder_impl.cc
@@ -68,11 +68,11 @@ int encoder_impl::general_work(int noutput_items,
                                gr_vector_const_void_star& input_items,
                                gr_vector_void_star& output_items)
 {
-    char* inbuffer = (char*)input_items[0];
+    const char* inbuffer = (const char*)input_items[0];
     char* outbuffer = (char*)output_items[0];
 
     for (int i = 0; i < noutput_items / output_multiple(); i++) {
-        d_encoder->generic_work((void*)(inbuffer + (i * d_input_size)),
+        d_encoder->generic_work((const void*)(inbuffer + (i * d_input_size)),
                                 (void*)(outbuffer + (i * d_output_size)));
     }
 

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
@@ -69,7 +69,7 @@ bool ldpc_bit_flip_decoder_impl::set_frame_size(unsigned int frame_size)
 double ldpc_bit_flip_decoder_impl::rate() { return d_rate; }
 
 
-void ldpc_bit_flip_decoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void ldpc_bit_flip_decoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     // Populate the information word
     const float* in = (const float*)inbuffer;

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.h
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.h
@@ -36,7 +36,7 @@ public:
     ldpc_bit_flip_decoder_impl(const fec_mtrx_sptr mtrx_obj, unsigned int max_iter = 100);
     ~ldpc_bit_flip_decoder_impl() override;
 
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     bool set_frame_size(unsigned int frame_size) override;
     double rate() override;
 };

--- a/gr-fec/lib/ldpc_decoder.cc
+++ b/gr-fec/lib/ldpc_decoder.cc
@@ -70,7 +70,7 @@ bool ldpc_decoder::set_frame_size(unsigned int frame_size)
     return true;
 }
 
-void ldpc_decoder::generic_work(void* inBuffer, void* outBuffer)
+void ldpc_decoder::generic_work(const void* inBuffer, void* outBuffer)
 {
     const float* in = (const float*)inBuffer;
     unsigned char* out = (unsigned char*)outBuffer;

--- a/gr-fec/lib/ldpc_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_encoder_impl.cc
@@ -42,7 +42,7 @@ int ldpc_encoder_impl::get_output_size() { return outputSize; }
 
 int ldpc_encoder_impl::get_input_size() { return inputSize; }
 
-void ldpc_encoder_impl::generic_work(void* inBuffer, void* outBuffer)
+void ldpc_encoder_impl::generic_work(const void* inBuffer, void* outBuffer)
 {
     const unsigned char* in = (const unsigned char*)inBuffer;
     unsigned char* out = (unsigned char*)outBuffer;

--- a/gr-fec/lib/ldpc_encoder_impl.h
+++ b/gr-fec/lib/ldpc_encoder_impl.h
@@ -25,7 +25,7 @@ class ldpc_encoder_impl : public ldpc_encoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inBuffer, void* outbuffer) override;
+    void generic_work(const void* inBuffer, void* outbuffer) override;
 
     // memory allocated for processing
     int outputSize;

--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
@@ -62,7 +62,7 @@ bool ldpc_gen_mtrx_encoder_impl::set_frame_size(unsigned int frame_size)
 
 double ldpc_gen_mtrx_encoder_impl::rate() { return d_rate; }
 
-void ldpc_gen_mtrx_encoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void ldpc_gen_mtrx_encoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     // Populate the information word
     const unsigned char* in = (const unsigned char*)inbuffer;

--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.h
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.h
@@ -21,7 +21,7 @@ namespace code {
 class FEC_API ldpc_gen_mtrx_encoder_impl : public ldpc_gen_mtrx_encoder
 {
 private:
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
 

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -82,7 +82,7 @@ bool ldpc_par_mtrx_encoder_impl::set_frame_size(unsigned int frame_size)
 
 double ldpc_par_mtrx_encoder_impl::rate() { return d_rate; }
 
-void ldpc_par_mtrx_encoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void ldpc_par_mtrx_encoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     // Populate the information word
     const unsigned char* in = (const unsigned char*)inbuffer;

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.h
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.h
@@ -21,7 +21,7 @@ class ldpc_par_mtrx_encoder_impl : public ldpc_par_mtrx_encoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
 
     // Number of bits in the frame to be encoded
     unsigned int d_frame_size;

--- a/gr-fec/lib/polar_decoder_sc.cc
+++ b/gr-fec/lib/polar_decoder_sc.cc
@@ -45,7 +45,7 @@ polar_decoder_sc::polar_decoder_sc(int block_size,
 
 polar_decoder_sc::~polar_decoder_sc() {}
 
-void polar_decoder_sc::generic_work(void* in_buffer, void* out_buffer)
+void polar_decoder_sc::generic_work(const void* in_buffer, void* out_buffer)
 {
     const float* in = (const float*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;

--- a/gr-fec/lib/polar_decoder_sc_list.cc
+++ b/gr-fec/lib/polar_decoder_sc_list.cc
@@ -50,7 +50,7 @@ polar_decoder_sc_list::polar_decoder_sc_list(int max_list_size,
 
 polar_decoder_sc_list::~polar_decoder_sc_list() {}
 
-void polar_decoder_sc_list::generic_work(void* in_buffer, void* out_buffer)
+void polar_decoder_sc_list::generic_work(const void* in_buffer, void* out_buffer)
 {
     const float* in = (const float*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;

--- a/gr-fec/lib/polar_decoder_sc_systematic.cc
+++ b/gr-fec/lib/polar_decoder_sc_systematic.cc
@@ -39,7 +39,7 @@ polar_decoder_sc_systematic::polar_decoder_sc_systematic(
 
 polar_decoder_sc_systematic::~polar_decoder_sc_systematic() {}
 
-void polar_decoder_sc_systematic::generic_work(void* in_buffer, void* out_buffer)
+void polar_decoder_sc_systematic::generic_work(const void* in_buffer, void* out_buffer)
 {
     const float* in = (const float*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;

--- a/gr-fec/lib/polar_encoder.cc
+++ b/gr-fec/lib/polar_encoder.cc
@@ -61,7 +61,7 @@ polar_encoder::polar_encoder(int block_size,
 
 polar_encoder::~polar_encoder() {}
 
-void polar_encoder::generic_work(void* in_buffer, void* out_buffer)
+void polar_encoder::generic_work(const void* in_buffer, void* out_buffer)
 {
     const unsigned char* in = (const unsigned char*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;

--- a/gr-fec/lib/polar_encoder_systematic.cc
+++ b/gr-fec/lib/polar_encoder_systematic.cc
@@ -38,7 +38,7 @@ polar_encoder_systematic::polar_encoder_systematic(int block_size,
 
 polar_encoder_systematic::~polar_encoder_systematic() {}
 
-void polar_encoder_systematic::generic_work(void* in_buffer, void* out_buffer)
+void polar_encoder_systematic::generic_work(const void* in_buffer, void* out_buffer)
 {
     const unsigned char* in = (const unsigned char*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;

--- a/gr-fec/lib/repetition_decoder_impl.cc
+++ b/gr-fec/lib/repetition_decoder_impl.cc
@@ -81,7 +81,7 @@ bool repetition_decoder_impl::set_frame_size(unsigned int frame_size)
 
 double repetition_decoder_impl::rate() { return 1.0 / static_cast<double>(d_rep); }
 
-void repetition_decoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void repetition_decoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     const float* in = (const float*)inbuffer;
     unsigned char* out = (unsigned char*)outbuffer;

--- a/gr-fec/lib/repetition_decoder_impl.h
+++ b/gr-fec/lib/repetition_decoder_impl.h
@@ -24,7 +24,7 @@ class FEC_API repetition_decoder_impl : public repetition_decoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
     int get_input_item_size() override;

--- a/gr-fec/lib/repetition_encoder_impl.cc
+++ b/gr-fec/lib/repetition_encoder_impl.cc
@@ -62,7 +62,7 @@ bool repetition_encoder_impl::set_frame_size(unsigned int frame_size)
 
 double repetition_encoder_impl::rate() { return static_cast<double>(d_rep); }
 
-void repetition_encoder_impl::generic_work(void* inbuffer, void* outbuffer)
+void repetition_encoder_impl::generic_work(const void* inbuffer, void* outbuffer)
 {
     const unsigned char* in = (const unsigned char*)inbuffer;
     unsigned char* out = (unsigned char*)outbuffer;

--- a/gr-fec/lib/repetition_encoder_impl.h
+++ b/gr-fec/lib/repetition_encoder_impl.h
@@ -23,7 +23,7 @@ class FEC_API repetition_encoder_impl : public repetition_encoder
 {
 private:
     // plug into the generic fec api
-    void generic_work(void* inbuffer, void* outbuffer) override;
+    void generic_work(const void* inbuffer, void* outbuffer) override;
     int get_output_size() override;
     int get_input_size() override;
 

--- a/gr-fec/lib/tagged_decoder_impl.cc
+++ b/gr-fec/lib/tagged_decoder_impl.cc
@@ -65,13 +65,13 @@ int tagged_decoder_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    const unsigned char* in = (unsigned char*)input_items[0];
+    const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
     d_debug_logger->debug(
         "{:d}, {:d}, {:d}", noutput_items, ninput_items[0], d_decoder->get_output_size());
 
-    d_decoder->generic_work((void*)in, (void*)out);
+    d_decoder->generic_work((const void*)in, (void*)out);
 
     return d_decoder->get_output_size();
 }

--- a/gr-fec/lib/tagged_encoder_impl.cc
+++ b/gr-fec/lib/tagged_encoder_impl.cc
@@ -62,7 +62,7 @@ int tagged_encoder_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    char* inbuffer = (char*)input_items[0];
+    const char* inbuffer = (const char*)input_items[0];
     char* outbuffer = (char*)output_items[0];
 
     d_debug_logger->debug("nout: {:d}   nin: {:d}   ret: {:d}",
@@ -70,7 +70,7 @@ int tagged_encoder_impl::work(int noutput_items,
                           ninput_items[0],
                           d_encoder->get_output_size());
 
-    d_encoder->generic_work((void*)(inbuffer), (void*)(outbuffer));
+    d_encoder->generic_work((const void*)(inbuffer), (void*)(outbuffer));
 
     return d_encoder->get_output_size();
 }

--- a/gr-fec/lib/tpc_decoder.cc
+++ b/gr-fec/lib/tpc_decoder.cc
@@ -803,7 +803,7 @@ int tpc_decoder::sgn(T val)
     return (T(0) < val) - (val < T(0));
 }
 
-void tpc_decoder::generic_work(void* inBuffer, void* outBuffer)
+void tpc_decoder::generic_work(const void* inBuffer, void* outBuffer)
 {
     const float* inPtr = (const float*)inBuffer;
     unsigned char* out = (unsigned char*)outBuffer;

--- a/gr-fec/lib/tpc_encoder.cc
+++ b/gr-fec/lib/tpc_encoder.cc
@@ -168,7 +168,7 @@ void tpc_encoder::block_conv_encode(std::vector<uint8_t>& output,
     }
 }
 
-void tpc_encoder::generic_work(void* inBuffer, void* outBuffer)
+void tpc_encoder::generic_work(const void* inBuffer, void* outBuffer)
 {
     const uint8_t* in = (const uint8_t*)inBuffer;
     uint8_t* out = (uint8_t*)outBuffer;

--- a/gr-fec/lib/viterbi/viterbi.cc
+++ b/gr-fec/lib/viterbi/viterbi.cc
@@ -80,7 +80,7 @@ namespace fec {
 
 /* Convolutionally encode data into binary symbols */
 unsigned char encode(unsigned char* symbols,
-                     unsigned char* data,
+                     const unsigned char* data,
                      unsigned int nbytes,
                      unsigned char encstate)
 {

--- a/gr-fec/python/fec/bindings/generic_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/generic_decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(generic_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(afdc6a2b05a7afcfe27356539ef41b03)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b38a197be292acc189000aa4d3c24cbe)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/generic_encoder_python.cc
+++ b/gr-fec/python/fec/bindings/generic_encoder_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(generic_encoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8f2010dc3c6371720e76fe7c2903bd84)                     */
+/* BINDTOOL_HEADER_FILE(generic_encoder.h)                                         */
+/* BINDTOOL_HEADER_FILE_HASH(4bf764edbc6d2d3d99af4d2a65417344)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/ldpc_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/ldpc_decoder_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(ldpc_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(99ed80d45d90c32de08353e24f63e572)                     */
+/* BINDTOOL_HEADER_FILE(ldpc_decoder.h)                                            */
+/* BINDTOOL_HEADER_FILE_HASH(6b32ddd2ca1998a65bdb3dc4642eed60)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_decoder_sc_list_python.cc
+++ b/gr-fec/python/fec/bindings/polar_decoder_sc_list_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(polar_decoder_sc_list.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(87aca1c0c780c3ddedb0ba5d8e84a85b)                     */
+/* BINDTOOL_HEADER_FILE(polar_decoder_sc_list.h)                                   */
+/* BINDTOOL_HEADER_FILE_HASH(1768f16735ba214ba4bafaf8657aacd2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_decoder_sc_python.cc
+++ b/gr-fec/python/fec/bindings/polar_decoder_sc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polar_decoder_sc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8197faa9638d564c84e0e54b25b244b5)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e86364fa0df926b222bd809660c1ee96)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_decoder_sc_systematic_python.cc
+++ b/gr-fec/python/fec/bindings/polar_decoder_sc_systematic_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(polar_decoder_sc_systematic.h) */
-/* BINDTOOL_HEADER_FILE_HASH(099e40a1ac6af816aa1de788d28f0e83)                     */
+/* BINDTOOL_HEADER_FILE(polar_decoder_sc_systematic.h)                             */
+/* BINDTOOL_HEADER_FILE_HASH(5894d70c72d9d3391c7dc7995be656f2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_encoder_python.cc
+++ b/gr-fec/python/fec/bindings/polar_encoder_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(polar_encoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2b7038339cef878f4b0d8fa563d59eab)                     */
+/* BINDTOOL_HEADER_FILE(polar_encoder.h)                                           */
+/* BINDTOOL_HEADER_FILE_HASH(cc42f020a4018011d46d5311c12cb8ca)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_encoder_systematic_python.cc
+++ b/gr-fec/python/fec/bindings/polar_encoder_systematic_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(polar_encoder_systematic.h) */
-/* BINDTOOL_HEADER_FILE_HASH(b3a718bae49ce966e2d475cdd189cde6)                     */
+/* BINDTOOL_HEADER_FILE(polar_encoder_systematic.h)                                */
+/* BINDTOOL_HEADER_FILE_HASH(b4ff5131364ee0850ea2fac6d84b051b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/tpc_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/tpc_decoder_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(tpc_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(725e4fb03e1dc125f6c29645ac836842)                     */
+/* BINDTOOL_HEADER_FILE(tpc_decoder.h)                                             */
+/* BINDTOOL_HEADER_FILE_HASH(50005ea702f9cbce991d6a22aaabd80f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/tpc_encoder_python.cc
+++ b/gr-fec/python/fec/bindings/tpc_encoder_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(tpc_encoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(49804f4f0a6411c21f530258b1437a5d)                     */
+/* BINDTOOL_HEADER_FILE(tpc_encoder.h)                                             */
+/* BINDTOOL_HEADER_FILE_HASH(0f8e4aca0463e1b8b4da59cbed2e6dab)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
@@ -202,7 +202,7 @@ public:
      * \param n_read (out) Number of samples actually read from \p input.
      * \return Number of samples put into \p output.
      */
-    int filter(gr_complex* output, gr_complex* input, int n_to_read, int& n_read);
+    int filter(gr_complex* output, const gr_complex* input, int n_to_read, int& n_read);
 };
 
 
@@ -332,7 +332,7 @@ public:
      * \param n_read (out) Number of samples actually read from \p input.
      * \return Number of samples put into \p output.
      */
-    int filter(gr_complex* output, gr_complex* input, int n_to_read, int& n_read);
+    int filter(gr_complex* output, const gr_complex* input, int n_to_read, int& n_read);
 };
 
 
@@ -524,7 +524,7 @@ public:
      * \param n_read (out) Number of samples actually read from \p input.
      * \return Number of samples put into \p output.
      */
-    int filter(float* output, float* input, int n_to_read, int& n_read);
+    int filter(float* output, const float* input, int n_to_read, int& n_read);
 };
 
 } /* namespace kernel */

--- a/gr-filter/lib/filter_delay_fc_impl.cc
+++ b/gr-filter/lib/filter_delay_fc_impl.cc
@@ -51,8 +51,8 @@ int filter_delay_fc_impl::work(int noutput_items,
                                gr_vector_const_void_star& input_items,
                                gr_vector_void_star& output_items)
 {
-    float* in0 = (float*)input_items[0];
-    float* in1;
+    const float* in0 = (const float*)input_items[0];
+    const float* in1;
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_update) {
@@ -70,7 +70,7 @@ int filter_delay_fc_impl::work(int noutput_items,
         break;
 
     case 2:
-        in1 = (float*)input_items[1];
+        in1 = (const float*)input_items[1];
         for (int j = 0; j < noutput_items; j++) {
             out[j] = gr_complex(in0[j + d_delay], d_fir.filter(&in1[j]));
         }

--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -56,7 +56,7 @@ int filterbank_vcvcf_impl::general_work(int noutput_items,
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.cc
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.cc
@@ -145,7 +145,7 @@ int freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::work(
     gr_vector_const_void_star& input_items,
     gr_vector_void_star& output_items)
 {
-    IN_T* in = (IN_T*)input_items[0];
+    const IN_T* in = (const IN_T*)input_items[0];
     OUT_T* out = (OUT_T*)output_items[0];
 
     // rebuild composite FIR if the center freq has changed

--- a/gr-filter/lib/hilbert_fc_impl.cc
+++ b/gr-filter/lib/hilbert_fc_impl.cc
@@ -45,7 +45,7 @@ int hilbert_fc_impl::work(int noutput_items,
                           gr_vector_const_void_star& input_items,
                           gr_vector_void_star& output_items)
 {
-    float* in = (float*)input_items[0];
+    const float* in = (const float*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     for (int i = 0; i < noutput_items; i++) {

--- a/gr-filter/lib/pfb_arb_resampler.cc
+++ b/gr-filter/lib/pfb_arb_resampler.cc
@@ -177,7 +177,7 @@ float pfb_arb_resampler_ccf::phase_offset(float freq, float fs)
 }
 
 int pfb_arb_resampler_ccf::filter(gr_complex* output,
-                                  gr_complex* input,
+                                  const gr_complex* input,
                                   int n_to_read,
                                   int& n_read)
 {
@@ -370,7 +370,7 @@ float pfb_arb_resampler_ccc::phase_offset(float freq, float fs)
 }
 
 int pfb_arb_resampler_ccc::filter(gr_complex* output,
-                                  gr_complex* input,
+                                  const gr_complex* input,
                                   int n_to_read,
                                   int& n_read)
 {
@@ -559,7 +559,10 @@ float pfb_arb_resampler_fff::phase_offset(float freq, float fs)
     return -adj * d_est_phase_change;
 }
 
-int pfb_arb_resampler_fff::filter(float* output, float* input, int n_to_read, int& n_read)
+int pfb_arb_resampler_fff::filter(float* output,
+                                  const float* input,
+                                  int n_to_read,
+                                  int& n_read)
 {
     int i_out = 0, i_in = 0;
     unsigned int j = d_last_filter;

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
@@ -122,7 +122,7 @@ int pfb_arb_resampler_ccc_impl::general_work(int noutput_items,
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
@@ -124,7 +124,7 @@ int pfb_arb_resampler_ccf_impl::general_work(int noutput_items,
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
@@ -124,7 +124,7 @@ int pfb_arb_resampler_fff_impl::general_work(int noutput_items,
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    float* in = (float*)input_items[0];
+    const float* in = (const float*)input_items[0];
     float* out = (float*)output_items[0];
 
     if (d_updated) {

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.cc
@@ -130,7 +130,7 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
@@ -159,7 +159,7 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
         i = (i + d_rate_ratio) % d_nfilts;
         last = i;
         while (i >= 0) {
-            in = (gr_complex*)input_items[j];
+            in = (const gr_complex*)input_items[j];
             d_fft.get_inbuf()[d_idxlut[j]] = d_fir_filters[i].filter(&in[n]);
             j++;
             i--;
@@ -167,7 +167,7 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
 
         i = d_nfilts - 1;
         while (i > last) {
-            in = (gr_complex*)input_items[j];
+            in = (const gr_complex*)input_items[j];
             d_fft.get_inbuf()[d_idxlut[j]] = d_fir_filters[i].filter(&in[n - 1]);
             j++;
             i--;

--- a/gr-filter/lib/pfb_decimator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.cc
@@ -123,7 +123,7 @@ int pfb_decimator_ccf_impl::work_fir_exp(int noutput_items,
                                          gr_vector_const_void_star& input_items,
                                          gr_vector_void_star& output_items)
 {
-    gr_complex* in;
+    const gr_complex* in;
     gr_complex* out = (gr_complex*)output_items[0];
 
     int i;
@@ -132,7 +132,7 @@ int pfb_decimator_ccf_impl::work_fir_exp(int noutput_items,
         out[i] = 0;
         for (int j = d_rate - 1; j >= 0; j--) {
             // Take items from M-1 to 0; filter and rotate
-            in = (gr_complex*)input_items[d_rate - 1 - j];
+            in = (const gr_complex*)input_items[d_rate - 1 - j];
             out[i] += d_fir_filters[j].filter(&in[i]) * d_rotator[j];
         }
     }
@@ -144,7 +144,7 @@ int pfb_decimator_ccf_impl::work_fir_fft(int noutput_items,
                                          gr_vector_const_void_star& input_items,
                                          gr_vector_void_star& output_items)
 {
-    gr_complex* in;
+    const gr_complex* in;
     gr_complex* out = (gr_complex*)output_items[0];
 
     int i;
@@ -153,7 +153,7 @@ int pfb_decimator_ccf_impl::work_fir_fft(int noutput_items,
         out[i] = 0;
         for (unsigned int j = 0; j < d_rate; j++) {
             // Take in the items from the first input stream to d_rate
-            in = (gr_complex*)input_items[d_rate - 1 - j];
+            in = (const gr_complex*)input_items[d_rate - 1 - j];
             d_fft.get_inbuf()[j] = d_fir_filters[j].filter(&in[i]);
         }
 
@@ -171,7 +171,7 @@ int pfb_decimator_ccf_impl::work_fft_exp(int noutput_items,
                                          gr_vector_const_void_star& input_items,
                                          gr_vector_void_star& output_items)
 {
-    gr_complex* in;
+    const gr_complex* in;
     gr_complex* out = (gr_complex*)output_items[0];
 
     int i;
@@ -180,7 +180,7 @@ int pfb_decimator_ccf_impl::work_fft_exp(int noutput_items,
     // noutput_items at once to avoid repeated calls to the FFT
     // setup and operation.
     for (unsigned int j = 0; j < d_rate; j++) {
-        in = (gr_complex*)input_items[d_rate - j - 1];
+        in = (const gr_complex*)input_items[d_rate - j - 1];
         d_fft_filters[j].filter(noutput_items, in, &(d_tmp[j * noutput_items]));
     }
 
@@ -201,13 +201,13 @@ int pfb_decimator_ccf_impl::work_fft_fft(int noutput_items,
                                          gr_vector_const_void_star& input_items,
                                          gr_vector_void_star& output_items)
 {
-    gr_complex* in;
+    const gr_complex* in;
     gr_complex* out = (gr_complex*)output_items[0];
 
     int i;
 
     for (unsigned int j = 0; j < d_rate; j++) {
-        in = (gr_complex*)input_items[d_rate - j - 1];
+        in = (const gr_complex*)input_items[d_rate - j - 1];
         d_fft_filters[j].filter(noutput_items, in, &d_tmp[j * noutput_items]);
     }
 

--- a/gr-filter/lib/pfb_interpolator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_interpolator_ccf_impl.cc
@@ -58,7 +58,7 @@ int pfb_interpolator_ccf_impl::work(int noutput_items,
                                     gr_vector_const_void_star& input_items,
                                     gr_vector_void_star& output_items)
 {
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -215,7 +215,7 @@ int pfb_synthesizer_ccf_impl::work(int noutput_items,
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    gr_complex* in = (gr_complex*)input_items[0];
+    const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
@@ -230,7 +230,7 @@ int pfb_synthesizer_ccf_impl::work(int noutput_items,
     if (d_twox == 1) {
         for (n = 0; n < noutput_items / d_numchans; n++) {
             for (i = 0; i < ninputs; i++) {
-                in = (gr_complex*)input_items[i];
+                in = (const gr_complex*)input_items[i];
                 d_fft->get_inbuf()[d_channel_map[i]] = in[n];
             }
 
@@ -249,7 +249,7 @@ int pfb_synthesizer_ccf_impl::work(int noutput_items,
         for (n = 0; n < noutput_items / d_numchans; n++) {
             for (i = 0; i < ninputs; i++) {
                 // in = (gr_complex*)input_items[ninputs-i-1];
-                in = (gr_complex*)input_items[i];
+                in = (const gr_complex*)input_items[i];
                 d_fft->get_inbuf()[d_channel_map[i]] = in[n];
             }
 

--- a/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_arb_resampler.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(575adbe9dca6665e15803cdc1f2fa028)                     */
+/* BINDTOOL_HEADER_FILE_HASH(1e0320421dc648e6542c979af4d6da3c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -226,8 +226,8 @@ int tcp_sink_impl::work(int noutput_items,
 
     ec.clear();
 
-    char* p_buff;
-    p_buff = (char*)input_items[0];
+    const char* p_buff;
+    p_buff = (const char*)input_items[0];
 
     while ((bytes_remaining > 0) && (!ec)) {
         bytes_written = asio::write(

--- a/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
@@ -28,8 +28,8 @@ public:
     ConstellationDisplayPlot(int nplots, QWidget*);
     ~ConstellationDisplayPlot() override;
 
-    void plotNewData(const std::vector<double*> realDataPoints,
-                     const std::vector<double*> imagDataPoints,
+    void plotNewData(const std::vector<const double*> realDataPoints,
+                     const std::vector<const double*> imagDataPoints,
                      const int64_t numDataPoints,
                      const double timeInterval);
 

--- a/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
@@ -40,7 +40,7 @@ public:
     EyeDisplayPlot& operator=(const EyeDisplayPlot&) = delete;
     EyeDisplayPlot& operator=(EyeDisplayPlot&&) = delete;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<const double*> dataPoints,
                      const int64_t numDataPoints,
                      int d_sps,
                      const double timeInterval,

--- a/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
@@ -57,7 +57,7 @@ public:
     double getStartFrequency() const;
     double getStopFrequency() const;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<const double*> dataPoints,
                      const int64_t numDataPoints,
                      const double noiseFloorAmplitude,
                      const double peakFrequency,

--- a/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
@@ -35,7 +35,7 @@ public:
     HistogramDisplayPlot& operator=(const HistogramDisplayPlot&) = delete;
     HistogramDisplayPlot& operator=(HistogramDisplayPlot&&) = delete;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<const double*> dataPoints,
                      const uint64_t numDataPoints,
                      const double timeInterval);
 

--- a/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
@@ -41,7 +41,7 @@ public:
     TimeDomainDisplayPlot& operator=(const TimeDomainDisplayPlot&) = delete;
     TimeDomainDisplayPlot& operator=(TimeDomainDisplayPlot&&) = delete;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<const double*> dataPoints,
                      const int64_t numDataPoints,
                      const double timeInterval,
                      const std::vector<std::vector<gr::tag_t>>& tags =

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -61,7 +61,8 @@ public:
                            const double units,
                            const std::string& strunits);
 
-    void plotNewData(const std::vector<double*> dataPoints, const uint64_t numDataPoints);
+    void plotNewData(const std::vector<const double*> dataPoints,
+                     const uint64_t numDataPoints);
 
     void plotNewData(const double* dataPoints, const uint64_t numDataPoints);
 

--- a/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
@@ -53,7 +53,7 @@ public:
 
     void setXAxisValues(const double start, const double step = 1.0);
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<const double*> dataPoints,
                      const int64_t numDataPoints,
                      const double refLevel,
                      const double timeInterval);

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -52,7 +52,7 @@ public:
     double getStartFrequency() const;
     double getStopFrequency() const;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<const double*> dataPoints,
                      const int64_t numDataPoints,
                      const double timePerFFT,
                      const gr::high_res_timer_type timestamp,

--- a/gr-qtgui/include/gnuradio/qtgui/spectrumUpdateEvents.h
+++ b/gr-qtgui/include/gnuradio/qtgui/spectrumUpdateEvents.h
@@ -115,7 +115,7 @@ public:
     ~TimeUpdateEvent() override;
 
     int which() const;
-    const std::vector<double*> getTimeDomainPoints() const;
+    const std::vector<const double*> getTimeDomainPoints() const;
     uint64_t getNumTimeDomainDataPoints() const;
     bool getRepeatDataFlag() const;
 
@@ -126,7 +126,7 @@ public:
 protected:
 private:
     size_t _nplots;
-    std::vector<double*> _dataTimeDomainPoints;
+    std::vector<const double*> _dataTimeDomainPoints;
     uint64_t _numTimeDomainDataPoints;
     std::vector<std::vector<gr::tag_t>> _tags;
 };
@@ -144,7 +144,7 @@ public:
     ~FreqUpdateEvent() override;
 
     int which() const;
-    const std::vector<double*> getPoints() const;
+    const std::vector<const double*> getPoints() const;
     uint64_t getNumDataPoints() const;
     bool getRepeatDataFlag() const;
 
@@ -153,7 +153,7 @@ public:
 protected:
 private:
     size_t _nplots;
-    std::vector<double*> _dataPoints;
+    std::vector<const double*> _dataPoints;
     uint64_t _numDataPoints;
 };
 
@@ -185,8 +185,8 @@ public:
     ~ConstUpdateEvent() override;
 
     int which() const;
-    const std::vector<double*> getRealPoints() const;
-    const std::vector<double*> getImagPoints() const;
+    const std::vector<const double*> getRealPoints() const;
+    const std::vector<const double*> getImagPoints() const;
     uint64_t getNumDataPoints() const;
     bool getRepeatDataFlag() const;
 
@@ -195,8 +195,8 @@ public:
 protected:
 private:
     size_t _nplots;
-    std::vector<double*> _realDataPoints;
-    std::vector<double*> _imagDataPoints;
+    std::vector<const double*> _realDataPoints;
+    std::vector<const double*> _imagDataPoints;
     uint64_t _numDataPoints;
 };
 
@@ -214,7 +214,7 @@ public:
     ~WaterfallUpdateEvent() override;
 
     int which() const;
-    const std::vector<double*> getPoints() const;
+    const std::vector<const double*> getPoints() const;
     uint64_t getNumDataPoints() const;
     bool getRepeatDataFlag() const;
 
@@ -225,7 +225,7 @@ public:
 protected:
 private:
     size_t _nplots;
-    std::vector<double*> _dataPoints;
+    std::vector<const double*> _dataPoints;
     uint64_t _numDataPoints;
 
     gr::high_res_timer_type _dataTimestamp;
@@ -243,7 +243,7 @@ public:
     ~TimeRasterUpdateEvent() override;
 
     int which() const;
-    const std::vector<double*> getPoints() const;
+    const std::vector<const double*> getPoints() const;
     uint64_t getNumDataPoints() const;
     bool getRepeatDataFlag() const;
 
@@ -252,7 +252,7 @@ public:
 protected:
 private:
     size_t _nplots;
-    std::vector<double*> _dataPoints;
+    std::vector<const double*> _dataPoints;
     uint64_t _numDataPoints;
 };
 
@@ -286,7 +286,7 @@ public:
     ~HistogramUpdateEvent() override;
 
     int which() const;
-    const std::vector<double*> getDataPoints() const;
+    const std::vector<const double*> getDataPoints() const;
     uint64_t getNumDataPoints() const;
     bool getRepeatDataFlag() const;
 
@@ -295,7 +295,7 @@ public:
 protected:
 private:
     size_t _nplots;
-    std::vector<double*> _points;
+    std::vector<const double*> _points;
     uint64_t _npoints;
 };
 

--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
+++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
@@ -131,10 +131,11 @@ void ConstellationDisplayPlot::set_pen_size(int size)
 void ConstellationDisplayPlot::replot() { QwtPlot::replot(); }
 
 
-void ConstellationDisplayPlot::plotNewData(const std::vector<double*> realDataPoints,
-                                           const std::vector<double*> imagDataPoints,
-                                           const int64_t numDataPoints,
-                                           const double timeInterval)
+void ConstellationDisplayPlot::plotNewData(
+    const std::vector<const double*> realDataPoints,
+    const std::vector<const double*> imagDataPoints,
+    const int64_t numDataPoints,
+    const double timeInterval)
 {
     if (!d_stop) {
         if ((numDataPoints > 0)) {
@@ -188,10 +189,10 @@ void ConstellationDisplayPlot::plotNewData(const double* realDataPoints,
                                            const int64_t numDataPoints,
                                            const double timeInterval)
 {
-    std::vector<double*> vecRealDataPoints;
-    std::vector<double*> vecImagDataPoints;
-    vecRealDataPoints.push_back((double*)realDataPoints);
-    vecImagDataPoints.push_back((double*)imagDataPoints);
+    std::vector<const double*> vecRealDataPoints;
+    std::vector<const double*> vecImagDataPoints;
+    vecRealDataPoints.push_back(realDataPoints);
+    vecImagDataPoints.push_back(imagDataPoints);
     plotNewData(vecRealDataPoints, vecImagDataPoints, numDataPoints, timeInterval);
 }
 

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -288,7 +288,7 @@ void DisplayPlot::setLineMarker(unsigned int which, QwtSymbol::Style marker)
 QwtSymbol::Style DisplayPlot::getLineMarker(unsigned int which) const
 {
     if (which < d_nplots) {
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        const QwtSymbol* sym = d_plot_curve[which]->symbol();
         return sym->style();
     } else {
         return QwtSymbol::NoSymbol;

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -116,7 +116,7 @@ void DisplayPlot::setLineColor(unsigned int which, QColor color)
         pen.setColor(color);
         d_plot_curve[which]->setPen(pen);
         // And set the color of the markers
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[which]->symbol());
         if (sym) {
             sym->setColor(color);
             sym->setPen(pen);
@@ -239,7 +239,7 @@ void DisplayPlot::setLineWidth(unsigned int which, int width)
         d_plot_curve[which]->setPen(pen);
 
         // Scale the marker size proportionally
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[which]->symbol());
         if (sym) {
             sym->setSize(7 + 10 * log10(1.0 * width), 7 + 10 * log10(1.0 * width));
             d_plot_curve[which]->setSymbol(sym);
@@ -277,7 +277,7 @@ Qt::PenStyle DisplayPlot::getLineStyle(unsigned int which) const
 void DisplayPlot::setLineMarker(unsigned int which, QwtSymbol::Style marker)
 {
     if (which < d_nplots) {
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[which]->symbol());
         if (sym) {
             sym->setStyle(marker);
             d_plot_curve[which]->setSymbol(sym);
@@ -308,7 +308,7 @@ void DisplayPlot::setMarkerAlpha(unsigned int which, int alpha)
         d_plot_curve[which]->setPen(pen);
 
         // And set the new color for the markers
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[which]->symbol());
         if (sym) {
             sym->setColor(color);
             sym->setPen(pen);

--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -519,7 +519,7 @@ void EyeDisplayPlot::setLineColor(unsigned int which, QColor color)
         pen.setColor(color);
         d_plot_curve[i]->setPen(pen);
         // And set the color of the markers
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[i]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[i]->symbol());
         if (sym) {
             sym->setColor(color);
             sym->setPen(pen);
@@ -538,7 +538,7 @@ void EyeDisplayPlot::setLineWidth(unsigned int which, int width)
         d_plot_curve[i]->setPen(pen);
 
         // Scale the marker size proportionally
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[i]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[i]->symbol());
         if (sym) {
             sym->setSize(7 + 10 * log10(1.0 * i), 7 + 10 * log10(1.0 * i));
             d_plot_curve[i]->setSymbol(sym);
@@ -550,7 +550,7 @@ void EyeDisplayPlot::setLineWidth(unsigned int which, int width)
 void EyeDisplayPlot::setLineMarker(unsigned int which, QwtSymbol::Style marker)
 {
     for (unsigned int i = 0; i < d_plot_curve.size(); ++i) {
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[i]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[i]->symbol());
         if (sym) {
             sym->setStyle(marker);
             d_plot_curve[i]->setSymbol(sym);
@@ -582,7 +582,7 @@ void EyeDisplayPlot::setMarkerAlpha(unsigned int which, int alpha)
         d_plot_curve[i]->setPen(pen);
 
         // And set the new color for the markers
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[i]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[i]->symbol());
         if (sym) {
             sym->setColor(color);
             sym->setPen(pen);

--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -175,7 +175,7 @@ EyeDisplayPlot::~EyeDisplayPlot()
 
 void EyeDisplayPlot::replot() { QwtPlot::replot(); }
 
-void EyeDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void EyeDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                  const int64_t numDataPoints,
                                  int sps,
                                  const double timeInterval,

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -275,7 +275,7 @@ void FrequencyDisplayPlot::replot()
     QwtPlot::replot();
 }
 
-void FrequencyDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void FrequencyDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                        const int64_t numDataPoints,
                                        const double noiseFloorAmplitude,
                                        const double peakFrequency,
@@ -361,8 +361,8 @@ void FrequencyDisplayPlot::plotNewData(const double* dataPoints,
                                        const double peakAmplitude,
                                        const double timeInterval)
 {
-    std::vector<double*> vecDataPoints;
-    vecDataPoints.push_back((double*)dataPoints);
+    std::vector<const double*> vecDataPoints;
+    vecDataPoints.push_back(dataPoints);
     plotNewData(vecDataPoints,
                 numDataPoints,
                 noiseFloorAmplitude,

--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -285,7 +285,7 @@ void HistogramDisplayPlot::setMarkerAlpha(unsigned int which, int alpha)
         d_plot_curve[which]->setPen(pen);
 
         // And set the new color for the markers
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[which]->symbol());
         if (sym) {
             sym->setColor(color);
             sym->setPen(pen);
@@ -320,7 +320,7 @@ void HistogramDisplayPlot::setLineColor(unsigned int which, QColor color)
         pen.setColor(color);
         d_plot_curve[which]->setPen(pen);
 
-        QwtSymbol* sym = (QwtSymbol*)d_plot_curve[which]->symbol();
+        QwtSymbol* sym = const_cast<QwtSymbol*>(d_plot_curve[which]->symbol());
         if (sym) {
             sym->setColor(color);
             sym->setPen(pen);

--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -123,7 +123,7 @@ HistogramDisplayPlot::~HistogramDisplayPlot()
 
 void HistogramDisplayPlot::replot() { QwtPlot::replot(); }
 
-void HistogramDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void HistogramDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                        const uint64_t numDataPoints,
                                        const double timeInterval)
 {

--- a/gr-qtgui/lib/QRfnocF15ColorMapper.cc
+++ b/gr-qtgui/lib/QRfnocF15ColorMapper.cc
@@ -135,7 +135,7 @@ bool QRfnocF15ColorMapper::addPalette(std::string name, QPixmap& pixmap)
     /* Convert to an OpenGL texture */
     /* Note: We use TEXTURE_2D because 1D isn't really supported by Qt
      * and it's also not in OpenGL ES */
-    QGLContext* ctx = (QGLContext*)QGLContext::currentContext();
+    QGLContext* ctx = const_cast<QGLContext*>(QGLContext::currentContext());
     GLuint tex_id = ctx->bindTexture(pixmap, GL_TEXTURE_2D);
 
     /* Configure behavior */

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -155,7 +155,7 @@ TimeDomainDisplayPlot::~TimeDomainDisplayPlot()
 
 void TimeDomainDisplayPlot::replot() { QwtPlot::replot(); }
 
-void TimeDomainDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void TimeDomainDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                         const int64_t numDataPoints,
                                         const double timeInterval,
                                         const std::vector<std::vector<gr::tag_t>>& tags)

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -555,7 +555,7 @@ void TimeRasterDisplayPlot::setPlotDimensions(const double rows,
     }
 }
 
-void TimeRasterDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void TimeRasterDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                         const uint64_t numDataPoints)
 {
     if (!d_stop) {
@@ -574,8 +574,8 @@ void TimeRasterDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
 void TimeRasterDisplayPlot::plotNewData(const double* dataPoints,
                                         const uint64_t numDataPoints)
 {
-    std::vector<double*> vecDataPoints;
-    vecDataPoints.push_back((double*)dataPoints);
+    std::vector<const double*> vecDataPoints;
+    vecDataPoints.push_back(dataPoints);
     plotNewData(vecDataPoints, numDataPoints);
 }
 

--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -245,7 +245,7 @@ void VectorDisplayPlot::replot()
     QwtPlot::replot();
 }
 
-void VectorDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void VectorDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                     const int64_t numDataPoints,
                                     const double refLevel,
                                     const double timeInterval)

--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -223,7 +223,7 @@ double WaterfallDisplayPlot::getStartFrequency() const { return d_start_frequenc
 
 double WaterfallDisplayPlot::getStopFrequency() const { return d_stop_frequency; }
 
-void WaterfallDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void WaterfallDisplayPlot::plotNewData(const std::vector<const double*> dataPoints,
                                        const int64_t numDataPoints,
                                        const double timePerFFT,
                                        const gr::high_res_timer_type timestamp,
@@ -318,8 +318,8 @@ void WaterfallDisplayPlot::plotNewData(const double* dataPoints,
                                        const gr::high_res_timer_type timestamp,
                                        const int droppedFrames)
 {
-    std::vector<double*> vecDataPoints;
-    vecDataPoints.push_back((double*)dataPoints);
+    std::vector<const double*> vecDataPoints;
+    vecDataPoints.push_back(dataPoints);
     plotNewData(vecDataPoints, numDataPoints, timePerFFT, timestamp, droppedFrames);
 }
 

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -276,8 +276,8 @@ int ber_sink_b_impl::general_work(int noutput_items,
             int items = ninput_items[i] <= ninput_items[i + 1] ? ninput_items[i]
                                                                : ninput_items[i + 1];
 
-            unsigned char* inbuffer0 = (unsigned char*)input_items[i];
-            unsigned char* inbuffer1 = (unsigned char*)input_items[i + 1];
+            const unsigned char* inbuffer0 = (const unsigned char*)input_items[i];
+            const unsigned char* inbuffer1 = (const unsigned char*)input_items[i + 1];
 
             if (items > 0) {
                 uint32_t ret;

--- a/gr-qtgui/lib/constellationdisplayform.cc
+++ b/gr-qtgui/lib/constellationdisplayform.cc
@@ -101,8 +101,8 @@ ConstellationDisplayPlot* ConstellationDisplayForm::getPlot()
 void ConstellationDisplayForm::newData(const QEvent* updateEvent)
 {
     const ConstUpdateEvent* tevent = (const ConstUpdateEvent*)updateEvent;
-    const std::vector<double*> realDataPoints = tevent->getRealPoints();
-    const std::vector<double*> imagDataPoints = tevent->getImagPoints();
+    const std::vector<const double*> realDataPoints = tevent->getRealPoints();
+    const std::vector<const double*> imagDataPoints = tevent->getImagPoints();
     const uint64_t numDataPoints = tevent->getNumDataPoints();
 
     getPlot()->plotNewData(realDataPoints, imagDataPoints, numDataPoints, d_update_time);

--- a/gr-qtgui/lib/constellationdisplayform.cc
+++ b/gr-qtgui/lib/constellationdisplayform.cc
@@ -100,7 +100,7 @@ ConstellationDisplayPlot* ConstellationDisplayForm::getPlot()
 
 void ConstellationDisplayForm::newData(const QEvent* updateEvent)
 {
-    ConstUpdateEvent* tevent = (ConstUpdateEvent*)updateEvent;
+    const ConstUpdateEvent* tevent = (const ConstUpdateEvent*)updateEvent;
     const std::vector<double*> realDataPoints = tevent->getRealPoints();
     const std::vector<double*> imagDataPoints = tevent->getImagPoints();
     const uint64_t numDataPoints = tevent->getNumDataPoints();

--- a/gr-qtgui/lib/eyedisplayform.cc
+++ b/gr-qtgui/lib/eyedisplayform.cc
@@ -222,7 +222,7 @@ EyeDisplayPlot* EyeDisplayForm::getSinglePlot(unsigned int i)
 
 void EyeDisplayForm::newData(const QEvent* updateEvent)
 {
-    TimeUpdateEvent* tevent = (TimeUpdateEvent*)updateEvent;
+    const TimeUpdateEvent* tevent = (const TimeUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = tevent->getTimeDomainPoints();
     const uint64_t numDataPoints = tevent->getNumTimeDomainDataPoints();
     const std::vector<std::vector<gr::tag_t>> tags = tevent->getTags();

--- a/gr-qtgui/lib/eyedisplayform.cc
+++ b/gr-qtgui/lib/eyedisplayform.cc
@@ -223,7 +223,7 @@ EyeDisplayPlot* EyeDisplayForm::getSinglePlot(unsigned int i)
 void EyeDisplayForm::newData(const QEvent* updateEvent)
 {
     const TimeUpdateEvent* tevent = (const TimeUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = tevent->getTimeDomainPoints();
+    const std::vector<const double*> dataPoints = tevent->getTimeDomainPoints();
     const uint64_t numDataPoints = tevent->getNumTimeDomainDataPoints();
     const std::vector<std::vector<gr::tag_t>> tags = tevent->getTags();
 

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -235,7 +235,7 @@ FrequencyDisplayPlot* FreqDisplayForm::getPlot()
 
 void FreqDisplayForm::newData(const QEvent* updateEvent)
 {
-    FreqUpdateEvent* fevent = (FreqUpdateEvent*)updateEvent;
+    const FreqUpdateEvent* fevent = (const FreqUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = fevent->getPoints();
     const uint64_t numDataPoints = fevent->getNumDataPoints();
 

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -236,7 +236,7 @@ FrequencyDisplayPlot* FreqDisplayForm::getPlot()
 void FreqDisplayForm::newData(const QEvent* updateEvent)
 {
     const FreqUpdateEvent* fevent = (const FreqUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = fevent->getPoints();
+    const std::vector<const double*> dataPoints = fevent->getPoints();
     const uint64_t numDataPoints = fevent->getNumDataPoints();
 
     getPlot()->plotNewData(dataPoints, numDataPoints, 0, 0, 0, d_update_time);

--- a/gr-qtgui/lib/histogramdisplayform.cc
+++ b/gr-qtgui/lib/histogramdisplayform.cc
@@ -96,7 +96,7 @@ HistogramDisplayPlot* HistogramDisplayForm::getPlot()
 void HistogramDisplayForm::newData(const QEvent* updateEvent)
 {
     const HistogramUpdateEvent* hevent = (const HistogramUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = hevent->getDataPoints();
+    const std::vector<const double*> dataPoints = hevent->getDataPoints();
     const uint64_t numDataPoints = hevent->getNumDataPoints();
 
     getPlot()->plotNewData(dataPoints, numDataPoints, d_update_time);

--- a/gr-qtgui/lib/histogramdisplayform.cc
+++ b/gr-qtgui/lib/histogramdisplayform.cc
@@ -95,7 +95,7 @@ HistogramDisplayPlot* HistogramDisplayForm::getPlot()
 
 void HistogramDisplayForm::newData(const QEvent* updateEvent)
 {
-    HistogramUpdateEvent* hevent = (HistogramUpdateEvent*)updateEvent;
+    const HistogramUpdateEvent* hevent = (const HistogramUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = hevent->getDataPoints();
     const uint64_t numDataPoints = hevent->getNumDataPoints();
 

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -233,21 +233,21 @@ void number_sink_impl::_gui_update_trigger()
 
 float number_sink_impl::get_item(const void* input_items, int n)
 {
-    char* inc;
-    short* ins;
-    float* inf;
+    const char* inc;
+    const short* ins;
+    const float* inf;
 
     switch (d_itemsize) {
     case (1):
-        inc = (char*)input_items;
+        inc = (const char*)input_items;
         return static_cast<float>(inc[n]);
         break;
     case (2):
-        ins = (short*)input_items;
+        ins = (const short*)input_items;
         return static_cast<float>(ins[n]);
         break;
     case (4):
-        inf = (float*)input_items;
+        inf = (const float*)input_items;
         return static_cast<float>(inf[n]);
         break;
     default:

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -213,7 +213,7 @@ void NumberDisplayForm::saveFigure()
 void NumberDisplayForm::newData(const QEvent* updateEvent)
 {
     if (!d_stop_state) {
-        NumberUpdateEvent* tevent = (NumberUpdateEvent*)updateEvent;
+        const NumberUpdateEvent* tevent = (const NumberUpdateEvent*)updateEvent;
         const std::vector<float> samples = tevent->getSamples();
 
         for (unsigned int i = 0; i < d_nplots; ++i) {

--- a/gr-qtgui/lib/plot_raster.cc
+++ b/gr-qtgui/lib/plot_raster.cc
@@ -96,7 +96,7 @@ int PlotTimeRaster::rtti() const { return QwtPlotItem::Rtti_PlotGrid; }
 void PlotTimeRaster::setColorMap(const QwtColorMap* map)
 {
     delete d_data->colorMap;
-    d_data->colorMap = (QwtColorMap*)map;
+    d_data->colorMap = const_cast<QwtColorMap*>(map);
 
     invalidateCache();
     itemChanged();

--- a/gr-qtgui/lib/spectrumUpdateEvents.cc
+++ b/gr-qtgui/lib/spectrumUpdateEvents.cc
@@ -142,12 +142,13 @@ TimeUpdateEvent::TimeUpdateEvent(const std::vector<volk::vector<double>> timeDom
     // TODO: make this whole thing a vector copy.
     _nplots = timeDomainPoints.size();
     for (size_t i = 0; i < _nplots; i++) {
-        _dataTimeDomainPoints.push_back(new double[_numTimeDomainDataPoints]);
+        double* newDataTimeDomainPoints = new double[_numTimeDomainDataPoints];
         if (numTimeDomainDataPoints > 0) {
-            memcpy(_dataTimeDomainPoints[i],
+            memcpy(newDataTimeDomainPoints,
                    timeDomainPoints[i].data(),
                    _numTimeDomainDataPoints * sizeof(double));
         }
+        _dataTimeDomainPoints.push_back(newDataTimeDomainPoints);
     }
 
     _tags = tags;
@@ -160,7 +161,7 @@ TimeUpdateEvent::~TimeUpdateEvent()
     }
 }
 
-const std::vector<double*> TimeUpdateEvent::getTimeDomainPoints() const
+const std::vector<const double*> TimeUpdateEvent::getTimeDomainPoints() const
 {
     return _dataTimeDomainPoints;
 }
@@ -191,10 +192,11 @@ FreqUpdateEvent::FreqUpdateEvent(const std::vector<volk::vector<double>> dataPoi
     _nplots = dataPoints.size();
     // TODO: do a vector copy.
     for (size_t i = 0; i < _nplots; i++) {
-        _dataPoints.push_back(new double[_numDataPoints]);
+        double* newDataPoints = new double[_numDataPoints];
         if (numDataPoints > 0) {
-            memcpy(_dataPoints[i], dataPoints[i].data(), _numDataPoints * sizeof(double));
+            memcpy(newDataPoints, dataPoints[i].data(), _numDataPoints * sizeof(double));
         }
+        _dataPoints.push_back(newDataPoints);
     }
 }
 
@@ -205,7 +207,10 @@ FreqUpdateEvent::~FreqUpdateEvent()
     }
 }
 
-const std::vector<double*> FreqUpdateEvent::getPoints() const { return _dataPoints; }
+const std::vector<const double*> FreqUpdateEvent::getPoints() const
+{
+    return _dataPoints;
+}
 
 uint64_t FreqUpdateEvent::getNumDataPoints() const { return _numDataPoints; }
 
@@ -241,16 +246,18 @@ ConstUpdateEvent::ConstUpdateEvent(const std::vector<volk::vector<double>> realD
     // Todo: do vector copies.
     _nplots = realDataPoints.size();
     for (size_t i = 0; i < _nplots; i++) {
-        _realDataPoints.push_back(new double[_numDataPoints]);
-        _imagDataPoints.push_back(new double[_numDataPoints]);
+        double* newRealDataPoints = new double[_numDataPoints];
+        double* newImagDataPoints = new double[_numDataPoints];
         if (numDataPoints > 0) {
-            memcpy(_realDataPoints[i],
+            memcpy(newRealDataPoints,
                    realDataPoints[i].data(),
                    _numDataPoints * sizeof(double));
-            memcpy(_imagDataPoints[i],
+            memcpy(newImagDataPoints,
                    imagDataPoints[i].data(),
                    _numDataPoints * sizeof(double));
         }
+        _realDataPoints.push_back(newRealDataPoints);
+        _imagDataPoints.push_back(newImagDataPoints);
     }
 }
 
@@ -262,12 +269,12 @@ ConstUpdateEvent::~ConstUpdateEvent()
     }
 }
 
-const std::vector<double*> ConstUpdateEvent::getRealPoints() const
+const std::vector<const double*> ConstUpdateEvent::getRealPoints() const
 {
     return _realDataPoints;
 }
 
-const std::vector<double*> ConstUpdateEvent::getImagPoints() const
+const std::vector<const double*> ConstUpdateEvent::getImagPoints() const
 {
     return _imagDataPoints;
 }
@@ -292,10 +299,11 @@ WaterfallUpdateEvent::WaterfallUpdateEvent(
 
     _nplots = dataPoints.size();
     for (size_t i = 0; i < _nplots; i++) {
-        _dataPoints.push_back(new double[_numDataPoints]);
+        double* newDataPoints = new double[_numDataPoints];
         if (numDataPoints > 0) {
-            memcpy(_dataPoints[i], dataPoints[i].data(), _numDataPoints * sizeof(double));
+            memcpy(newDataPoints, dataPoints[i].data(), _numDataPoints * sizeof(double));
         }
+        _dataPoints.push_back(newDataPoints);
     }
 
     _dataTimestamp = dataTimestamp;
@@ -308,7 +316,10 @@ WaterfallUpdateEvent::~WaterfallUpdateEvent()
     }
 }
 
-const std::vector<double*> WaterfallUpdateEvent::getPoints() const { return _dataPoints; }
+const std::vector<const double*> WaterfallUpdateEvent::getPoints() const
+{
+    return _dataPoints;
+}
 
 uint64_t WaterfallUpdateEvent::getNumDataPoints() const { return _numDataPoints; }
 
@@ -333,10 +344,11 @@ TimeRasterUpdateEvent::TimeRasterUpdateEvent(
 
     _nplots = dataPoints.size();
     for (size_t i = 0; i < _nplots; i++) {
-        _dataPoints.push_back(new double[_numDataPoints]);
+        double* newDataPoints = new double[_numDataPoints];
         if (numDataPoints > 0) {
-            memcpy(_dataPoints[i], dataPoints[i].data(), _numDataPoints * sizeof(double));
+            memcpy(newDataPoints, dataPoints[i].data(), _numDataPoints * sizeof(double));
         }
+        _dataPoints.push_back(newDataPoints);
     }
 }
 
@@ -347,7 +359,7 @@ TimeRasterUpdateEvent::~TimeRasterUpdateEvent()
     }
 }
 
-const std::vector<double*> TimeRasterUpdateEvent::getPoints() const
+const std::vector<const double*> TimeRasterUpdateEvent::getPoints() const
 {
     return _dataPoints;
 }
@@ -381,10 +393,11 @@ HistogramUpdateEvent::HistogramUpdateEvent(const std::vector<volk::vector<double
 
     _nplots = points.size();
     for (size_t i = 0; i < _nplots; i++) {
-        _points.push_back(new double[_npoints]);
+        double* newPoints = new double[_npoints];
         if (npoints > 0) {
-            memcpy(_points[i], points[i].data(), _npoints * sizeof(double));
+            memcpy(newPoints, points[i].data(), _npoints * sizeof(double));
         }
+        _points.push_back(newPoints);
     }
 }
 
@@ -395,7 +408,10 @@ HistogramUpdateEvent::~HistogramUpdateEvent()
     }
 }
 
-const std::vector<double*> HistogramUpdateEvent::getDataPoints() const { return _points; }
+const std::vector<const double*> HistogramUpdateEvent::getDataPoints() const
+{
+    return _points;
+}
 
 uint64_t HistogramUpdateEvent::getNumDataPoints() const { return _npoints; }
 

--- a/gr-qtgui/lib/spectrumdisplayform.cc
+++ b/gr-qtgui/lib/spectrumdisplayform.cc
@@ -194,12 +194,12 @@ void SpectrumDisplayForm::newFrequencyData(const SpectrumUpdateEvent* spectrumUp
         spectrumUpdateEvent->getLastOfMultipleUpdateFlag();
     const gr::high_res_timer_type generatedTimestamp =
         spectrumUpdateEvent->getEventGeneratedTimestamp();
-    double* realTimeDomainDataPoints =
-        (double*)spectrumUpdateEvent->getRealTimeDomainPoints();
-    double* imagTimeDomainDataPoints =
-        (double*)spectrumUpdateEvent->getImagTimeDomainPoints();
+    const double* realTimeDomainDataPoints =
+        spectrumUpdateEvent->getRealTimeDomainPoints();
+    const double* imagTimeDomainDataPoints =
+        spectrumUpdateEvent->getImagTimeDomainPoints();
 
-    std::vector<double*> timeDomainDataPoints;
+    std::vector<const double*> timeDomainDataPoints;
     timeDomainDataPoints.push_back(realTimeDomainDataPoints);
     timeDomainDataPoints.push_back(imagTimeDomainDataPoints);
 

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -232,7 +232,7 @@ TimeDomainDisplayPlot* TimeDisplayForm::getPlot()
 void TimeDisplayForm::newData(const QEvent* updateEvent)
 {
     const TimeUpdateEvent* tevent = (const TimeUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = tevent->getTimeDomainPoints();
+    const std::vector<const double*> dataPoints = tevent->getTimeDomainPoints();
     const uint64_t numDataPoints = tevent->getNumTimeDomainDataPoints();
     const std::vector<std::vector<gr::tag_t>> tags = tevent->getTags();
 

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -231,7 +231,7 @@ TimeDomainDisplayPlot* TimeDisplayForm::getPlot()
 
 void TimeDisplayForm::newData(const QEvent* updateEvent)
 {
-    TimeUpdateEvent* tevent = (TimeUpdateEvent*)updateEvent;
+    const TimeUpdateEvent* tevent = (const TimeUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = tevent->getTimeDomainPoints();
     const uint64_t numDataPoints = tevent->getNumTimeDomainDataPoints();
     const std::vector<std::vector<gr::tag_t>> tags = tevent->getTags();

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -136,7 +136,7 @@ double TimeRasterDisplayForm::getMaxIntensity(unsigned int which)
 
 void TimeRasterDisplayForm::newData(const QEvent* updateEvent)
 {
-    TimeRasterUpdateEvent* event = (TimeRasterUpdateEvent*)updateEvent;
+    const TimeRasterUpdateEvent* event = (const TimeRasterUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = event->getPoints();
     const uint64_t numDataPoints = event->getNumDataPoints();
 

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -137,13 +137,13 @@ double TimeRasterDisplayForm::getMaxIntensity(unsigned int which)
 void TimeRasterDisplayForm::newData(const QEvent* updateEvent)
 {
     const TimeRasterUpdateEvent* event = (const TimeRasterUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = event->getPoints();
+    const std::vector<const double*> dataPoints = event->getPoints();
     const uint64_t numDataPoints = event->getNumDataPoints();
 
     for (size_t i = 0; i < dataPoints.size(); i++) {
-        double* min_val =
+        const double* min_val =
             std::min_element(&dataPoints[i][0], &dataPoints[i][numDataPoints - 1]);
-        double* max_val =
+        const double* max_val =
             std::max_element(&dataPoints[i][0], &dataPoints[i][numDataPoints - 1]);
         if (*min_val < d_min_val)
             d_min_val = *min_val;

--- a/gr-qtgui/lib/vectordisplayform.cc
+++ b/gr-qtgui/lib/vectordisplayform.cc
@@ -77,7 +77,7 @@ VectorDisplayPlot* VectorDisplayForm::getPlot()
 
 void VectorDisplayForm::newData(const QEvent* updateEvent)
 {
-    FreqUpdateEvent* fevent = (FreqUpdateEvent*)updateEvent;
+    const FreqUpdateEvent* fevent = (const FreqUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = fevent->getPoints();
     const uint64_t numDataPoints = fevent->getNumDataPoints();
 

--- a/gr-qtgui/lib/vectordisplayform.cc
+++ b/gr-qtgui/lib/vectordisplayform.cc
@@ -78,7 +78,7 @@ VectorDisplayPlot* VectorDisplayForm::getPlot()
 void VectorDisplayForm::newData(const QEvent* updateEvent)
 {
     const FreqUpdateEvent* fevent = (const FreqUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = fevent->getPoints();
+    const std::vector<const double*> dataPoints = fevent->getPoints();
     const uint64_t numDataPoints = fevent->getNumDataPoints();
 
     getPlot()->plotNewData(dataPoints, numDataPoints, d_ref_level, d_update_time);

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -119,14 +119,14 @@ WaterfallDisplayPlot* WaterfallDisplayForm::getPlot()
 void WaterfallDisplayForm::newData(const QEvent* updateEvent)
 {
     const WaterfallUpdateEvent* event = (const WaterfallUpdateEvent*)updateEvent;
-    const std::vector<double*> dataPoints = event->getPoints();
+    const std::vector<const double*> dataPoints = event->getPoints();
     const uint64_t numDataPoints = event->getNumDataPoints();
     const gr::high_res_timer_type dataTimestamp = event->getDataTimestamp();
 
     for (size_t i = 0; i < dataPoints.size(); i++) {
-        double* min_val =
+        const double* min_val =
             std::min_element(&dataPoints[i][0], &dataPoints[i][numDataPoints - 1]);
-        double* max_val =
+        const double* max_val =
             std::max_element(&dataPoints[i][0], &dataPoints[i][numDataPoints - 1]);
         if (*min_val < d_min_val)
             d_min_val = *min_val;

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -118,7 +118,7 @@ WaterfallDisplayPlot* WaterfallDisplayForm::getPlot()
 
 void WaterfallDisplayForm::newData(const QEvent* updateEvent)
 {
-    WaterfallUpdateEvent* event = (WaterfallUpdateEvent*)updateEvent;
+    const WaterfallUpdateEvent* event = (const WaterfallUpdateEvent*)updateEvent;
     const std::vector<double*> dataPoints = event->getPoints();
     const uint64_t numDataPoints = event->getNumDataPoints();
     const gr::high_res_timer_type dataTimestamp = event->getDataTimestamp();

--- a/gr-trellis/lib/constellation_metrics_cf_impl.cc
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.cc
@@ -62,7 +62,7 @@ int constellation_metrics_cf_impl::general_work(int noutput_items,
     unsigned int nstreams = input_items.size();
 
     for (unsigned int m = 0; m < nstreams; m++) {
-        const gr_complex* in = (gr_complex*)input_items[m];
+        const gr_complex* in = (const gr_complex*)input_items[m];
         float* out = (float*)output_items[m];
 
         for (unsigned int i = 0; i < noutput_items / d_O; i++) {

--- a/gr-trellis/lib/metrics_impl.cc
+++ b/gr-trellis/lib/metrics_impl.cc
@@ -102,7 +102,7 @@ int metrics_impl<T>::general_work(int noutput_items,
     int nstreams = input_items.size();
 
     for (int m = 0; m < nstreams; m++) {
-        const T* in = (T*)input_items[m];
+        const T* in = (const T*)input_items[m];
         float* out = (float*)output_items[m];
 
         for (int i = 0; i < noutput_items / d_O; i++) {

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -230,7 +230,7 @@ int sink_s_impl::work(int noutput_items,
                       gr_vector_const_void_star& input_items,
                       gr_vector_void_star& output_items)
 {
-    short *src_pixels_0, *src_pixels_1, *src_pixels_2;
+    const short *src_pixels_0, *src_pixels_1, *src_pixels_2;
     int noutput_items_produced = 0;
     int plane;
     int delay = (int)d_avg_delay;
@@ -246,9 +246,9 @@ int sink_s_impl::work(int noutput_items,
 
     switch (input_items.size()) {
     case 3: // first channel=Y, second channel is  U , third channel is V
-        src_pixels_0 = (short*)input_items[0];
-        src_pixels_1 = (short*)input_items[1];
-        src_pixels_2 = (short*)input_items[2];
+        src_pixels_0 = (const short*)input_items[0];
+        src_pixels_1 = (const short*)input_items[1];
+        src_pixels_2 = (const short*)input_items[2];
         for (int i = 0; i < noutput_items; i += d_chunk_size) {
             copy_plane_to_surface(1, d_chunk_size, src_pixels_1);
             copy_plane_to_surface(2, d_chunk_size, src_pixels_2);
@@ -261,8 +261,8 @@ int sink_s_impl::work(int noutput_items,
         break;
     case 2:
         // first channel=Y, second channel is alternating pixels U and V
-        src_pixels_0 = (short*)input_items[0];
-        src_pixels_1 = (short*)input_items[1];
+        src_pixels_0 = (const short*)input_items[0];
+        src_pixels_1 = (const short*)input_items[1];
         for (int i = 0; i < noutput_items; i += d_chunk_size) {
             copy_plane_to_surface(12, d_chunk_size / 2, src_pixels_1);
             noutput_items_produced +=
@@ -274,7 +274,7 @@ int sink_s_impl::work(int noutput_items,
     case 1: // grey (Y) input
         /* Y component */
         plane = 0;
-        src_pixels_0 = (short*)input_items[plane];
+        src_pixels_0 = (const short*)input_items[plane];
         for (int i = 0; i < noutput_items; i += d_chunk_size) {
             noutput_items_produced +=
                 copy_plane_to_surface(plane, d_chunk_size, src_pixels_0);

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -224,7 +224,7 @@ int sink_uc_impl::work(int noutput_items,
                        gr_vector_const_void_star& input_items,
                        gr_vector_void_star& output_items)
 {
-    unsigned char *src_pixels_0, *src_pixels_1, *src_pixels_2;
+    const unsigned char *src_pixels_0, *src_pixels_1, *src_pixels_2;
     int noutput_items_produced = 0;
     int plane;
     int delay = (int)d_avg_delay;
@@ -241,9 +241,9 @@ int sink_uc_impl::work(int noutput_items,
 
     switch (input_items.size()) {
     case 3: // first channel=Y, second channel is  U , third channel is V
-        src_pixels_0 = (unsigned char*)input_items[0];
-        src_pixels_1 = (unsigned char*)input_items[1];
-        src_pixels_2 = (unsigned char*)input_items[2];
+        src_pixels_0 = (const unsigned char*)input_items[0];
+        src_pixels_1 = (const unsigned char*)input_items[1];
+        src_pixels_2 = (const unsigned char*)input_items[2];
         for (int i = 0; i < noutput_items; i += d_chunk_size) {
             copy_plane_to_surface(1, d_chunk_size, src_pixels_1);
             copy_plane_to_surface(2, d_chunk_size, src_pixels_2);
@@ -256,8 +256,8 @@ int sink_uc_impl::work(int noutput_items,
         break;
     case 2:
         // first channel=Y, second channel is alternating pixels U and V
-        src_pixels_0 = (unsigned char*)input_items[0];
-        src_pixels_1 = (unsigned char*)input_items[1];
+        src_pixels_0 = (const unsigned char*)input_items[0];
+        src_pixels_1 = (const unsigned char*)input_items[1];
         for (int i = 0; i < noutput_items; i += d_chunk_size) {
             copy_plane_to_surface(12, d_chunk_size / 2, src_pixels_1);
             noutput_items_produced +=
@@ -269,7 +269,7 @@ int sink_uc_impl::work(int noutput_items,
     case 1: // grey (Y) input
         /* Y component */
         plane = 0;
-        src_pixels_0 = (unsigned char*)input_items[plane];
+        src_pixels_0 = (const unsigned char*)input_items[plane];
         for (int i = 0; i < noutput_items; i += d_chunk_size) {
             noutput_items_produced +=
                 copy_plane_to_surface(plane, d_chunk_size, src_pixels_0);

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -87,7 +87,7 @@ int freedv_rx_ss_impl::general_work(int noutput_items,
                                     gr_vector_const_void_star& input_items,
                                     gr_vector_void_star& output_items)
 {
-    short* in = (short*)input_items[0];
+    short* in = const_cast<short*>((const short*)input_items[0]);
     short* out = (short*)output_items[0];
 
     int in_offset = 0, out_offset = 0;

--- a/gr-vocoder/lib/freedv_tx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.cc
@@ -98,7 +98,7 @@ int freedv_tx_ss_impl::general_work(int noutput_items,
                                     gr_vector_const_void_star& input_items,
                                     gr_vector_void_star& output_items)
 {
-    short* in = (short*)input_items[0];
+    short* in = const_cast<short*>((const short*)input_items[0]);
     short* out = (short*)output_items[0];
     int i;
 


### PR DESCRIPTION
## Description
Don't remove `const`-ness where there is no need to do so, and use `const_cast` when it is necessary (particularly in qgui). Refactor plotting to accept immutable data, and refactor some data marshaling to pass immutable points rather than mutable points to avoid unnecessary adaptation.

This significantly reduces `-Wcast-qual` warnings. Also turn that on by default to reduce the chances of regressions.

(Individual commits may have more details.)

## Which blocks/areas does this affect?
This should have negligible to no impact on code generation, since not dropping `const` when not needed should have no effect, and replacing C-style casts with `const_cast` *definitely* should have no effect. I don't expect changing `vector<double*>` to `vector<const double*>` to have any effect either, as the `vector` still holds a mutable pointer in both cases. (Note that we're talking about mutable pointers to (im)mutable data; that is, the pointers are always mutable, the change is whether what they point *to* is `const`. I can readily imagine `vector<T>` and `vector<T const>` having different codegen, but I don't know any reason why `vector<T*>` and `vector<T const*>` would differ.) The usage never needed mutable data, so should not be affected.

## Testing Done
Compiled locally with `-Werror=cast-qual` on Fedora 39 and ran `ctest`.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass. (No new APIs.)

I *suspect* the documentation is more user-facing and isn't affected by the changes to the plotting API, but as I'm not sure, I left that unchecked. If there's any documentation changes needed, I'd appreciate if someone can point me in the direction of what to change; thanks!