### PR TITLE
Fix issue with out of order creation of code for function probe #7360

### DIFF
--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -34,6 +34,8 @@ templates:
     make: |+
         def _${id}_probe():
           while True:
+            if self.initialized != True:
+              continue
             <% obj = 'self' + ('.' + block_id if block_id else '') %>
             val = ${obj}.${function_name}(${function_args})
             try:

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -221,6 +221,8 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         % endfor
         % endif
 
+        self.initialized = True
+
 ########################################################
 ## QT sink close method reimplementation
 ########################################################


### PR DESCRIPTION
## Description
I created a way for block to detect if class was initialized

## Related Issue
This fixes issue #7360 

## Which blocks/areas does this affect?
It affects Function Probe block and global template for generating flow graph in python

## Testing Done
I did not test it yet, since I am going to sleep, just wanted to do it so I do not forget it

## Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
