### PR TITLE
grc-qt: AcceptSave mode for save dialog instead of AcceptOpen

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -1012,6 +1012,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         file_dialog.setWindowTitle(self.actions["save"].statusTip())
         file_dialog.setNameFilter('Flow Graph Files (*.grc)')
         file_dialog.setDefaultSuffix('grc')
+        file_dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
         filename = None
         if file_dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             filename = file_dialog.selectedFiles()[0]
@@ -1038,6 +1039,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         file_dialog.setWindowTitle(self.actions["save"].statusTip())
         file_dialog.setNameFilter('Flow Graph Files (*.grc)')
         file_dialog.setDefaultSuffix('grc')
+        file_dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
 
         filename = None
         if file_dialog.exec_() == QtWidgets.QFileDialog.Accepted:


### PR DESCRIPTION
## Description
QFileDialog defaults to an "open" dialog, which doesn't work for saving files (unless you want to overwrite an existing file). Change to use "save" mode for Save As and Save Copy dialogs.

## Which blocks/areas does this affect?
GRC-Qt

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
