### PR TITLE
cmake: Bump minimum required CMake version to what is specified (backport to maint-3.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_BUILD_TYPE
 ########################################################################
 # Make sure this version matches ${GR_CMAKE_MIN_VERSION} (a variable can't be
 # used here).
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(gnuradio CXX C)
 enable_testing()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)

--- a/cmake/Modules/GrMinReq.cmake
+++ b/cmake/Modules/GrMinReq.cmake
@@ -11,7 +11,9 @@ endif()
 set(__INCLUDED_GR_MIN_REQ_CMAKE TRUE)
 # Minimum dependency versions for central dependencies:
 set(GR_BOOST_MIN_VERSION "1.69") ## Version in CentOS 8 (EPEL)
-set(GR_CMAKE_MIN_VERSION "3.16.3") ## Version in Ubuntu 20.04LTS
+# !!!WHEN CHANGING MINIMUM CMAKE VERSION!!!
+# ADJUST MAIN CMakeLists.txt OF PROJECT, gr-newmod AND THE GRC C++ TEMPLATE
+set(GR_CMAKE_MIN_VERSION "3.16.3") ## Version in Ubuntu 20.04LTS 
 set(GR_MAKO_MIN_VERSION "1.1.0") ## Version in Ubuntu 20.04LTS
 set(GR_PYTHON_MIN_VERSION "3.7.2") ## 3.7 is already EOL, but was 3.6.5
 set(GR_PYGCCXML_MIN_VERSION "2.0.0") ## Version to support c++17 (in pip)

--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_BUILD_TYPE
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(gr-howto CXX C)
 enable_testing()
 

--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -17,7 +17,7 @@ version_list = config.version_parts
 short_version = '.'.join(version_list[0:2])
 %>\
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 14)
 
 project(${class_name})


### PR DESCRIPTION
Backport #7389