### PR TITLE
python: set numpy type propagation policy in gateway

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2011-2012, 2018, 2020 Free Software Foundation, Inc.
+# Copyright 2024 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -14,6 +15,18 @@ import ctypes
 from . import gr_python as gr
 from .gr_python import io_signature  # , io_signaturev
 from .gr_python import block_gateway
+
+from packaging.version import Version as _version
+if _version(numpy.version.version) >= _version('1.24.0'):
+    """
+    Numpy 2.0 changes type promotion rules: https://numpy.org/neps/nep-0050-scalar-promotion.html
+    Ensure that we're using the same type promotion rules on post-3.10 main, as far as possible.
+
+    Since this might break existing user applications (as easy as the fix is,
+    https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion),
+    this can't be backported to 3.10.
+    """
+    numpy._set_promotion_state('weak')
 
 
 ########################################################################


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

This way, Python code using GNU Radio blocks has the same type propagation behaviour as numpy 2, no matter whether it's using numpy 1 (>=1.24.0) or 2.

Background is that numpy2 makes test cases fail that do something like

```python
a = numpy.ndarray([1,2], dtype=numpy.uint8)
b = a[0] * 256 + a[1]
```

because numpy2's propagation rules convert 256 to the dtype of `a[0]` first, and that fails, because 256 is too large to fit an 8 bit integer.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

#7458 highlights how numpy2 test cases differ from numpy1 test cases

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Sadly, everything that imports from gnuradio in Python

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

None, this should, if anything, make *more* testcases fail; I expect the same failure we see on the Mingw64 test (using numpy2) to happen everywhere that's got a recent enough python version (Deb12, Ubuntu24, Fedoras)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
