### PR TITLE
blocks: Fix displayed SigMF dataset format strings

### DIFF
--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -10,6 +10,7 @@ parameters:
     label: Stream Type
     dtype: enum
     options: [complex float (fc32_le), real float (rc32_le), complex short (sc16_le), real short (rc16_le)]
+    option_labels: [complex float (cf32_le), real float (rf32_le), complex short (ci16_le), real short (ri16_le)]
     option_attributes:
         type: [complex, float, short, short]
         size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_short, gr.sizeof_short]

--- a/gr-blocks/grc/blocks_sigmf_source_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_source_minimal.block.yml
@@ -10,6 +10,7 @@ parameters:
     label: Output Type
     dtype: enum
     options: [complex float (fc32_le), real float (rc32_le), complex short (sc16_le), real short (rc16_le)]
+    option_labels: [complex float (cf32_le), real float (rf32_le), complex short (ci16_le), real short (ri16_le)]
     option_attributes:
         type: [complex, float, short, short]
         size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_short, gr.sizeof_short]


### PR DESCRIPTION
## Description
The SigMF dataset format strings shown in the SigMF Source & Sink (Minimal) blocks are incorrect. Here I've changed them in accordance with the specification (https://sigmf.org/#sigmf-dataset-format).

## Which blocks/areas does this affect?
* SigMF Source (Minimal)
* SigMF Sink (Minimal)

## Testing Done
I verified that the correct names appear in the drop-down menus, and that existing flow graphs still function after the change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
