### PR TITLE
gr-qtgui: Add numeric entry widget

### DIFF
--- a/gr-qtgui/examples/qtgui_numeric_entry.grc
+++ b/gr-qtgui/examples/qtgui_numeric_entry.grc
@@ -1,0 +1,122 @@
+options:
+  parameters:
+    author: Philipp Niedermayer
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: qtGuiNumericEntry
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: QT GUI Numeric Entry Example
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: freq
+  id: variable_qtgui_numeric_entry
+  parameters:
+    alias: ''
+    comment: ''
+    description: Example frequency value for testing
+    gui_hint: 0,0
+    increment: '0.1'
+    label: Frequency
+    precision: '5'
+    unit: kHz
+    value: '1'
+    value_max: limit_max
+    value_min: limit_min
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [64, 148.0]
+    rotation: 0
+    state: enabled
+- name: limit_max
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    entry_signal: editingFinished
+    gui_hint: 5,0
+    label: Max frequency
+    type: raw
+    value: 1e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 260.0]
+    rotation: 0
+    state: enabled
+- name: limit_min
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    entry_signal: editingFinished
+    gui_hint: 4,0
+    label: Min frequency
+    type: raw
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 172.0]
+    rotation: 0
+    state: enabled
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: variable_qtgui_label_0
+  id: variable_qtgui_label
+  parameters:
+    comment: ''
+    formatter: None
+    gui_hint: 1,0
+    label: 'Actual value:'
+    type: raw
+    value: freq
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [72, 268.0]
+    rotation: 0
+    state: enabled
+
+connections: []
+
+metadata:
+  file_format: 1
+  grc_version: 3.10.8.0

--- a/gr-qtgui/grc/qtgui.tree.yml
+++ b/gr-qtgui/grc/qtgui.tree.yml
@@ -21,6 +21,7 @@
     - variable_qtgui_check_box
     - variable_qtgui_push_button
     - variable_qtgui_entry
+    - variable_qtgui_numeric_entry
     - variable_qtgui_label
     - qtgui_edit_box_msg
     - qtgui_auto_correlator_sink

--- a/gr-qtgui/grc/qtgui_numeric_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_numeric_entry.block.yml
@@ -1,0 +1,103 @@
+id: variable_qtgui_numeric_entry
+label: QT GUI Numeric Entry
+flags: [ show_id, python ]
+
+documentation: |-
+    This block creates a variable with a text entry box to accept numeric data in any common format.
+    It handles units, numeric expressions and lower/upper bounds.
+    
+    Examples (unit Hz):
+    "0.1" -> 0.1 Hz
+    "1e3" -> 1000 Hz
+    "5*2-3" -> 7 Hz
+    "8 kHz" -> 8000 Hz
+    "30m" -> 0.03 Hz
+    
+    When the entry is focussed, the user can use the UP/DOWN keys to in-/decrement the value by the specified increment, and the PageUp/PageDown for ten times the increment.
+    
+    The label color is used to indicate the status:
+    blue = editing but value not yet applied
+    red = invalid input
+    black = value applied
+    
+    If one of the boundaries (min/max value) changes, or if the variable is changed from some other place in the flowgraph via the top block's "set_xxx()" callback (e.g. Message Pair to Var block), this is reflected on the UI
+    
+    The precision defines the maximum decimal places to consider.
+    
+    The widget can be en-/disabled dynamically if required to prevent the user from changing the values (programatic limit and value updates are still applied).
+    
+    The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.
+
+
+parameters:
+- id: label
+  label: Label
+  dtype: string
+  hide: ${ ('none' if label else 'part') }
+- id: unit
+  label: Unit
+  dtype: string
+  default: ''
+  hide: part
+- id: value
+  label: Default value
+  dtype: float
+  default: '0'
+- id: value_min
+  label: Minimum value
+  dtype: float
+  default: '-1e999'
+  hide: part
+- id: value_max
+  label: Maximum value
+  dtype: float
+  default: 'float("inf")'
+  hide: part
+- id: increment
+  label: Increment
+  dtype: float
+  default: '0.1'
+  hide: part
+- id: precision
+  label: Precision
+  dtype: int
+  default: 10
+  hide: part
+- id: description
+  label: Tooltip
+  dtype: string
+  default: ''
+  hide: part
+- id: enabled
+  label: Enabled
+  dtype: bool
+  default: True
+  hide: part
+- id: gui_hint
+  label: GUI Hint
+  dtype: gui_hint
+  hide: part
+
+value: ${ value }
+
+
+templates:
+  var_make: self.${id} = ${id} = ${value}
+  make: |-
+    <%
+        win = 'self._%s_tool_bar'%id
+        callback = 'self.set_%s'%id
+    %>        
+    ${win} = qtgui.NumericEntry(${callback}, ${label}, ${value}, ${increment}, ${unit}, ${description}, ${precision}, ${enabled})
+    ${win}.set_limits(${value_min}, ${value_max})
+    ${gui_hint() % win}
+  callbacks:
+    - self.set_${id}(${value})
+    - self._${id}_tool_bar.set_value(${id})
+    - self._${id}_tool_bar.set_limits(${value_min}, ${value_max})
+    - self._${id}_tool_bar.set_enabled(${enabled})
+
+
+#  'file_format' specifies the version of the GRC yml format used in the file
+#  and should usually not be changed.
+file_format: 1

--- a/gr-qtgui/python/qtgui/CMakeLists.txt
+++ b/gr-qtgui/python/qtgui/CMakeLists.txt
@@ -17,6 +17,7 @@ gr_python_install(
     FILES __init__.py
           compass.py
           togglebutton.py
+          numeric_entry.py
           msgpushbutton.py
           msgcheckbox.py
           distanceradar.py

--- a/gr-qtgui/python/qtgui/__init__.py
+++ b/gr-qtgui/python/qtgui/__init__.py
@@ -36,6 +36,7 @@ from . import util
 
 from .compass import GrCompass
 from .togglebutton import ToggleButton
+from .numeric_entry import NumericEntry
 from .msgpushbutton import MsgPushButton
 from .msgcheckbox import MsgCheckBox
 from .digitalnumbercontrol import MsgDigitalNumberControl

--- a/gr-qtgui/python/qtgui/numeric_entry.py
+++ b/gr-qtgui/python/qtgui/numeric_entry.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2024 Philipp Niedermayer.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+
+from PyQt5 import Qt, QtCore, QtWidgets
+from gnuradio import gr
+import math
+import re
+
+
+class NumericEntry(Qt.QToolBar):
+    def __init__(self, callback, label="", value=0, increment=0, unit="", description=None, precision=10, enabled=True):
+        QtWidgets.QWidget.__init__(self)
+
+        self.value = value
+        self.value_min = self.value_max = None
+        self.increment = increment
+        self.unit = unit
+        self.description = description
+        self.precision = precision
+        self.callback = callback
+
+        self.label = Qt.QLabel(label + ": ")
+        self.addWidget(self.label)
+
+        self.edit = Qt.QLineEdit()
+        self.edit.editingFinished.connect(self._apply)
+        self.edit.textEdited.connect(lambda: self._set_editing())
+        self._editing = (False, None)
+        self.addWidget(self.edit)
+
+        self._update_tooltip()
+        self.set_value(value)
+        self.set_enabled(enabled)
+
+    def set_enabled(self, enabled):
+        self.edit.setEnabled(enabled)
+
+    def keyPressEvent(self, event):
+        # in-/decrement
+        if event.key() == QtCore.Qt.Key_Up and self.increment:
+            self._apply(self.value + self.increment)
+        elif event.key() == QtCore.Qt.Key_Down and self.increment:
+            self._apply(self.value - self.increment)
+        elif event.key() == QtCore.Qt.Key_PageUp and self.increment:
+            self._apply(self.value + 10 * self.increment)
+        elif event.key() == QtCore.Qt.Key_PageDown and self.increment:
+            self._apply(self.value - 10 * self.increment)
+        else:
+            super().keyPressEvent(event)
+
+    def _set_editing(self, editing=True, valid=True):
+        if self._editing != (editing, valid):
+            style = "QLabel { color: red }" if not valid else \
+                    "QLabel { color: blue }" if editing else ""
+            Qt.QMetaObject.invokeMethod(self.label, "setStyleSheet", Qt.Q_ARG("QString", style))
+            self._editing = (editing, valid)
+
+    def _fmt(self, value):
+        return f"{value:.{self.precision}g} {self.unit}".strip()
+
+    def _update_tooltip(self):
+        tip = ""
+        if self.description:
+            tip += f"{self.description}\n"
+        if self.value_min is not None and not math.isinf(self.value_min):
+            tip += f"Minimum value: {self._fmt(self.value_min)}\n"
+        if self.value_max is not None and not math.isinf(self.value_max):
+            tip += f"Maximum value: {self._fmt(self.value_max)}\n"
+        if self.increment:
+            tip += f"Increment (up/down key): {self._fmt(self.increment)}\n"
+        self.label.setToolTip(tip.strip())
+
+    def set_limits(self, lower, upper):
+        self.value_min = lower
+        self.value_max = upper
+        self._update_tooltip()
+        self._apply()
+
+    def set_value(self, value):
+        """Public method used to set new value"""
+        self.value = float(value)
+        Qt.QMetaObject.invokeMethod(self.edit, "setText", Qt.Q_ARG("QString", self._fmt(self.value)))
+        self._set_editing(False)
+
+    def _parse(self, string):
+        SI = dict(G=1e9, M=1e6, k=1e3, m=1e-3, u=1e-6, μ=1e-6, n=1e-9)
+        scale = 1
+        # handle physical units
+        if self.unit:
+            if string.endswith(self.unit):
+                string = string[:-len(self.unit)].strip()
+            elif len(self.unit) > 1:
+                for prefix, factor in SI.items():
+                    if self.unit.startswith(prefix) and string.endswith(self.unit[1:]):
+                        string = string[:-len(self.unit[1:])].strip()
+                        scale /= factor
+        # handle engeneering shortforms like "1k"
+        if string[-1] in SI:
+            scale *= SI[string[-1]]
+            string = string[:-1]
+        # handle common typos
+        string = string.replace(',', '.').strip()
+        # evaluate
+        try:
+            value = float(string)
+        except ValueError:
+            # check string before evaluation for security
+            string = string.replace(self.unit, '')
+            if match := re.search(r'[^0-9.e+\-*/() ]', string):
+                raise ValueError("Characters not allowed: " + match.group())
+            value = float(eval(string))
+
+        return scale * value
+
+    def _apply(self, value=None):
+        if value is None:
+            value = self.edit.text()
+
+        if isinstance(value, str):
+            # parse string
+            value = value.strip()
+            try:
+                if value == "":
+                    value = self.value
+                else:
+                    value = self._parse(value)
+            except Exception as e:
+                self._set_editing(valid=False)
+                return
+
+        # apply limits
+        if self.value_min is not None:
+            value = max(self.value_min, value)
+        if self.value_max is not None:
+            value = min(self.value_max, value)
+
+        # apply precision
+        value = float(f"{value:.{self.precision}g}")
+
+        # call callback if it changed
+        if value != self.value:
+            self.value = value
+            self.callback(value)
+
+        # set text to reflect actual value
+        self.set_value(self.value)


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The numeric entry widget combines the useful features of Range and Entry widgets and adds support for unit handling, numeric expressions in any common format and lower/upper bounds.
    
Examples (unit Hz):

    "0.1" -> 0.1 Hz
    "1e3" -> 1000 Hz
    "5*2-3" -> 7 Hz
    "8 kHz" -> 8000 Hz
    "30m" -> 0.03 Hz
    
When the entry is focussed, the user can use the UP/DOWN keys to in-/decrement the value by the specified increment, and the PageUp/PageDown for ten times the increment.
    
The label color is used to indicate the status:
blue = editing but value not yet applied
red = invalid input
black = value applied
    
If the variable is changed from some other place in the flowgraph via the top block's "set_xxx()" callback, or if one of the boundaries (min/max value) changes, this is reflected on the UI
    
The precision defines the maximum decimal places to consider.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
none

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
new block in gr-qtgui

![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/d5eb245d-7c90-4c9e-9dd2-6cfc70fdd6ed)

![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/d9266d1b-b585-46d1-887e-27190a3be791)


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

In my own OOT. Added an example flow graph to this PR: `gr-qtgui/examples/qtgui_numeric_entry.grc`

![qtgui_numeric_entry](https://github.com/gnuradio/gnuradio/assets/19860638/16668d31-6e9d-46f0-963c-de22a02c0458)



## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
