### PR TITLE
modtool: Add shell completions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,51 @@ else(ENABLE_PERFORMANCE_COUNTERS)
     message(STATUS "NO PERF COUNTERS")
 endif(ENABLE_PERFORMANCE_COUNTERS)
 
+string(COMPARE EQUAL "${CMAKE_INSTALL_PREFIX}" "/usr/local" isusrlocal)
+string(COMPARE EQUAL "${CMAKE_INSTALL_PREFIX}" "$ENV{HOME}/.local" ishomelocal)
+
+option(ENABLE_BASH_COMPLETIONS "Enable shell completions for bash" ON)
+if(ENABLE_BASH_COMPLETIONS)
+    if(NOT DEFINED GR_BASH_COMPLETIONS_DIR)
+        if(isusr OR isusrlocal OR ishomelocal)
+            set(GR_BASH_COMPLETIONS_DIR
+                share/bash-completion/completions
+                CACHE PATH "Path to install bash completions")
+        else(isusr OR isusrlocal OR ishomelocal)
+            message(WARNING "GR_BASH_COMPLETIONS_DIR is not defined")
+            set(ENABLE_BASH_COMPLETIONS OFF)
+        endif(isusr OR isusrlocal OR ishomelocal)
+    endif(NOT DEFINED GR_BASH_COMPLETIONS_DIR)
+endif(ENABLE_BASH_COMPLETIONS)
+
+option(ENABLE_ZSH_COMPLETIONS "Enable shell completions for zsh" ON)
+if(ENABLE_ZSH_COMPLETIONS)
+    if(NOT DEFINED GR_ZSH_COMPLETIONS_DIR)
+        if(isusr OR isusrlocal)
+            set(GR_ZSH_COMPLETIONS_DIR
+                share/zsh/site-functions
+                CACHE PATH "Path to install zsh completions")
+        else(isusr OR isusrlocal)
+            message(WARNING "GR_ZSH_COMPLETIONS_DIR is not defined")
+            set(ENABLE_ZSH_COMPLETIONS OFF)
+        endif(isusr OR isusrlocal)
+    endif(NOT DEFINED GR_ZSH_COMPLETIONS_DIR)
+endif(ENABLE_ZSH_COMPLETIONS)
+
+option(ENABLE_FISH_COMPLETIONS "Enable shell completions for fish" ON)
+if(ENABLE_FISH_COMPLETIONS)
+    if(NOT DEFINED GR_FISH_COMPLETIONS_DIR)
+        if(isusr OR ishomelocal)
+            set(GR_FISH_COMPLETIONS_DIR
+                share/fish/vendor_completions.d
+                CACHE PATH "Path to install fish completions")
+        else(isusr OR ishomelocal)
+            message(WARNING "GR_FISH_COMPLETIONS_DIR is not defined")
+            set(ENABLE_FISH_COMPLETIONS OFF)
+        endif(isusr OR ishomelocal)
+    endif(NOT DEFINED GR_FISH_COMPLETIONS_DIR)
+endif(ENABLE_FISH_COMPLETIONS)
+
 ########################################################################
 # Variables replaced when configuring the package config files
 ########################################################################

--- a/gr-utils/modtool/CMakeLists.txt
+++ b/gr-utils/modtool/CMakeLists.txt
@@ -28,6 +28,35 @@ install(
     DESTINATION ${GR_PREFSDIR}
 )
 
+
+########################################################################
+# Install shell completion scripts
+########################################################################
+if(ENABLE_BASH_COMPLETIONS)
+    install(
+        FILES complete_bash.in
+        RENAME gr_modtool
+        DESTINATION ${GR_BASH_COMPLETIONS_DIR}
+    )
+endif(ENABLE_BASH_COMPLETIONS)
+
+if(ENABLE_ZSH_COMPLETIONS)
+    install(
+        FILES complete_zsh.in
+        RENAME _gr_modtool
+        DESTINATION ${GR_ZSH_COMPLETIONS_DIR}
+    )
+endif(ENABLE_ZSH_COMPLETIONS)
+
+if(ENABLE_FISH_COMPLETIONS)
+    install(
+        FILES complete_fish.in
+        RENAME gr_modtool.fish
+        DESTINATION ${GR_FISH_COMPLETIONS_DIR}
+    )
+endif(ENABLE_FISH_COMPLETIONS)
+
+
 GR_PYTHON_INSTALL(
     PROGRAMS    gr_modtool
     DESTINATION ${GR_RUNTIME_DIR}

--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -20,8 +20,25 @@ from ..tools import SequenceCompleter, ask_yes_no
 from .base import common_params, block_name, run, cli_input, ModToolException
 
 
+class BlockType(click.ParamType):
+    name = "blocktype"
+
+    def convert(self, value, param, ctx):
+        if value in ModToolAdd.block_types:
+            return value
+        else:
+            self.fail(f"Invalid blocktype: '{value}'")
+
+    def shell_complete(self, ctx, param, incomplete: str):
+        return [
+            click.shell_completion.CompletionItem(name, help=description)
+            for name, description in ModToolAdd.block_types.items()
+            if name.startswith(incomplete)
+        ]
+
+
 @click.command('add')
-@click.option('-t', '--block-type', type=click.Choice(ModToolAdd.block_types),
+@click.option('-t', '--block-type', type=BlockType(),
               help=f"One of {', '.join(ModToolAdd.block_types)}.")
 @click.option('--license-file',
               help="File containing the license header for every source code file.")

--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -41,6 +41,7 @@ class BlockType(click.ParamType):
 @click.option('-t', '--block-type', type=BlockType(),
               help=f"One of {', '.join(ModToolAdd.block_types)}.")
 @click.option('--license-file',
+              type=click.Path(file_okay=True, dir_okay=False, readable=True),
               help="File containing the license header for every source code file.")
 @click.option('--copyright',
               help="Name of the copyright holder (you or your company) MUST be a quoted string.")

--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -56,7 +56,7 @@ class BlockType(click.ParamType):
 @click.option('-l', '--lang', type=click.Choice(ModToolAdd.language_candidates),
               help="Programming Language")
 @common_params
-@block_name
+@click.argument("blockname", nargs=1, required=False, metavar="BLOCK_NAME")
 def cli(**kwargs):
     """Adds a block to the out-of-tree module."""
     kwargs['cli'] = True

--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -35,6 +35,7 @@ import click
 from click import ClickException
 
 from gnuradio import gr
+from ..core import get_block_candidates
 
 
 class ModToolException(ClickException):
@@ -150,8 +151,16 @@ def common_params(func):
     return wrapper
 
 
-block_name = click.argument(
-    'blockname', nargs=1, required=False, metavar="BLOCK_NAME")
+def block_name(**kwargs):
+    """ Block name parameter with completion from candidates """
+    def block_name_complete(ctx, param, incomplete: str):
+        return sorted(
+            name for name in get_block_candidates(**kwargs)
+            if name.startswith(incomplete)
+        )
+    return click.argument(
+        'blockname', nargs=1, required=False, metavar="BLOCK_NAME",
+        shell_complete=block_name_complete)
 
 
 @click.command(cls=CommandCLI,

--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -127,6 +127,7 @@ def cli_input(msg):
 def common_params(func):
     """ Common parameters for various modules"""
     @click.option('-d', '--directory', default='.',
+                  type=click.Path(file_okay=False, dir_okay=True, readable=True, writable=True),
                   help="Base directory of the module. Defaults to the cwd.")
     @click.option('--skip-lib', is_flag=True,
                   help="Don't do anything in the lib/ subdirectory.")

--- a/gr-utils/modtool/cli/bind.py
+++ b/gr-utils/modtool/cli/bind.py
@@ -35,7 +35,7 @@ from .base import common_params, block_name, run, cli_input
 @click.option('-u', '--update-hash-only', is_flag=True,
               help='If given, only the hash in the binding will be updated')
 @common_params
-@block_name
+@block_name(skip_grc=True, skip_lib=True, skip_python=True)
 def cli(**kwargs):
     """
     \b

--- a/gr-utils/modtool/cli/disable.py
+++ b/gr-utils/modtool/cli/disable.py
@@ -18,7 +18,7 @@ from .base import common_params, block_name, run, cli_input
 
 @click.command('disable', short_help=ModToolDisable.description)
 @common_params
-@block_name
+@block_name()
 def cli(**kwargs):
     """Disable a block (comments out CMake entries for files)"""
     kwargs['cli'] = True

--- a/gr-utils/modtool/cli/makeyaml.py
+++ b/gr-utils/modtool/cli/makeyaml.py
@@ -31,7 +31,7 @@ from .base import common_params, block_name, run, cli_input
 @click.option('-o', '--output', is_flag=True,
               help='If given, a file with desired output format will be generated')
 @common_params
-@block_name
+@block_name(skip_grc=True, skip_include=True, skip_python=True)  # TODO: python blocks
 def cli(**kwargs):
     """
     \b

--- a/gr-utils/modtool/cli/newmod.py
+++ b/gr-utils/modtool/cli/newmod.py
@@ -21,6 +21,7 @@ from .base import common_params, run, cli_input, ModToolException
 
 @click.command('newmod', short_help=ModToolNewModule.description)
 @click.option('--srcdir',
+              type=click.Path(file_okay=False, dir_okay=True, readable=True),
               help="Source directory for the module template.")
 @common_params
 @click.argument('module_name', metavar="MODULE-NAME", nargs=1, required=False)

--- a/gr-utils/modtool/cli/rename.py
+++ b/gr-utils/modtool/cli/rename.py
@@ -20,7 +20,7 @@ from .base import common_params, block_name, run, cli_input, ModToolException
 
 @click.command('rename', short_help=ModToolRename.description)
 @common_params
-@block_name
+@block_name()
 @click.argument('new-name', metavar="NEW-BLOCK-NAME", nargs=1, required=False)
 def cli(**kwargs):
     """

--- a/gr-utils/modtool/cli/rm.py
+++ b/gr-utils/modtool/cli/rm.py
@@ -18,7 +18,7 @@ from .base import common_params, block_name, run, cli_input
 
 @click.command('remove', short_help=ModToolRemove.description)
 @common_params
-@block_name
+@block_name()
 def cli(**kwargs):
     """ Remove block (delete files and remove Makefile entries) """
     kwargs['cli'] = True

--- a/gr-utils/modtool/cli/update.py
+++ b/gr-utils/modtool/cli/update.py
@@ -16,12 +16,19 @@ from ..tools import SequenceCompleter
 from .base import block_name, run, cli_input, ModToolException
 
 
+def xml_blockname_complete(ctx, param, incomplete: str):
+    return sorted(
+        name for name in get_xml_candidates()
+        if name.startswith(incomplete)
+    )
+
+
 @click.command('update', short_help=ModToolUpdate.description)
 @click.option('--complete', is_flag=True, default=None,
               help="Convert all the XML bindings to YAML.")
 @click.option('-I', '--include-blacklisted', is_flag=True, default=None,
               help="Include XML files with blacklisted names in the conversion process")
-@block_name
+@click.argument("blockname", nargs=1, required=False, metavar="BLOCK_NAME", shell_complete=xml_blockname_complete)
 def cli(**kwargs):
     """ Update the XML bindings to YAML bindings """
     kwargs['cli'] = True

--- a/gr-utils/modtool/complete_bash.in
+++ b/gr-utils/modtool/complete_bash.in
@@ -1,0 +1,38 @@
+# GNU Radio ModTool completion for bash                    -*- shell-script -*-
+#
+# Copyright 2014 Pallets
+# Copyright 2024 Oleg Nikitin
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+_gr_modtool_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _GR_MODTOOL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_gr_modtool_completion_setup() {
+    complete -o nosort -F _gr_modtool_completion gr_modtool
+}
+
+_gr_modtool_completion_setup;

--- a/gr-utils/modtool/complete_fish.in
+++ b/gr-utils/modtool/complete_fish.in
@@ -1,0 +1,27 @@
+# GNU Radio ModTool completion for fish                    -*- shell-script -*-
+#
+# Copyright 2014 Pallets
+# Copyright 2024 Oleg Nikitin
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+function _gr_modtool_completion
+    set -l response (env _GR_MODTOOL_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) gr_modtool)
+
+    for completion in $response
+        set -l metadata (string split "," $completion)
+
+        if test $metadata[1] = "dir"
+            __fish_complete_directories $metadata[2]
+        else if test $metadata[1] = "file"
+            __fish_complete_path $metadata[2]
+        else if test $metadata[1] = "plain"
+            echo $metadata[2]
+        end
+    end
+end
+
+complete --no-files --command gr_modtool --arguments "(_gr_modtool_completion)"

--- a/gr-utils/modtool/complete_zsh.in
+++ b/gr-utils/modtool/complete_zsh.in
@@ -1,0 +1,49 @@
+#compdef gr_modtool
+# GNU Radio ModTool completion for zsh                     -*- shell-script -*-
+#
+# Copyright 2014 Pallets
+# Copyright 2024 Oleg Nikitin
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+_gr_modtool_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[gr_modtool] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _GR_MODTOOL_COMPLETE=zsh_complete gr_modtool)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _gr_modtool_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _gr_modtool_completion gr_modtool
+fi

--- a/gr-utils/modtool/core/add.py
+++ b/gr-utils/modtool/core/add.py
@@ -40,8 +40,17 @@ class ModToolAdd(ModTool):
     """ Add block to the out-of-tree module. """
     name = 'add'
     description = 'Add new block into a module.'
-    block_types = ('sink', 'source', 'sync', 'decimator', 'interpolator',
-                   'general', 'tagged_stream', 'hier', 'noblock')
+    block_types = {
+        "sink": "Source block with outputs, but no stream inputs",
+        "source": "Sink block with inputs, but no stream outputs",
+        "sync": "Block with synchronous 1:1 input-to-output",
+        "decimator": "Block with synchronous N:1 input-to-output",
+        "interpolator": "Block with synchronous 1:N input-to-output",
+        "general": "General-purpose block type",
+        "tagged_stream": "Block with input-to-output flow controlled by input stream tags (e.g. packetized streams)",
+        "hier": "Hierarchical container block for other blocks; usually can be described by a flowgraph",
+        "noblock": "C++ or Python class",
+    }
     language_candidates = ('cpp', 'python', 'c++')
 
     def __init__(self, blockname=None, block_type=None, lang=None, copyright=None,


### PR DESCRIPTION
## Description
Adds shell (tab) completions for `gr_modtool` using capabilities of Click ([docs](https://click.palletsprojects.com/en/8.1.x/shell-completion)).

## Related Issue
Fixes #5206

## Which blocks/areas does this affect?
gr_modtool

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
