### PR TITLE
modtool: make importlib.metadata.entrypoints usage robust

### DIFF
--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -18,7 +18,14 @@ try:
     from importlib.metadata import entry_points
 
     def entries(group: str):
-        return entry_points().select(group=group)
+        eps = entry_points()
+        # entry_points() in older versions returns a dict-alike, in
+        # newer it returns a special object without dict interface.
+        # I don't know why – I think the old API was nice.
+        # Anyways, here's what should work for both.
+        if hasattr(eps, "select"):
+            return eps.select(group=group)
+        return eps.get(group, [])
 except ImportError:
     from pkg_resources import iter_entry_points as entries
 


### PR DESCRIPTION
The return type incompatibly changed; need to account for breakage on older platforms.

In order to not let 3.10 and main code base diverge, here's the `main` targetting PR to the `maint-3.10` targetting #7342. 

Followup to #7317 

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

#7342

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
