### PR TITLE
Draft: gr-blocks: Add variable save restore block

### DIFF
--- a/gr-blocks/examples/variable_save_restore.grc
+++ b/gr-blocks/examples/variable_save_restore.grc
@@ -1,0 +1,303 @@
+options:
+  parameters:
+    author: Philipp Niedermayer
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: variable_save_restore
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Varialbe Save Restore example
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: info
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    entry_signal: editingFinished
+    gui_hint: 101,0
+    label: Slot description
+    type: string
+    value: '?'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1016, 148.0]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: slot
+  id: variable_qtgui_chooser
+  parameters:
+    comment: ''
+    gui_hint: 100,0
+    label: Slot
+    label0: '1'
+    label1: '2'
+    label2: '3'
+    label3: TEST
+    label4: private
+    labels: '[]'
+    num_opts: '5'
+    option0: '1'
+    option1: '2'
+    option2: '3'
+    option3: TEST
+    option4: private
+    options: '[0, 1, 2]'
+    orient: Qt.QVBoxLayout
+    type: string
+    value: '1'
+    widget: combo_box
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [888, 204.0]
+    rotation: 0
+    state: true
+- name: variable_0
+  id: variable
+  parameters:
+    comment: ''
+    value: '456'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [440, 88.0]
+    rotation: 0
+    state: true
+- name: variable_check_0
+  id: variable_qtgui_check_box
+  parameters:
+    comment: ''
+    'false': 'False'
+    gui_hint: ''
+    label: Check
+    'true': 'True'
+    type: bool
+    value: 'True'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [568, 356.0]
+    rotation: 0
+    state: true
+- name: variable_chooser_0
+  id: variable_qtgui_chooser
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Choice
+    label0: A
+    label1: B
+    label2: C
+    label3: ''
+    label4: ''
+    labels: '[]'
+    num_opts: '3'
+    option0: '0'
+    option1: '1'
+    option2: '2'
+    option3: '3'
+    option4: '4'
+    options: '[0, 1, 2]'
+    orient: Qt.QVBoxLayout
+    type: int
+    value: '0'
+    widget: combo_box
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [416, 356.0]
+    rotation: 0
+    state: true
+- name: variable_entry_0
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    entry_signal: editingFinished
+    gui_hint: ''
+    label: 'Raw:'
+    type: raw
+    value: samp_rate
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [584, 92.0]
+    rotation: 0
+    state: true
+- name: variable_entry_1
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    entry_signal: editingFinished
+    gui_hint: ''
+    label: Float
+    type: real
+    value: '3.1415'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [584, 172.0]
+    rotation: 0
+    state: true
+- name: variable_entry_2
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    entry_signal: editingFinished
+    gui_hint: ''
+    label: String
+    type: string
+    value: hello
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [584, 252.0]
+    rotation: 0
+    state: true
+- name: variable_qtgui_label_0
+  id: variable_qtgui_label
+  parameters:
+    comment: ''
+    formatter: None
+    gui_hint: ''
+    label: 'Value of variable_0:'
+    type: real
+    value: variable_0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [392, 164.0]
+    rotation: 0
+    state: true
+- name: variable_qtgui_label_0_0
+  id: variable_qtgui_label
+  parameters:
+    comment: ''
+    formatter: None
+    gui_hint: ''
+    label: 'Double of variable_1:'
+    type: real
+    value: 2*variable_entry_1
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [384, 252.0]
+    rotation: 0
+    state: true
+- name: variable_save_restore_1
+  id: variable_save_restore
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    description_variable: '"info"'
+    restore_trigger: '"variable_to_trigger_restore"'
+    save_trigger: '"variable_to_trigger_save"'
+    show_msg_ports: 'Yes'
+    slot: slot
+    variables: '"""
+
+      samp_rate,variable_0,variable_entry_0,variable_entry_1,
+
+      variable_entry_2,
+
+      variable_chooser_0,variable_check_0,
+
+      """'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1376, 264.0]
+    rotation: 0
+    state: true
+- name: restore
+  id: variable_qtgui_msg_push_button
+  parameters:
+    comment: ''
+    gui_hint: 103,0
+    label: Restore
+    msgName: pressed
+    relBackgroundColor: default
+    relFontColor: default
+    type: int
+    value: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1016, 332.0]
+    rotation: 0
+    state: true
+- name: save
+  id: variable_qtgui_msg_push_button
+  parameters:
+    comment: ''
+    gui_hint: 102,0
+    label: Save
+    msgName: pressed
+    relBackgroundColor: default
+    relFontColor: default
+    type: int
+    value: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1016, 236.0]
+    rotation: 0
+    state: true
+
+connections:
+- [restore, pressed, variable_save_restore_1, restore]
+- [save, pressed, variable_save_restore_1, save]
+
+metadata:
+  file_format: 1
+  grc_version: 3.10.8.0

--- a/gr-blocks/grc/blocks.tree.yml
+++ b/gr-blocks/grc/blocks.tree.yml
@@ -173,3 +173,4 @@
   - blocks_vco_c
 - Variables:
   - variable_tag_object
+  - variable_save_restore

--- a/gr-blocks/grc/blocks_variable_save_restore.block.yml
+++ b/gr-blocks/grc/blocks_variable_save_restore.block.yml
@@ -1,0 +1,86 @@
+id: variable_save_restore
+label: Variable Save Restore
+
+documentation: |-
+    Block to save and restore variable values
+    
+    Values are saved to ~/.config/gnuradio/FLOWGRAPH.variables.sav (replace FLOWGRAPH with actual flowgraph name).
+    
+    Slot is a string that can be used to save multiple sets of values, e.g. to quickly switch between configurations.
+    
+    Variables is a list or comma-separated string of flowgraph variable names to save and restore. Variables inside hier blocks can be addressed as "hier_block_id.variable_id".
+
+    Slot descr. var. is optionally the name of a special string variable which serves as editable label for the slot. It's value will be kept in sync with the selected slot *even before* variable values are restored. Use the name of a QT GUI Entry widget string variable here.   
+    
+    Saving and restoring can either be triggered by messages on the respective ports (message content is ignored), or by a dedicated variable on positive flank (e.g. if the value changes from 0 -> 1 or False -> True).
+    
+    For GUI values it is strongly recommended to use the following widgets, which will reflect an update of the value on the display:
+    - QT GUI Entry
+    - QT GUI Chooser
+    - QT GUI Check Box
+    
+    
+
+templates:
+  imports: from gnuradio import blocks
+  make: blocks.saveRestoreVariables(self, ${slot}, ${variables}, ${save_trigger}, ${restore_trigger}, ${description_variable})
+  callbacks:
+  - set_slot(${slot})
+  - set_variables(${variables})
+  - set_save_trigger(${save_trigger})
+  - set_restore_trigger(${restore_trigger})
+  
+
+parameters:
+- id: slot
+  label: Slot
+  dtype: string
+  default: "default"
+- id: description_variable
+  label: Slot descr. var.
+  dtype: raw
+  default: '""'
+- id: variables
+  label: Variables
+  dtype: _multiline
+  default: |
+    """
+    samp_rate,variable_1,
+    other_variable,
+    hier_block_1.my_var_0
+    """
+- id: show_msg_ports
+  label: Show msg ports
+  dtype: enum
+  default: "Yes"
+  options: ["Yes", "No"]
+  option_attributes:
+      show: [True, False]
+  hide: 'part'
+- id: save_trigger
+  label: Save trg
+  dtype: raw
+  default: '"variable_to_trigger_save"'
+  hide: ${'all' if show_msg_ports.show else 'part'}
+- id: restore_trigger
+  label: Restore trg
+  dtype: raw
+  default: '"variable_to_trigger_restore"'
+  hide: ${'all' if show_msg_ports.show else 'part'}
+
+inputs:
+- label: save
+  domain: message
+  id: save
+  optional: true
+  hide: ${not show_msg_ports.show}
+- label: restore
+  domain: message
+  id: restore
+  optional: true
+  hide: ${not show_msg_ports.show}
+
+
+#  'file_format' specifies the version of the GRC yml format used in the file
+#  and should usually not be changed.
+file_format: 1

--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -17,6 +17,7 @@ gr_python_install(
           msg_pair_to_var.py
           msg_meta_to_pair.py
           var_to_msg.py
+          variable_save_restore.py
           pdu_compatibility.py # REMOVE IN 3.11
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/blocks)
 

--- a/gr-blocks/python/blocks/__init__.py
+++ b/gr-blocks/python/blocks/__init__.py
@@ -26,6 +26,7 @@ from .stream_to_vector_decimator import *
 from .msg_meta_to_pair import meta_to_pair
 from .msg_pair_to_var import msg_pair_to_var
 from .var_to_msg import var_to_msg_pair
+from .variable_save_restore import variable_save_restore
 from .matrix_interleaver import *
 from .parse_file_metadata import parse_header, parse_extra_dict
 

--- a/gr-blocks/python/blocks/variable_save_restore.py
+++ b/gr-blocks/python/blocks/variable_save_restore.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2023 Philipp Niedermayer.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+
+import numpy
+from gnuradio import gr
+import pickle
+import pmt
+import os
+
+
+class variable_save_restore(gr.sync_block):
+    """
+    (see description in this blocks yml file)
+    """
+
+    def __init__(self, top_block=None, slot="default", variables="", save_trigger=False, restore_trigger=False, description_variable=None):
+        gr.sync_block.__init__(self, name="variable_save_restore", in_sig=[], out_sig=None)
+        self.message_port_register_in(pmt.intern("save"))
+        self.set_msg_handler(pmt.intern("save"), self.handle_msg_save)
+        self.message_port_register_in(pmt.intern("restore"))
+        self.set_msg_handler(pmt.intern("restore"), self.handle_msg_restore)
+
+        self.filename = f"~/.config/gnuradio/{top_block.__class__.__name__}.variables.sav"
+        self.filename = os.path.expanduser(self.filename)
+        print(f"[VariableSaveRestore] Config file: {self.filename}")
+        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
+        self.load_storage()
+
+        self.top_block = top_block
+        self.description_variable = description_variable
+        self.set_slot(slot)
+        self.set_variables(variables)
+        self.save_trigger = save_trigger
+        self.restore_trigger = restore_trigger
+
+    def set_slot(self, slot):
+        self.slot = slot
+        if self.description_variable:
+            data = self.storage.get(self.slot, {})
+            info = data.get(self.description_variable, "")
+            self.set_variable_values({self.description_variable: info})
+
+    def set_variables(self, variables):
+        if isinstance(variables, str):
+            variables = [v.strip() for v in variables.split(",") if v.strip()]
+        self.variables = variables
+        if self.description_variable:
+            self.variables.append(self.description_variable)
+
+    def set_save_trigger(self, save_trigger):
+        if save_trigger and not self.save_trigger:
+            self.save()
+        self.save_trigger = save_trigger
+
+    def set_restore_trigger(self, restore_trigger):
+        if restore_trigger and not self.restore_trigger:
+            self.restore()
+        self.restore_trigger = restore_trigger
+
+    def handle_msg_save(self, msg):
+        self.save()
+
+    def handle_msg_restore(self, msg):
+        self.restore()
+
+    def get_variable_values(self):
+        """Get values of variables using top-glock getters"""
+        data = {}
+        for name in self.variables:
+            try:
+                data[name] = self._get_variable(self.top_block, name)
+            except AttributeError as e:
+                print("AttributeError:", e)
+                print(f"ERROR: Failed to get variable `{name}`")
+
+        return data
+
+    def _get_variable(self, block, name):
+        if "." in name:
+            subblock, name = name.split(".", maxsplit=1)
+            return self._get_variable(getattr(block, subblock), name)
+        return getattr(block, f"get_{name}")()
+
+    def set_variable_values(self, data, verbose=False):
+        """Set values of variables using top-glock setters"""
+        n = 0
+        for name, val in data.items():
+            if verbose:
+                print(f"{name:20s}    {val}")
+            try:
+                self._set_variable(self.top_block, name, val)
+                n += 1
+            except AttributeError as e:
+                print("AttributeError:", e)
+                print(f"ERROR: Failed to set variable `{name}` to `{val}`")
+        return n
+
+    def _set_variable(self, block, name, val):
+        if "." in name:
+            subblock, name = name.split(".", maxsplit=1)
+            return self._set_variable(getattr(block, subblock), name, val)
+        setter = getattr(block, f"set_{name}")
+        setter(val)
+
+    def save(self):
+        data = self.get_variable_values()
+        self.storage[self.slot] = data
+        try:
+            self.save_storage()
+        except Exception as e:
+            print("Exception:", e)
+            print(f"[VariableSaveRestore] Failed to save variables to slot {self.slot}")
+        else:
+            print(f"[VariableSaveRestore] Saved {len(data)} of {len(self.variables)} variables to slot {self.slot}")
+
+    def restore(self):
+        data = self.storage.get(self.slot, {})
+        data = {k: v for k, v in data.items() if k in self.variables}
+        n = self.set_variable_values(data)
+        print(f"[VariableSaveRestore] Restored {n} of {len(self.variables)} variables from slot {self.slot}")
+
+    def load_storage(self):
+        """Load from disk into memory"""
+        if os.path.exists(self.filename):
+            with open(self.filename, 'rb') as handle:
+                self.storage = pickle.load(handle)
+        else:
+            self.storage = {}
+
+    def save_storage(self):
+        """Save from memory to disk"""
+        with open(self.filename, 'wb') as handle:
+            pickle.dump(self.storage, handle)
+
+    def work(self, input_items, output_items):
+        print("You shall not work!")
+        return 0


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->


## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->


Allows saving multiple variables and restoring their values at a later point. Multiple slots are available to support different sets of values in parallel.

Useful to save the UI state or to quickly switch between different configurations.

Preferably to be used with variables from the following widgets, which reflect value changes on the UI:
- QT GUI Entry
- QT GUI Numeric Entry (#7349)
- QT GUI Chooser
- QT GUI Check Box



Related to the *Variable Config* block, however it is different because *Variable Config* actually creates a (single) variable, so it cannot be a GUI widget variable at the same time and thus not save/restore UI states.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
none

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
adds a new block to gr-blocks (categorized under "Variables")

![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/a7d142b0-92f5-45b2-a742-972885983d32)

![grafik](https://github.com/gnuradio/gnuradio/assets/19860638/d5df9c2b-5503-4a8a-b865-ac0396bb86c5)

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

In my own OOT. Added an example flow graph to this PR

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
