### PR TITLE
blocks/blockinterleaving: rework permutation check to suppress warning (backport to maint-3.10)

### DIFF
--- a/gr-blocks/lib/blockinterleaving.cc
+++ b/gr-blocks/lib/blockinterleaving.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2022 Johannes Demel.
+ * Copyright 2024 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -11,12 +12,12 @@
 #include <gnuradio/blocks/blockinterleaving.h>
 
 /* ensure that tweakme.h is included before the bundled spdlog/fmt header, see
- * https://github.com/gabime/spdlog/issues/2922 */
+ * https://github.com/gabime/spdlog/issues/2922 ; fixed upstream in spdlog v1.13.0 */
 #include <spdlog/tweakme.h>
 
 #include <spdlog/fmt/fmt.h>
-#include <algorithm>
-#include <numeric>
+
+#include <stdexcept>
 #include <vector>
 
 namespace gr {
@@ -32,33 +33,61 @@ block_interleaving::block_interleaving(std::vector<size_t> interleaver_indices)
 void block_interleaving::set_interleaver_indices(
     const std::vector<size_t>& interleaver_indices)
 {
-    std::vector<size_t> test(interleaver_indices);
-    std::sort(test.begin(), test.end());
-    std::unique(test.begin(), test.end());
-    const auto [min, max] = std::minmax_element(test.begin(), test.end());
-    if (test.size() != interleaver_indices.size() || *min != 0 ||
-        *max != interleaver_indices.size() - 1) {
-        throw std::invalid_argument(
-            fmt::format("Incorrect interleaver indices! Expected {} unique elements in "
-                        "the range[0, {}) "
-                        "in random order, but got {} elements in range [{}, {})!",
-                        interleaver_indices.size(),
-                        interleaver_indices.size(),
-                        test.size(),
-                        *min,
-                        *max + 1));
+    if (interleaver_indices.empty()) {
+        throw std::invalid_argument("Incorrect interleaver indices! Can't be empty.");
     }
 
-    _interleaver_indices = std::vector<size_t>(interleaver_indices);
+    std::vector<size_t> deinterleaver_indices(interleaver_indices.size(), 0);
+    bool zero_seen = false;
+    for (size_t counter = 0; counter < interleaver_indices.size(); ++counter) {
+        const auto index = interleaver_indices[counter];
 
-    _deinterleaver_indices.resize(_interleaver_indices.size());
-    std::iota(_deinterleaver_indices.begin(), _deinterleaver_indices.end(), 0);
-    // sort indexes based on comparing values in v
-    std::sort(_deinterleaver_indices.begin(),
-              _deinterleaver_indices.end(),
-              [&interleaver_indices](size_t i1, size_t i2) {
-                  return interleaver_indices[i1] < interleaver_indices[i2];
-              });
+        // check bounds
+        if (index >= interleaver_indices.size()) {
+            throw std::invalid_argument(fmt::format(
+                "Incorrect interleaver indices! Expected {0} unique elements in the "
+                "range[0, {0}) in random order, but element {1} >= {0}!",
+                interleaver_indices.size(),
+                index));
+        }
+
+        // check for duplicate zero
+        if (index == 0) {
+            if (zero_seen) {
+                throw std::invalid_argument(fmt::format(
+                    "Incorrect interleaver indices! Expected {0} unique elements in the "
+                    "range[0, {0}) in random order, but element {1} appears twice, at "
+                    "positions {2} and {3}!",
+                    interleaver_indices.size(),
+                    index,
+                    deinterleaver_indices[index],
+                    counter));
+            }
+            zero_seen = true;
+            deinterleaver_indices[0] = counter;
+        }
+
+        // put into deinterleaver, check duplicity while doing that
+        else if (deinterleaver_indices[index] == 0) { // not yet used
+            deinterleaver_indices[index] = counter;
+        } else {
+            throw std::invalid_argument(fmt::format(
+                "Incorrect interleaver indices! Expected {0} unique elements in the "
+                "range[0, {0}) in random order, but element {1} appears twice, at "
+                "positions {2} and {3}!",
+                interleaver_indices.size(),
+                index,
+                deinterleaver_indices[index],
+                counter));
+        }
+    }
+
+    /* At this point, we have inserted all N elements from interleaver_indices into our
+     * deinterleaver_indices, no duplicates occurred during processing of N elements, and
+     * none was >= N, which implies the range is unique and consecutive from 0 to N-1.
+     */
+    _interleaver_indices = interleaver_indices;
+    _deinterleaver_indices = std::move(deinterleaver_indices);
 }
 
 } /* namespace kernel */

--- a/gr-blocks/python/blocks/qa_blockinterleaver_xx.py
+++ b/gr-blocks/python/blocks/qa_blockinterleaver_xx.py
@@ -15,6 +15,7 @@ import numpy as np
 class test_blockinterleaver_xx(gr_unittest.TestCase):
     def setUp(self):
         self.tb = gr.top_block()
+        np.random.seed(0x13375eed)
 
     def tearDown(self):
         self.tb = None


### PR DESCRIPTION
Backport #7293