### PR TITLE
grc: Attribute error

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -288,7 +288,8 @@ class FlowGraph(Element):
                 namespace[variable_block.name] = value
                 # rewrite on subsequent blocks depends on an updated self.namespace
                 self.namespace.update(namespace)
-            except (TypeError, FileNotFoundError):  # Type Errors or FileNotFoundError may happen, but that doesn't matter as they are displayed in the gui
+            # The following Errors may happen, but that doesn't matter as they are displayed in the gui
+            except (TypeError, FileNotFoundError, AttributeError):
                 pass
             except Exception:
                 log.exception(f'Failed to evaluate variable block {variable_block.name}', exc_info=True)

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -236,6 +236,7 @@ class Application(Gtk.Application):
             }[action])
             if changed:
                 flow_graph_update()
+                page.flow_graph.update()
                 page.state_cache.save_new_state(flow_graph.export_data())
                 page.saved = False
         ##################################################

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -1155,6 +1155,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
     def undo_triggered(self):
         log.debug("undo")
         self.currentFlowgraphScene.undoStack.undo()
+        self.currentFlowgraphScene.update()
         self.updateActions()
 
     def redo_triggered(self):


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
**grc --gtk**
If you disable a block in flowgraph not all depending blocks are marked as invalid. Reenabling the disabled  block marks the fg as invalid. You have to open and close a block to mark the fg as valid.

**grc -qt**
Disableing and reenabling work without errors.
But disableing and Undo'ing leaves a fg invalid.

This issue is fixed by this pr.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7367

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

**Start grc --gtk**
Load example_corr_est_and_and_clock_sync.grc from digital/packet
Select the Constellation object hdr_const
disable this block
enable this block again
The Correlator Estimator block gets invalid.

**Start grc --qt**
Load example_corr_est_and_and_clock_sync.grc from digital/packet
Select the Constellation object hdr_const
disable this block
press Ctrl+Z

The Correlator Estimator block remains invalid
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
