### PR TITLE
grc-qt: Some improvements to the block parameter editor

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -11,6 +11,7 @@ import sys
 import types
 import logging
 import shlex
+import yaml
 from operator import methodcaller, attrgetter
 from typing import (List, Set, Optional, Iterator, Iterable, Tuple, Union, OrderedDict)
 
@@ -289,7 +290,7 @@ class FlowGraph(Element):
                 # rewrite on subsequent blocks depends on an updated self.namespace
                 self.namespace.update(namespace)
             # The following Errors may happen, but that doesn't matter as they are displayed in the gui
-            except (TypeError, FileNotFoundError, AttributeError):
+            except (TypeError, FileNotFoundError, AttributeError, yaml.YAMLError):
                 pass
             except Exception:
                 log.exception(f'Failed to evaluate variable block {variable_block.name}', exc_info=True)

--- a/grc/gui_qt/components/dialogs.py
+++ b/grc/gui_qt/components/dialogs.py
@@ -79,7 +79,8 @@ class PropsDialog(QDialog):
         self.edit_params = []
 
         self.tabs = QTabWidget()
-        ignore_dtype_labels = ["_multiline", "_multiline_python_external"]
+        error_msg = QLabel()
+        ignore_dtype_labels = ["_multiline", "_multiline_python_external", "file_open", "file_save"]
 
         for cat in unique_categories():
             qvb = QGridLayout()
@@ -115,6 +116,17 @@ class PropsDialog(QDialog):
                                 else param.value
                             )
                             dropdown.setCurrentText(value_label)
+                    elif param.dtype in ("file_open", "file_save"):
+                        dtype_label = QPushButton("...")
+                        dtype_label.setFlat(True)
+                        file_name = QLineEdit(param.value)
+                        file_name.param = param
+                        qvb.addWidget(file_name, i, 1)
+                        self.edit_params.append(file_name)
+                        if param.dtype == "file_open":
+                            dtype_label.clicked.connect(self.open_filero)
+                        else:
+                            dtype_label.clicked.connect(self.open_filerw)
                     elif param.dtype == "_multiline":
                         line_edit = QPlainTextEdit(param.value)
                         line_edit.param = param
@@ -144,7 +156,6 @@ class PropsDialog(QDialog):
                         line_edit = QPlainTextEdit(param.value)
                         line_edit.param = param
                         qvb.addWidget(editor_widget, i, 1)
-                        # self.edit_params.append(line_edit)
                     else:
                         line_edit = QLineEdit(param.value)
                         line_edit.param = param
@@ -170,9 +181,29 @@ class PropsDialog(QDialog):
         self.buttonBox.rejected.connect(self.reject)
         self.layout = QVBoxLayout()
         self.layout.addWidget(self.tabs)
+        error_msg.setText('\n\n'.join(self._block.get_error_messages()))
+        self.layout.addWidget(error_msg)
         self.layout.addWidget(self.buttonBox)
 
         self.setLayout(self.layout)
+
+    def find_param_widget(self, button):
+        # Find the correct layout
+        layout = self.tabs.currentWidget().layout()
+        # Find the location in the layout of the clicked button
+        location = layout.getItemPosition(layout.indexOf(button))
+        # The required widget is at column 1
+        return layout.itemAtPosition(location[0], 1).widget()
+
+    def open_filero(self):
+        f_name, fltr = QFileDialog.getOpenFileName(self, "Open a Data File")
+        button = self.sender()
+        self.find_param_widget(button).setText(f_name)
+
+    def open_filerw(self):
+        f_name, fltr = QFileDialog.getSaveFileName(self, "Save a Data File")
+        button = self.sender()
+        self.find_param_widget(button).setText(f_name)
 
     def accept(self):
         super().accept()

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -200,9 +200,6 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         self.show()
     """
 
-    def handle_all_actions(self, var_edit):
-        var_edit.all_editor_actions.connect(self.handle_editor_action)
-
     @QtCore.Slot(VariableEditorAction)
     def handle_editor_action(self, key):
         # Calculate the position to insert a new block


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
While grc --gtk maps the dtype file_open, file_save to a filedialog, that can be used to select a file, grc --qt maps this type to a string. So the value has to be known and can't be selected by an dialog.

This is changed by this pr.

In addition the editor displays error messages at the bottom corresponding to this block, if they exist. This is already done in grc --gtk.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
PropsDialog
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Just add a yaml_config block or  some File blocks.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
