### PR TITLE
tools: update clang_format script to search for clang-format 14

### DIFF
--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -49,8 +49,8 @@ if __name__ == "__main__" and __package__ is None:
 #
 
 # Expected version of clang-format
-CLANG_FORMAT_VERSION = "7.0.1"
-CLANG_FORMAT_SHORT_VERSION = "7.0"
+CLANG_FORMAT_VERSION = "14.0.0"
+CLANG_FORMAT_SHORT_VERSION = "14.0"
 
 # Name of clang-format as a binary
 CLANG_FORMAT_PROGNAME = "clang-format"


### PR DESCRIPTION


## Description
The old clang_format.py script searches for clang-format 7, but the version that the github CI uses is 14

## Related Issue
Fixes #7063

## Which blocks/areas does this affect?
tools

## Testing Done
Verified that error stops when ran on a docker container running the same ubuntu version as the github ubuntu CI (22.04)

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. NA
- [ ] I have added tests to cover my changes, and all previous tests pass. NA
