### PR TITLE
CI: disable EOL F38 build

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -76,11 +76,6 @@ jobs:
             cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             # ldpath:
-          - distro: 'Fedora 38'
-            containerid: 'gnuradio/ci:fedora-38-3.10'
-            cxxflags: -Werror
-            ctest_args: '-E ""'
-            ldpath: /usr/local/lib64/
           - distro: 'Fedora 39 (with 0xFE memory initialization, GLIBCXX_ASSERTIONS)'
             containerid: 'gnuradio/ci:fedora-39-3.10'
             cxxflags: -Werror -ftrivial-auto-var-init=pattern -Wp,-D_GLIBCXX_ASSERTIONS
@@ -92,11 +87,6 @@ jobs:
             cmakeflags: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64 
-          # - distro: 'CentOS 8.4'
-          #   containerid: 'gnuradio/ci:centos-8.4-3.10'
-          #   cxxflags: ''
-          #   ctest_args: '-E ""'
-          #   ldpath: /usr/local/lib64/
           - distro: 'Debian 12'
             containerid: 'gnuradio/ci:debian-12-3.10'
             cxxflags: -Werror


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Fedora 38 is end-of-life. We should be adding Ubuntu 24.04 LTS as CI platform, so this is a removal in order to free up Github CPU minutes for that platform.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

CI 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
