### PR TITLE
grc: Improve check for connection in properties dialog

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -23,7 +23,9 @@ class Connection(Element):
     """
 
     is_connection = True
+    category = []
     documentation = {'': ''}
+    doc_url = ''
 
     def __init__(self, parent, source, sink):
         """

--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -239,6 +239,8 @@ class PropsDialog(Gtk.Dialog):
             if urlparse(url).scheme not in ("", "file"):
                 icon += "🌐"
             self._docs_link.set_markup(f'<a href="{url}">{icon} Visit Documentation Page</a>')
+        elif self._block.is_connection:
+            self._docs_link.set_markup('Connection Properties')
         else:
             self._docs_link.set_markup('Out of Tree Block, No documentation URL specified')
 


### PR DESCRIPTION
Without this fix, GRC tries to populate a full block-property dialog when opening a property dialog on connections. This improves the checking for the right attributes to correctly identify connections, and removes the following spurious output when opening property dialogs on connections:
```
Traceback (most recent call last):
  File "..../grc/gui/PropsDialog.py", line 210, in update_gui
    self._update_docs_page()
  File "..../grc/gui/PropsDialog.py", line 219, in _update_docs_page
    in_tree = self._block.category and self._block.category[0] == "Core"
AttributeError: 'Connection' object has no attribute 'category'
```

## Description

Opening a dialog before the fix:

![image](https://github.com/user-attachments/assets/93f588be-294a-43f5-bd69-90ae2c6e1a5a)

After the fix:

![image](https://github.com/user-attachments/assets/db9b5a67-0bf5-4a70-9af7-4bfa03cccf41)

## Which blocks/areas does this affect?

AFAICT, only edges with properties.

## Testing Done

See pics above.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
