### PR TITLE
gr-uhd: Do not require PyQt5 for all python functionality

### DIFF
--- a/gr-uhd/CMakeLists.txt
+++ b/gr-uhd/CMakeLists.txt
@@ -17,6 +17,8 @@ else()
     set(UHD_FOUR_POINT_OH_RFNOC FALSE)
 endif()
 
+gr_python_check_module("PyQt5" PyQt5 True PYQT5_FOUND)
+
 ########################################################################
 # Register component
 ########################################################################

--- a/gr-uhd/examples/grc/CMakeLists.txt
+++ b/gr-uhd/examples/grc/CMakeLists.txt
@@ -16,7 +16,6 @@ install(
           rfnoc_null_source_sink.grc
           rfnoc_radio_ddc.grc
           rfnoc_radio_ddc_multichan.grc
-          rfnoc_replay.grc
           rfnoc_siggen.grc
           rfnoc_split_stream.grc
           rfnoc_switchboard.grc
@@ -30,3 +29,7 @@ install(
           uhd_two_tone_loopback.grc
           uhd_wbfm_receive.grc
     DESTINATION ${GR_PKG_UHD_EXAMPLES_DIR})
+
+if(PYQT5_FOUND)
+      install(FILES rfnoc_replay.grc DESTINATION ${GR_PKG_UHD_EXAMPLES_DIR})
+endif(PYQT5_FOUND)

--- a/gr-uhd/grc/CMakeLists.txt
+++ b/gr-uhd/grc/CMakeLists.txt
@@ -51,7 +51,6 @@ if(ENABLE_UHD_RFNOC)
               uhd_fpga_radio.block.yml
               uhd_fpga_sep.block.yml
               uhd_fpga_x310.block.yml
-              uhd_msgpushbutton.block.yml
               uhd_rfnoc_addsub.block.yml
               uhd_rfnoc_fft.block.yml
               uhd_rfnoc_fosphor.block.yml
@@ -66,4 +65,7 @@ if(ENABLE_UHD_RFNOC)
               uhd_rfnoc_tx_streamer.block.yml
               uhd_rfnoc_vector_iir.block.yml
         DESTINATION ${GRC_BLOCKS_DIR})
+    if(PYQT5_FOUND)
+        install (FILES uhd_msgpushbutton.block.yml DESTINATION ${GRC_BLOCKS_DIR})
+    endif(PYQT5_FOUND)
 endif(ENABLE_UHD_RFNOC)

--- a/gr-uhd/python/uhd/CMakeLists.txt
+++ b/gr-uhd/python/uhd/CMakeLists.txt
@@ -10,7 +10,11 @@
 ########################################################################
 include(GrPython)
 
-gr_python_install(FILES __init__.py replaymsgpushbutton.py DESTINATION ${GR_PYTHON_DIR}/gnuradio/uhd)
+gr_python_install(FILES __init__.py DESTINATION ${GR_PYTHON_DIR}/gnuradio/uhd)
+
+if(PYQT5_FOUND)
+    gr_python_install(FILES replaymsgpushbutton.py DESTINATION ${GR_PYTHON_DIR}/gnuradio/uhd)
+endif(PYQT5_FOUND)
 
 ########################################################################
 # Handle the unit tests

--- a/gr-uhd/python/uhd/__init__.py
+++ b/gr-uhd/python/uhd/__init__.py
@@ -80,4 +80,11 @@ def _prepare_uhd_python():
 _prepare_uhd_python()
 
 from .uhd_python import *
-from .replaymsgpushbutton import ReplayMsgPushButton
+
+try:
+    from .replaymsgpushbutton import ReplayMsgPushButton
+except ModuleNotFoundError:
+    # This Button uses PyQt5 and is only used in GUI applications that use the replay block;
+    # the rest of gr-uhd python functionality should not be limited by PyQt5 being installed,
+    # so ignore if the module is not found
+    pass


### PR DESCRIPTION
The push-button helper for the replay block uses PyQt5, however using gr-uhd in python as a whole should not be gated by PyQt5 being installed.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
During some recent development, we ran into an error requiring PyQt5 being installed because the added replay block message button helper now added in an import for PyQt5, however everything else in gr-uhd doesn't require this python module.

To work around this, I added a try-except to ignore the module import error. Then I also removed the installation of the replay block message button related items in the cmake files, so that a user doesn't see functionality that they cannot use.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
gr-uhd

## Testing Done
Testing importing gnuradio.uhd no longer errors if PyQt5 is not installed, and checked that the related items are not installed (i.e. .py file, grc example, block not available in UHD->RFNoC tree in GRC). Then installed PyQt5 module, re-built and confirmed functionality by running the previously uninstall replay block GRC example.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
