### PR TITLE
grc-qt: Fix failing tests

### DIFF
--- a/grc/tests/test_qtbot.py
+++ b/grc/tests/test_qtbot.py
@@ -98,7 +98,11 @@ def gather_menu_items(menu):
 def add_block_from_query(qtbot, app, query):
     qtbot.keyClick(app.focusWidget(), QtCore.Qt.Key_F, QtCore.Qt.ControlModifier)
     type_text(qtbot, app, query)
-    keystroke(qtbot, app, QtCore.Qt.Key_Enter)
+    qtbot.wait(10)
+    pag.press('down')
+    qtbot.wait(10)
+    pag.press('enter')
+    qtbot.wait(10)
 
 
 def find_blocks(flowgraph, block_type):
@@ -186,7 +190,6 @@ def test_delete_block(qtbot, qapp_cls_):
 def test_add_null_sink(qtbot, qapp_cls_):
     qtbot.wait(100)
     add_block_from_query(qtbot, qapp_cls_, "null sin")
-    qtbot.wait(100)
 
     n_sink = find_blocks(qapp_cls_.MainWindow.currentFlowgraph, "blocks_null_sink")
     assert n_sink is not None


### PR DESCRIPTION

Fixes: #7448

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
As the behaviour of the blocklib window was modified, the corresponding tests must be modified , too. The first idea is to insert a KeyDown sequence in the add_block_from_query. But that did'nt work for me. The KeyDown sequence was not executed. The workaround is to use the press function rom pyautogui. To work properly some delays must be inserted.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7448
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run
pytest grc/tests/test_qtbot.py
without errors
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
