### PR TITLE
grc-qt: Implement open hier source

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -484,7 +484,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         actions["toggle_sink_bus"] = Action(_("toggle_sink_bus"), self)
 
         actions["create_hier"].setEnabled(False)
-        actions["open_hier"].setEnabled(False)
+        actions["open_hier"].setEnabled(True)
         actions["toggle_source_bus"].setEnabled(False)
         actions["toggle_sink_bus"].setEnabled(False)
 
@@ -1431,6 +1431,13 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             self.rebuild_tab(idx)
 
         self.updateActions()
+
+    def open_hier_triggered(self):
+        log.debug("Open hier block triggered")
+        for block in self.currentFlowgraphScene.selected_blocks():
+            grc_source = block.core.extra_data.get('grc_source', '')
+            if grc_source:
+                self.open_triggered(grc_source)
 
     def rebuild_tab(self, idx):
         fgscene = self.tabWidget.widget(idx).scene()


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
If the block is an hier block, the block source can be loaded by 
right clicking -> more -> Open hierarchical block
on the hier block.
Selecting multiple blocks works , too.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
