### PR TITLE
modtool/bind: GCC12/13 on Ubuntu needs a flag for binding

### DIFF
--- a/gr-utils/blocktool/core/parseheader.py
+++ b/gr-utils/blocktool/core/parseheader.py
@@ -101,7 +101,9 @@ class BlockHeaderParser(BlockTool):
             include_paths=self.include_paths,
             compiler='gcc',
             define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC'],
-            cflags='-std=c++11')
+            # See the comment parseheader_generic: -fsized-deallocation
+            # helps what seems to be a compiler bug (?).
+            cflags='-std=c++17 -fPIC -fsized-deallocation')
         decls = parser.parse(
             [self.target_file], xml_generator_config)
         global_namespace = declarations.get_global_namespace(decls)

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -48,7 +48,7 @@ class GenericHeaderParser(BlockTool):
         self.parsed_data = {}
         self.addcomments = blocktool_comments
         self.define_symbols = ('BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC', 'DISABLE_LOGGER_H')
-        if (define_symbols):
+        if define_symbols:
             self.define_symbols += define_symbols
         self.include_paths = None
         if (include_paths):

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -48,7 +48,7 @@ class GenericHeaderParser(BlockTool):
         self.parsed_data = {}
         self.addcomments = blocktool_comments
         self.define_symbols = ('BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC', 'DISABLE_LOGGER_H')
-        if(define_symbols):
+        if (define_symbols):
             self.define_symbols += define_symbols
         self.include_paths = None
         if (include_paths):
@@ -318,10 +318,17 @@ class GenericHeaderParser(BlockTool):
                 xml_generator_path=generator_path,
                 xml_generator=generator_name,
                 include_paths=self.include_paths,
-                compiler='gcc',
+                compiler='g++',
                 undefine_symbols=['__PIE__'],
                 define_symbols=self.define_symbols,
-                cflags='-std=c++17 -fPIC')
+                # There seems to be a bug where on some platforms, GCC fails because it finds the
+                # _GLIBCXX_OPERATOR_DELETE and considers it a "non-usual deallocation function".
+                # Even if that is inherent to C++17. Anyways, in
+                # https://github.com/gnuradio/gnuradio/issues/6477 user boatbod convinces us that
+                # adding -fsized_deallocations helps this. Neither we nor the GCC mailing lists
+                # are perfectly sure why that is, but it does help. Since this is just for binding,
+                # none of the thus-generated code ends up anywhere, so here we go:
+                cflags='-std=c++17 -fPIC -fsized-deallocation')
             decls = parser.parse(
                 [self.target_file], xml_generator_config,
                 compilation_mode=parser.COMPILATION_MODE.ALL_AT_ONCE)


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

There seems to be a bug where on some platforms, GCC fails because it finds the
_GLIBCXX_OPERATOR_DELETE and considers it a "non-usual deallocation function".
Even if that is inherent to C++17. Anyways, in
https://github.com/gnuradio/gnuradio/issues/6477 user boatbod convinces us that
adding -fsized_deallocations helps this. Neither we nor the GCC mailing lists
are perfectly sure why that is, but it does help. Since this is just for binding,
none of the thus-generated code ends up anywhere, which reduces the
headaches of introducing any random compiler flags.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Closes #6477

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

binding only, as these flags are *only* used for that and nowhere in our actual chain

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

none, as we're currently not set up for running such tests (other PRs need to go first)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
