### PR TITLE
Remove the filename from os.makedirs(newpath) in get_config_file_path

### DIFF
--- a/grc/main.py
+++ b/grc/main.py
@@ -14,6 +14,7 @@ import logging.handlers
 import os
 import platform
 import sys
+from pathlib import Path
 
 
 VERSION_AND_DISCLAIMER_TEMPLATE = """\
@@ -201,7 +202,9 @@ def get_config_file_path(config_file: str = "grc.conf") -> str:
             return oldpath
         # Default to the correct path if both are configured.
         # neither old, nor new path exist: create new path, return that
-        os.makedirs(newpath, exist_ok=True)
+        path_parts = Path(newpath).parts[:-1]
+        pathdir = os.path.join(*path_parts)
+        os.makedirs(pathdir, exist_ok=True)
         return newpath
     except ImportError:
         log.warn("Could not retrieve GNU Radio configuration directory from GNU Radio. Trying defaults.")
@@ -214,7 +217,9 @@ def get_config_file_path(config_file: str = "grc.conf") -> str:
                      f"files to '{newpath}'.")
             return oldpath
         # neither old, nor new path exist: create new path, return that
-        os.makedirs(xdgcand, exist_ok=True)
+        path_parts = Path(xdgcand).parts[:-1]
+        pathdir = os.path.join(*path_parts)
+        os.makedirs(pathdir, exist_ok=True)
         return xdgcand
 
 


### PR DESCRIPTION
We want to make a directory to to contain the file grc.conf, newpath is the full pathname with the file included.  Make the directory without using newpath as it creates the directory $HOME/.config/gnuradio/grc.conf.

This pr contains a proposed small change for #7350.

Signed-off-by: Chris Gorman <chrisjohgorman@gmail.com>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
When gnuradio-companion is run, it attempts to create the directory $HOME/.config/gnuradio/grc.conf.  There is no problem with this if the file is currently in place, but if there is no file in place it creates the directory and gnuradio can't source grc.conf.  This change fixes the problem and only creates the directory $HOME/.config/gnuradio if it doesn't exist.  There may be a further need to do this for the other case in get_config_file_path. 

```
    except ImportError:
        log.warn("Could not retrieve GNU Radio configuration directory from GNU Radio. Trying defaults.")
        xdgconf = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
        xdgcand = os.path.join(xdgconf, config_file)
        if os.path.exists(xdgcand):
            return xdgcand
        if os.path.exists(oldpath):
            log.warn(f"Using legacy config path '{oldpath}'. Please consider moving configuration " +
                     f"files to '{newpath}'.")
            return oldpath
        # neither old, nor new path exist: create new path, return that
        os.makedirs(xdgcand, exist_ok=True)
        return xdgcand
```
I didn't test the second case or the get_state_directory function as I couldn't figure out how to set them up in windows.  

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
I tested the changes stepping through code with pdb
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
