### PR TITLE
ci: conda: Build with VS2022 for Windows (backport to maint-3.10)

### DIFF
--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -1,11 +1,11 @@
 c_compiler:
-- vs2019
+- vs2022
 channel_sources:
 - conda-forge
 channel_targets:
 - gnuradio main
 cxx_compiler:
-- vs2019
+- vs2022
 fftw:
 - '3'
 gsl:

--- a/.conda/recipe/conda_build_config.yaml
+++ b/.conda/recipe/conda_build_config.yaml
@@ -1,2 +1,6 @@
 channel_targets:
   - gnuradio main
+c_compiler:    # [win]
+- vs2022       # [win]
+cxx_compiler:  # [win]
+- vs2022       # [win]


### PR DESCRIPTION
Backport #7363