### PR TITLE
grc: add missing developer name tag to metainfo file

### DIFF
--- a/grc/scripts/freedesktop/org.gnuradio.grc.metainfo.xml
+++ b/grc/scripts/freedesktop/org.gnuradio.grc.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    This file was tested against `appstream cli validate` v0.12.7 (Fedora 31)
+    This file was tested against `appstreamcli validate` v0.12.7 (Fedora 31)
     and v0.12.5 (Debian 10) It fails to validate under v0.12.0 (Ubuntu 18.04).
     So, this file becomes valid somewhere between v0.12.1 and v0.12.5.
     Note that metainfo doesn't mandate (even support at this point) schema
@@ -13,6 +13,7 @@
 <metadata_license>CC0-1.0</metadata_license>
 <project_license>GPL-3.0+</project_license>
 <name>GNU Radio Companion</name>
+<developer_name>Radio project</developer_name>
 <summary>Graphical Signal Processing Flow Graph Design Tool</summary>
 <description>
   <p>


### PR DESCRIPTION
## Description
This PR adds the previously missing developer name tag to the GRC AppStream metainfo file.

It replaces the original #7478 PR that also added OARS metadata that should not be added.

It also fixes a small typo in the comment section.

Please note that the current developer name content is just a placeholder for the actual (correct) developer name. If it is incorrect, please let me know and I will change it to the correct one provided by you.

/cc @marcusmueller

## Which blocks/areas does this affect?
None.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
