### PR TITLE
runtime: Use ABC's in tag_utils

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping, Collection
+from numbers import Integral
+
 import pmt
 
 from . import gr_python as gr
@@ -45,10 +48,10 @@ def python_to_tag(tag_struct):
     """
     good = False
     tag = gr.tag_t()
-    if(type(tag_struct) == dict):
+    if(isinstance(tag_struct, Mapping)):
         if('offset' in tag_struct):
-            if(isinstance(tag_struct['offset'], int)):
-                tag.offset = tag_struct['offset']
+            if(isinstance(tag_struct['offset'], Integral)):
+                tag.offset = int(tag_struct['offset'])
                 good = True
 
         if('key' in tag_struct):
@@ -66,10 +69,10 @@ def python_to_tag(tag_struct):
                 tag.srcid = tag_struct['srcid']
                 good = True
 
-    elif(type(tag_struct) == list or type(tag_struct) == tuple):
+    elif(isinstance(tag_struct, Collection)):
         if(len(tag_struct) == 4):
-            if(isinstance(tag_struct[0], int)):
-                tag.offset = tag_struct[0]
+            if(isinstance(tag_struct[0], Integral)):
+                tag.offset = int(tag_struct[0])
                 good = True
 
             if(isinstance(tag_struct[1], pmt.pmt_base)):
@@ -85,8 +88,8 @@ def python_to_tag(tag_struct):
                 good = True
 
         elif(len(tag_struct) == 3):
-            if(isinstance(tag_struct[0], int)):
-                tag.offset = tag_struct[0]
+            if(isinstance(tag_struct[0], Integral)):
+                tag.offset = int(tag_struct[0])
                 good = True
 
             if(isinstance(tag_struct[1], pmt.pmt_base)):


### PR DESCRIPTION
## Description
Currently, tag_utils detects if an argument in python is an integer/list/whatever by checking its type. This can lead to hard to track bugs if e.g. the programmer attempts to use a numpy np.int_ or an ndarray. These types can be supported by having isinstance check for an abstract base class.


## Which blocks/areas does this affect?
None

## Testing Done
This change is trivial so I have not added a unit test, but all old tests still pass. If I should create a unit test, let me know.
An older codebase I was reformatting was not working due to np.ndarray and numpy int usage, and now it works with this change, so the change seems to do exactly what it ought to do.

## Checklist

- [ X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X ] I have squashed my commits to have one significant change per commit. 
- [ X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. NA
- [ ] I have added tests to cover my changes, and all previous tests pass. NA
