### PR TITLE
gui_prefs_file does not need to use os.path.join

### DIFF
--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -28,8 +28,7 @@ class Config(CoreConfig):
 
     name = 'GNU Radio Companion'
 
-    gui_prefs_file = os.environ.get(
-        'GRC_PREFS_PATH', os.path.join(get_config_file_path(), 'grc.conf'))
+    gui_prefs_file = os.environ.get('GRC_PREFS_PATH', get_config_file_path())
 
     def __init__(self, install_prefix, *args, **kwargs):
         CoreConfig.__init__(self, *args, **kwargs)

--- a/grc/gui_qt/Config.py
+++ b/grc/gui_qt/Config.py
@@ -11,8 +11,7 @@ class Config(CoreConfig):
 
     name = 'GNU Radio Companion'
 
-    gui_prefs_file = os.environ.get(
-        'GRC_QT_PREFS_PATH', os.path.join(get_config_file_path(), 'grc_qt.conf'))
+    gui_prefs_file = os.environ.get('GRC_QT_PREFS_PATH', get_config_file_path('grc_qt.conf'))
 
     def __init__(self, install_prefix, *args, **kwargs):
         CoreConfig.__init__(self, *args, **kwargs)


### PR DESCRIPTION
When os.path.join is used, it appends an extra directory to the config file path.  For grc the config file is $HOME/.config/gnuradio/grc.conf/grc.conf and for grc qt the file is $HOME/.config/gnuradio/grc.conf/grc_qt.conf.

This patch proposes to change this and remove the grc.conf directory from the path.  This would make the grc config file $HOME/.config/gnuradio/grc.conf and the grc qt config file $HOME/.config/gnuradio/grc_qt.conf.

All that is needed to accomplish this is to remove the use of os.path.join to generate the gui_prefs_file.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
The above change removes the use of os.path.join(get_config_file_path(), 'grc.conf') to set the variable gui_prefs_file in both grc and grc_qt.
<!--- Why is this change required? What problem does it solve? -->
This change is required because current method adds an extra grc.conf directory to the config file path.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
This patch affects the grc/gui/Config.py and grc/gui_qt/Config.py.
<!--- areas these changes affect, such as performance. -->


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
I moved the .config directory to .config.old.  Then I tested both with and without the patch on both windows msys2 and linux.
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
I could not see where this would break other areas of code, but I am new to making changes to gnuradio, so it is possible that this change is a mistake, although I wouldn't make a PR unless I thought it warranted. 
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
