### PR TITLE
fec: Add encode and decode functions to generic encoder bindings

### DIFF
--- a/gr-fec/python/fec/bindings/generic_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/generic_decoder_python.cc
@@ -18,6 +18,7 @@
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -107,6 +108,25 @@ void bind_generic_decoder(py::module& m)
         .def("get_iterations",
              &generic_decoder::get_iterations,
              D(generic_decoder, get_iterations))
+
+        .def("decode",
+             [](generic_decoder& self,
+                const py::array_t<float, py::array::c_style | py::array::forcecast>&
+                    array) {
+                 py::buffer_info inb = array.request();
+                 if (inb.ndim != 1) {
+                     throw std::runtime_error("Only ONE-dimensional vectors allowed!");
+                 }
+                 if (inb.size != self.get_input_size()) {
+                     throw std::runtime_error("Input vector size != input_size!");
+                 }
+                 auto result = py::array_t<unsigned char>(self.get_output_size());
+                 py::buffer_info resb = result.request();
+
+                 self.generic_work((const unsigned char*)inb.ptr,
+                                   (unsigned char*)resb.ptr);
+                 return result;
+             })
 
         ;
 


### PR DESCRIPTION
This allows to use all FEC encoders and decoders by just creating corresponding encoder and decoder objects in Python and without creating a flowgraph


## Description
Adds additional methods to the Python class, to call the generic_work functions with numpy buffers. 

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
fec/generic_encoder fec/generic_decoder

## Testing Done
I'd like to add some test, but first I'd like to see the opinion on having this kind of change in-tree.

## Checklist


- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
