### PR TITLE
grc-qt: Fix another KeyError in variable_editor

### DIFF
--- a/grc/gui_qt/components/variable_editor.py
+++ b/grc/gui_qt/components/variable_editor.py
@@ -162,9 +162,15 @@ class VariableEditor(QDockWidget, base.Component):
                     variable_.setForeground(0, colors.BLOCK_DISABLED_COLOR)
                     variable_.setForeground(1, colors.BLOCK_DISABLED_COLOR)
             else:
-                variable_.setText(1, block.params['value'].get_value())
-                # variable_.setText(1, '<Open Properties>')
                 variable_.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+                if block.enabled:
+                    variable_.setText(1, str(block.evaluate(block.value)))
+                    variable_.setForeground(0, colors.BLOCK_ENABLED_COLOR)
+                    variable_.setForeground(1, colors.BLOCK_ENABLED_COLOR)
+                else:
+                    variable_.setText(1, '<Open Properties>')
+                    variable_.setForeground(0, colors.BLOCK_DISABLED_COLOR)
+                    variable_.setForeground(1, colors.BLOCK_DISABLED_COLOR)
             variable_.setIcon(2, QtGui.QIcon.fromTheme("list-remove"))
 
         self.currently_rebuilding = False


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
There are two types of variable blocks:
-  with key == variable
-  with key != variable

At the moment some blocks with key != variable force a KeyError.

  File "/usr/local/gnuradio/lib64/python3.12/site-packages/gnuradio/grc/gui_qt/components/variable_editor.py", line 100, in set_scene
    self.update_gui(self.scene.core.blocks)
  File "/usr/local/gnuradio/lib64/python3.12/site-packages/gnuradio/grc/gui_qt/components/variable_editor.py", line 175, in update_gui
    self._rebuild()
  File "/usr/local/gnuradio/lib64/python3.12/site-packages/gnuradio/grc/gui_qt/components/variable_editor.py", line 165, in _rebuild
    variable_.setText(1, block.params['value'].get_value())
                         ~~~~~~~~~~~~^^^^^^^^^
KeyError: 'value'

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run grc --qt

Load the example example_corr_est_and_clock_sync.grc from digital/packet
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
