### PR TITLE
grc: Don't overwrite port domain on auto-type deduction

### DIFF
--- a/grc/core/ports/port.py
+++ b/grc/core/ports/port.py
@@ -163,7 +163,7 @@ class Port(Element):
             self.set_evaluated('vlen', port.vlen)
             self.domain = port.domain
         except AttributeError:
-            self.domain = Constants.DEFAULT_DOMAIN
+            pass
 
     def add_clone(self):
         """


### PR DESCRIPTION
Fixes the following issue: Create a port with automatic type deduction which is *not* in the streaming domain (e.g., create an RFNoC RX streamer block with no changes to settings from the default).

GRC will attempt to guess the dtype of this port (e.g., if it is connected to another block that does sc16, it will now also be sc16). However, due to the order in which objects are evaluated, the first time this is attempted is before the connection objects are generated, which means the auto-type deduction will fail the first time it is attempted.

The issue is, on failure, we re-set the port domain to 'stream' unconditionally. If the port domain was anything else (e.g., as above, 'rfnoc') then it will temporarily disable any domain-specific settings until the connection object is created, which is too late to import connection-and-domain-specific settings.

With this change, we simply don't touch the domain when the auto-type deduction fails.


## Description

See above. However, I'm not sure that the original code wasn't catching any corner case.

## Related Issue

This is easily reproduced by creating an RFNoC flowgraph in GRC with an RX streamer object, e.g., 


Radio -> RX streamer -> Null sink.

The connection from the Radio to the RX streamer will have no "Properties" box. There's a workaround: You can manually fix the type of the RX streamer input to 'sc16', and then there's no problem (after you reload the GRC). With this fix, no workaround is required.

## Which blocks/areas does this affect?

Currently this is most easily tested with RFNoC blocks.

## Testing Done

I used my test case from above to test. However, I don't know which corner cases should be tested to make sure this didn't break other stuff down the line.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
