### PR TITLE
digital: corr._access_code QA: don't try to cast 256 to uint8

### DIFF
--- a/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
+++ b/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
@@ -74,8 +74,10 @@ class test_correlate_access_code_XX_ts(gr_unittest.TestCase):
         # header contains packet length, twice (bit-swapped)
         header = numpy.array([(payload_len & 0xFF00) >> 8, payload_len & 0xFF] * 2, dtype=numpy.uint8)
         # make sure we've built the length header correctly
-        self.assertEqual(header[0] * 256 + header[1], header[2] * 256 + header[3])
-        self.assertEqual(header[0] * 256 + header[1], len(payload))
+        # (header[0] * 256 + header[1], header[2] * 256 + header[3])
+        self.assertEqual(header[0], header[2])  # upper byte
+        self.assertEqual(header[1], header[3])  # lower byte
+        self.assertEqual(int(header[0]) * 256 + int(header[1]), len(payload))
 
         packet = numpy.concatenate((header, payload))
         pad = (0,) * PADDING_LEN


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Numpy 2 changed type propagation rules (see PR #7465, which should make the failures we see on a numpy2 builder happen on numpy1 builders, as well).

This fixes breakage in all Mingw64 builds

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #7458

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

QA of correlator_access_code

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

test should now pass

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
