### PR TITLE
make grc use correct config paths

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2009 Free Software Foundation, Inc.
+ * Copyright 2024 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -33,6 +34,7 @@ int main(int argc, char** argv)
         "sysconfdir", "print GNU Radio system configuration directory")(
         "prefsdir", "print GNU Radio preferences directory")(
         "userprefsdir", "print GNU Radio user preferences directory")(
+        "persistentdir", "print GNU Radio persistent state directory")(
         "prefs", "print GNU Radio preferences")(
         "builddate", "print GNU Radio build date (RFC2822 format)")(
         "enabled-components", "print GNU Radio build time enabled components")(
@@ -69,6 +71,9 @@ int main(int argc, char** argv)
 
     if (vm.count("userprefsdir") || print_all)
         std::cout << gr::paths::userconf().string() << std::endl;
+
+    if (vm.count("persistentdir") || print_all)
+        std::cout << gr::paths::persistent().string() << std::endl;
 
     // Not included in print all due to verbosity
     if (vm.count("prefs"))

--- a/gnuradio-runtime/include/gnuradio/sys_paths.h
+++ b/gnuradio-runtime/include/gnuradio/sys_paths.h
@@ -43,9 +43,8 @@ GR_RUNTIME_API std::filesystem::path cache();
 /*! \brief directory to store persistent application state (e.g. window layouts, generated
  *          GRC hier blocks)
  */
-/*
+
 GR_RUNTIME_API std::filesystem::path persistent();
-*/
 } /* namespace  paths */
 
 //! directory to create temporary files

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -10,7 +10,6 @@
 
 #include <gnuradio/sys_paths.h>
 #include <type_traits>
-#include <algorithm>
 #include <cstdlib> //getenv
 #include <filesystem>
 
@@ -89,6 +88,18 @@ std::filesystem::path cache()
     }
     path = getenv("XDG_CACHE_HOME");
     return (path ? fs::path{ path } : appdata() / ".cache") / "gnuradio";
+}
+
+std::filesystem::path persistent()
+{
+    namespace fs = std::filesystem;
+    // explicit env variable always wins
+    const char* path = getenv("GR_STATE_PATH");
+    if (path) {
+        return { path };
+    }
+    path = getenv("XDG_STATE_HOME");
+    return (path ? fs::path{ path } : appdata() / ".local" / "state") / "gnuradio";
 }
 } // namespace paths
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/sys_paths_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/sys_paths_python.cc
@@ -44,6 +44,7 @@ void bind_sys_paths(py::module& m)
     paths.def("appdata", []() { return gr::paths::appdata().u8string(); });
     paths.def("userconf", []() { return gr::paths::userconf().u8string(); });
     paths.def("cache", []() { return gr::paths::cache().u8string(); });
+    paths.def("persistent", []() { return gr::paths::persistent().u8string(); });
 
     // Legacy interfaces, deprecated
     m.def(

--- a/gnuradio-runtime/python/gnuradio/gr/qa_sys_paths.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_sys_paths.py
@@ -38,6 +38,7 @@ class test_prefs (gr_unittest.TestCase):
         self.assertTrue(gr.paths.tmp())
         self.assertTrue(gr.paths.appdata())
         self.assertTrue(gr.paths.userconf())
+        self.assertTrue(gr.paths.persistent())
 
     def test_002_react_to_GR_PREFS_PATH(self):
         self._test_env("GR_PREFS_PATH")

--- a/grc/converter/main.py
+++ b/grc/converter/main.py
@@ -10,6 +10,8 @@ import json
 import logging
 import os
 
+from ..main import get_state_directory
+from ..core import Constants
 from . import block_tree, block
 
 path = os.path
@@ -18,6 +20,7 @@ logger = logging.getLogger(__name__)
 excludes = [
     'qtgui_',
     '.grc_gnuradio/',
+    os.path.join(get_state_directory(), Constants.GRC_SUBDIR),
     'blks2',
     'wxgui',
     'epy_block.xml',
@@ -31,7 +34,7 @@ excludes = [
 
 class Converter(object):
 
-    def __init__(self, search_path, output_dir='~/.cache/grc_gnuradio'):
+    def __init__(self, search_path: str, output_dir: str = os.path.join(get_state_directory(), Constants.GRC_SUBDIR)):
         self.search_path = search_path
         self.output_dir = os.path.expanduser(output_dir)
         logger.info("Saving converted files to {}".format(self.output_dir))

--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -9,6 +9,7 @@ import os
 from os.path import expanduser, normpath, expandvars, exists
 from collections import OrderedDict
 
+from ..main import get_state_directory, get_config_file_path
 from . import Constants
 
 
@@ -17,8 +18,7 @@ class Config(object):
     license = __doc__.strip()
     website = 'https://www.gnuradio.org/'
 
-    hier_block_lib_dir = os.environ.get(
-        'GRC_HIER_PATH', Constants.DEFAULT_HIER_BLOCK_LIB_DIR)
+    hier_block_lib_dir = os.environ.get('GRC_HIER_PATH', get_state_directory())
 
     def __init__(self, version, version_parts=None, name=None, prefs=None):
         self._gr_prefs = prefs if prefs else DummyPrefs()

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -19,11 +19,14 @@ import numpy
 DATA_DIR = os.path.dirname(__file__)
 BLOCK_DTD = os.path.join(DATA_DIR, 'block.dtd')
 DEFAULT_FLOW_GRAPH = os.path.join(DATA_DIR, 'default_flow_graph.grc')
-DEFAULT_HIER_BLOCK_LIB_DIR = os.path.expanduser('~/.grc_gnuradio')
 DEFAULT_FLOW_GRAPH_ID = 'default'
 
-CACHE_FILE = os.path.expanduser('~/.cache/grc_gnuradio/cache_v2.json')
-EXAMPLE_CACHE_FILE = os.path.expanduser('~/.cache/grc_gnuradio/example_cache.json')
+PROJECT_DEFAULT_DIR = 'gnuradio'
+GRC_SUBDIR = 'grc'
+CACHE_FILE_NAME = 'cache_v2.json'
+FALLBACK_CACHE_FILE = os.path.expanduser(f'~/.cache/{PROJECT_DEFAULT_DIR}/{GRC_SUBDIR}/{CACHE_FILE_NAME}')
+EXAMPLE_CACHE_FILE_NAME = 'example_cache.json'
+FALLBACK_EXAMPLE_CACHE_FILE = os.path.expanduser(f'~/.cache/{PROJECT_DEFAULT_DIR}/{GRC_SUBDIR}/{EXAMPLE_CACHE_FILE_NAME}')
 
 BLOCK_DESCRIPTION_FILE_FORMAT_VERSION = 1
 # File format versions:

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -95,7 +95,7 @@ class ${class_name}(gr.top_block, Qt.QWidget):
         self.top_grid_layout = Qt.QGridLayout()
         self.top_layout.addLayout(self.top_grid_layout)
 
-        self.settings = Qt.QSettings("GNU Radio", "${class_name}")
+        self.settings = Qt.QSettings("gnuradio/flowgraphs", "${class_name}")
 
         try:
             geometry = self.settings.value("geometry")

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -133,7 +133,12 @@ class Platform(Element):
         self.cpp_connection_templates.clear()
         self._block_categories.clear()
 
-        with Cache(Constants.CACHE_FILE, version=self.config.version) as cache:
+        try:
+            from gnuradio.gr import paths
+            cache_file = os.path.join(paths.cache(), Constants.GRC_SUBDIR, Constants.CACHE_FILE_NAME)
+        except ImportError:
+            cache_file = Constants.FALLBACK_CACHE_FILE
+        with Cache(cache_file, version=self.config.version) as cache:
             for file_path in self._iter_files_in_block_path(path):
 
                 if file_path.endswith('.block.yml'):

--- a/grc/grc.conf.in
+++ b/grc/grc.conf.in
@@ -1,6 +1,6 @@
 # This file contains system wide configuration data for GNU Radio.
 # You may override any setting on a per-user basis by editing
-# ~/.gnuradio/config.conf
+# ~/.config/gnuradio/grc.conf
 
 [grc]
 global_blocks_path = @blocksdir@

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -11,6 +11,7 @@ import sys
 import os
 import configparser
 
+from ..main import get_config_file_path
 from ..core.Config import Config as CoreConfig
 from . import Constants
 
@@ -28,7 +29,7 @@ class Config(CoreConfig):
     name = 'GNU Radio Companion'
 
     gui_prefs_file = os.environ.get(
-        'GRC_PREFS_PATH', os.path.expanduser('~/.gnuradio/grc.conf'))
+        'GRC_PREFS_PATH', os.path.join(get_config_file_path(), '/grc.conf'))
 
     def __init__(self, install_prefix, *args, **kwargs):
         CoreConfig.__init__(self, *args, **kwargs)

--- a/grc/gui_qt/Config.py
+++ b/grc/gui_qt/Config.py
@@ -3,6 +3,7 @@ from os.path import expanduser, normpath, expandvars, exists
 from collections import OrderedDict
 
 from ..core.Config import Config as CoreConfig
+from ..main import get_config_file_path
 from qtpy import QtCore
 
 
@@ -11,7 +12,7 @@ class Config(CoreConfig):
     name = 'GNU Radio Companion'
 
     gui_prefs_file = os.environ.get(
-        'GRC_QT_PREFS_PATH', os.path.expanduser('~/.gnuradio/grc_qt.conf'))
+        'GRC_QT_PREFS_PATH', os.path.join(get_config_file_path(), 'grc_qt.conf'))
 
     def __init__(self, install_prefix, *args, **kwargs):
         CoreConfig.__init__(self, *args, **kwargs)

--- a/grc/gui_qt/components/example_browser.py
+++ b/grc/gui_qt/components/example_browser.py
@@ -250,7 +250,12 @@ class ExampleBrowser(QWidget, base.Component):
     def find_examples(self, progress_callback, ext="grc"):
         """Iterate through the example flowgraph directories and parse them."""
         examples_dict = {}
-        with Cache(Constants.EXAMPLE_CACHE_FILE, log=False) as cache:
+        try:
+            from gnuradio.gr import paths
+            cache_file = os.path.join(paths.cache(), Constants.GRC_SUBDIR, Constants.EXAMPLE_CACHE_FILE_NAME)
+        except ImportError:
+            cache_file = Constants.FALLBACK_EXAMPLE_CACHE_FILE
+        with Cache(cache_file, log=False) as cache:
             for entry in self.platform.config.example_paths:
                 if entry == '':
                     log.info("Empty example path!")

--- a/grc/gui_qt/properties.py
+++ b/grc/gui_qt/properties.py
@@ -53,6 +53,7 @@ class Paths(object):
     TOP_BLOCK_FILE_MODE = HIER_BLOCK_FILE_MODE | stat.S_IXUSR | stat.S_IXGRP
 
     # Setup paths
+    # FIXME: this should use ..main.get_config_directory() and get_state_directory(), probably.
     '''
     HIER_BLOCKS_LIB_DIR = os.environ.get('GRC_HIER_PATH',
                                          os.path.expanduser('~/.grc_gnuradio'))

--- a/grc/main.py
+++ b/grc/main.py
@@ -187,9 +187,71 @@ def run_qt(args, log):
     sys.exit(app.run())
 
 
+def get_config_file_path(config_file: str = "grc.conf") -> str:
+    oldpath = os.path.join(os.path.expanduser("~/.gnuradio"), config_file)
+    try:
+        from gnuradio.gr import paths
+        newpath = os.path.join(paths.userconf(), config_file)
+        if os.path.exists(newpath):
+            return newpath
+        if os.path.exists(oldpath):
+            log.warn(f"Found specification for config path '{newpath}', but file does not exist. " +
+                     f"Old default config file path '{oldpath}' exists; using that. " +
+                     "Please consider moving configuration to new location.")
+            return oldpath
+        # Default to the correct path if both are configured.
+        # neither old, nor new path exist: create new path, return that
+        os.makedirs(newpath, exist_ok=True)
+        return newpath
+    except ImportError:
+        log.warn("Could not retrieve GNU Radio configuration directory from GNU Radio. Trying defaults.")
+        xdgconf = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+        xdgcand = os.path.join(xdgconf, config_file)
+        if os.path.exists(xdgcand):
+            return xdgcand
+        if os.path.exists(oldpath):
+            log.warn(f"Using legacy config path '{oldpath}'. Please consider moving configuration " +
+                     f"files to '{newpath}'.")
+            return oldpath
+        # neither old, nor new path exist: create new path, return that
+        os.makedirs(xdgcand, exist_ok=True)
+        return xdgcand
+
+
+def get_state_directory() -> str:
+    oldpath = os.path.expanduser("~/.gnuradio")
+    try:
+        from gnuradio.gr import paths
+        newpath = paths.persistent()
+        if os.path.exists(newpath):
+            return newpath
+        if os.path.exists(oldpath):
+            log.warn(f"Found specification for persistent state path '{newpath}', but file does not exist. " +
+                     f"Old default persistent state path '{oldpath}' exists; using that. " +
+                     "Please consider moving state to new location.")
+            return oldpath
+        # Default to the correct path if both are configured.
+        # neither old, nor new path exist: create new path, return that
+        os.makedirs(newpath, exist_ok=True)
+        return newpath
+    except (ImportError, NameError):
+        log.warn("Could not retrieve GNU Radio persistent state directory from GNU Radio. Trying defaults.")
+        xdgstate = os.getenv("XDG_STATE_HOME", os.path.expanduser("~/.local/state"))
+        xdgcand = os.path.join(xdgstate, "gnuradio")
+        if os.path.exists(xdgcand):
+            return xdgcand
+        if os.path.exists(oldpath):
+            log.warn(f"Using legacy state path '{oldpath}'. Please consider moving state " +
+                     f"files to '{newpath}'.")
+            return oldpath
+        # neither old, nor new path exist: create new path, return that
+        os.makedirs(xdgcand, exist_ok=True)
+        return xdgcand
+
+
 def main():
     grc_version_from_config = ""
-    grc_qt_config_file = os.path.expanduser('~/.gnuradio/grc_qt.conf')
+    grc_qt_config_file = get_config_file_path('grc_qt.conf')
     if os.path.isfile(grc_qt_config_file):
         try:
             from qtpy.QtCore import QSettings
@@ -227,7 +289,7 @@ def main():
     log.info("Starting GNU Radio Companion {} (Python {})".format(gr.version(), py_version))
 
     # File logging
-    log_file = os.path.expanduser('~') + "/.gnuradio/grc.log"
+    log_file = os.path.join(get_state_directory(), "grc.log")
     try:
         fileHandler = logging.FileHandler(log_file)
         file_msg_format = '%(asctime)s [%(levelname)s] %(message)s'


### PR DESCRIPTION
- **runtime/paths: add persistent() for persistent application data**
- **GRC: GR config & persistent state location instead of ~/.gnuradio || ~/.grc_gnuradio**

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

As discussed in [GRC Development](https://matrix.to/#/!BMFENoeifGOSJaeGco:gnuradio.org/$BblQe5QpHvTswR1Ypi42C1ZJ33i6xwfViBwH2KhBKkg?via=gnuradio.org&via=matrix.org&via=ei8fdb.org),
it would be the right thing if GRC configuration ends up in the same tree as
GNU Radio itself stores configuration. (And we're now doing `XDG_CONFIG_HOME`,
unless that doesn't exist, but the legacy `.gnuradio` does.)

Same for generated hier blocks: they should live in a standard persistent state
directory. And for caches from the example browser and block lib, use the
appropriate cache dir.

Luckily, GNU Radio offers these paths by now; `gr.paths` is your friend. Just
need to use them.

We're also including fallbacks, should importing that fail for whatever reason.
## Related Issues

Closes #7337

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

GRC Qt, GTK, converter

We add (no API breakage) a `persistent` getter to `sys_paths` and export it to python.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
