### PR TITLE
Python template startup event

### DIFF
--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -33,6 +33,7 @@ templates:
     var_make: self.${id} = ${id} = ${value}
     make: |+
         def _${id}_probe():
+          self.flowgraph_started.wait()
           while True:
             <% obj = 'self' + ('.' + block_id if block_id else '') %>
             val = ${obj}.${function_name}(${function_args})

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -161,6 +161,9 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
 
         self._lock = threading.RLock()
 % endif
+% if not generate_options.startswith('hb'):
+        self.flowgraph_started = threading.Event()
+% endif
 ########################################################
 ##Create Parameters
 ##  Set the parameter to a property of self.
@@ -335,6 +338,7 @@ def main(top_block_cls=${class_name}, options=None):
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
     % if flow_graph.get_option('run'):
     tb.start(${flow_graph.get_option('max_nouts') or ''})
+    tb.flowgraph_started.set()
     % endif
     ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}
     % if flow_graph.get_option('qt_qss_theme'):
@@ -367,6 +371,7 @@ def main(top_block_cls=${class_name}, options=None):
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
     try:
         tb.start()
+        tb.flowgraph_started.set()
         ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}
         bokehgui.utils.run_server(tb, sizing_mode = "${flow_graph.get_option('sizing_mode')}",  widget_placement =  ${flow_graph.get_option('placement')}, window_size =  ${flow_graph.get_option('window_size')})
     finally:
@@ -393,6 +398,7 @@ def main(top_block_cls=${class_name}, options=None):
 
     % if flow_graph.get_option('run_options') == 'prompt':
     tb.start(${ flow_graph.get_option('max_nouts') or '' })
+    tb.flowgraph_started.set()
     ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}
     % for m in monitors:
     % if m.params['en'].get_value() == 'True':
@@ -407,6 +413,7 @@ def main(top_block_cls=${class_name}, options=None):
     ## ${'snippets_main_after_stop(tb)' if snippets['main_after_stop'] else ''}
     % elif flow_graph.get_option('run_options') == 'run':
     tb.start(${flow_graph.get_option('max_nouts') or ''})
+    tb.flowgraph_started.set()
     ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}
     % for m in monitors:
     % if m.params['en'].get_value() == 'True':

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -163,8 +163,8 @@ class TopBlockGenerator(object):
             imports.append('import os')
             imports.append('import sys')
 
-        if fg.get_option('thread_safe_setters'):
-            imports.append('import threading')
+        # Used by thread_safe_setters and startup Event
+        imports.append('import threading')
 
         def is_duplicate(l):
             if (l.startswith('import') or l.startswith('from')) and l in seen:


### PR DESCRIPTION
## Description
Add a `self.flowgraph_started` event to the Python Mako code and set it after the top block `start()` is called. This lets anything else that should not run until after everything is initiazed wait on the event.

The code generator does not know that certain blocks (e.g., function probe) depend on other blocks, and especially their accessors, to be available at the time a block may start its own thread. This caused a race between access in a thread spawned by code from a yml template and existance of the `self.` object.

Change the Function Probe Python template code to wait on the event before accessing variables, in case they don't exist yet.

Supercedes #7361

## Related Issue
Fixes #7360

## Which blocks/areas does this affect?
GRC code generation, Function Probe

## Testing Done

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
