### PR TITLE
modtool: robustify entry points (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -18,7 +18,14 @@ try:
     from importlib.metadata import entry_points
 
     def entries(group: str):
-        return entry_points().select(group=group)
+        eps = entry_points()
+        # entry_points() in older versions returns a dict-alike, in
+        # newer it returns a special object without dict interface.
+        # I don't know why – I think the old API was nice.
+        # Anyways, here's what should work for both.
+        if hasattr(eps, "select"):
+            return eps.select(group=group)
+        return eps.get(group, [])
 except ImportError:
     from pkg_resources import iter_entry_points as entries
 

--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -14,8 +14,15 @@ import sys
 import logging
 import functools
 from importlib import import_module
-from pkg_resources import iter_entry_points
-from logging import Formatter, StreamHandler
+try:
+    from importlib.metadata import entry_points
+
+    def entries(group: str):
+        return entry_points().select(group=group)
+except ImportError:
+    from pkg_resources import iter_entry_points as entries
+
+from logging import StreamHandler
 
 import click
 from click import ClickException
@@ -140,10 +147,10 @@ block_name = click.argument(
     'blockname', nargs=1, required=False, metavar="BLOCK_NAME")
 
 
-@with_plugins(iter_entry_points('gnuradio.modtool.cli.plugins'))
+@with_plugins(entries('gnuradio.modtool.cli.plugins'))
 @click.command(cls=CommandCLI,
-               epilog='Manipulate with GNU Radio modules source code tree. ' +
-               'Call it without options to run specified command interactively')
+               epilog='Manipulate the source code tree of a GNU Radio module. ' +
+               'Call without options to run specified command interactively')
 def cli():
     """A tool for editing GNU Radio out-of-tree modules."""
     pass


### PR DESCRIPTION
Backport #7317 
Backport #7346 

- **modtool: replace pkg_resources with import.metadata when available**
- **modtool: make importlib.metadata.entrypoints usage robust**
