### PR TITLE
gr_modtool: util_functions.py add newline to variable modified_last

### DIFF
--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -42,7 +42,7 @@ def append_re_line_sequence(filename: str, linepattern: str, newline: str, closi
     if closing_parentheses is not None and last_line.rstrip().endswith(closing_parentheses):
         modified_last = f'\n{last_line.rstrip()[:-len(closing_parentheses)]}\n{closing_parentheses}\n'
     else:
-        modified_last = last_line + '\n'
+        modified_last = last_line + newline + '\n'
     newfile = oldfile.replace(last_line, modified_last)
     with open(filename, 'w') as f:
         f.write(newfile)


### PR DESCRIPTION
Under windows this fixes a problem with python modifying `__init__.py` improperly and I believe this will occur under linux as well.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Without this change `__init.py__` gets populated as follows.  (Without the `from .{_blockname} import {_blockname}` lines.)
```
# Copyright 2008,2009 Free Software Foundation, Inc.
#
# SPDX-License-Identifier: GPL-3.0-or-later
#

# The presence of this file turns this directory into a Python package

'''
This is the GNU Radio CUSTOMMODULE module. Place your Python package
description here (python/__init__.py).
'''
import os

# import pybind11 generated symbols into the customModule namespace
try:
    # this might fail if the module is python-only
    from .customModule_python import *
except ModuleNotFoundError:
    pass

# import any pure python here

#
```

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
This affects the `gr_modtool` tool, specifically the add python code function.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I stepped through the code with pdb under msys2 with gnuradio-3.10.11.0.  I have not tested this under linux, but believe the error will occur there too.  I would also like to ensure that this doesn't negatively impact cpp code generation as I have not yet tested it with cpp.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
