### PR TITLE
grc: Fix issue #7484 (channelizer output count incorrect in some situations).

### DIFF
--- a/gr-filter/grc/filter_pfb_channelizer_hier.block.yml
+++ b/gr-filter/grc/filter_pfb_channelizer_hier.block.yml
@@ -44,7 +44,7 @@ inputs:
 outputs:
 -   domain: stream
     dtype: complex
-    multiplicity: ${ nchans }
+    multiplicity: ${ nchans if outchans is None else len(outchans) }
 
 templates:
     imports: from gnuradio.filter import pfb


### PR DESCRIPTION
Fixes #7484 by checking both the number of channels being produced AND the output map (if provided) to determine the actual number of output ports that the block will produce at runtime.

## Description
Full description is in issue #7484

## Which blocks/areas does this affect?
This issue (and patch) only affects GNURadio Companion.

## Testing Done
I used the example flow graph in issue #7484 to both reproduce the issue and to verify the fix.

## Checklist
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
