### PR TITLE
digital: Fix NumPy 2 compatibility

### DIFF
--- a/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
+++ b/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
@@ -12,6 +12,7 @@
 from gnuradio import gr, gr_unittest, digital, blocks
 import pmt
 import numpy
+import struct
 
 default_access_code = '\xAC\xDD\xA4\xE2\xF2\x8C\x20\xFC'
 
@@ -74,8 +75,9 @@ class test_correlate_access_code_XX_ts(gr_unittest.TestCase):
         # header contains packet length, twice (bit-swapped)
         header = numpy.array([(payload_len & 0xFF00) >> 8, payload_len & 0xFF] * 2, dtype=numpy.uint8)
         # make sure we've built the length header correctly
-        self.assertEqual(header[0] * 256 + header[1], header[2] * 256 + header[3])
-        self.assertEqual(header[0] * 256 + header[1], len(payload))
+        length1, length2 = struct.unpack(">HH", header)
+        self.assertEqual(length1, length2)
+        self.assertEqual(length1, len(payload))
 
         packet = numpy.concatenate((header, payload))
         pad = (0,) * PADDING_LEN


### PR DESCRIPTION
## Description
The following test code, which was added in #7125, now fails on the MinGW-w64 build:

https://github.com/gnuradio/gnuradio/blob/30a0aa916b227d7409238f7451f10e9786403955/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py#L76-L78

```
======================================================================
ERROR: test_payload_lengths (__main__.test_correlate_access_code_XX_ts.test_payload_lengths)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:/a/gnuradio/gnuradio/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py", line 104, in test_payload_lengths
    self._variable_payload_t(length)
  File "D:/a/gnuradio/gnuradio/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py", line 77, in _variable_payload_t
    self.assertEqual(header[0] * 256 + header[1], header[2] * 256 + header[3])
                     ~~~~~~~~~~^~~~~
OverflowError: Python integer 256 out of bounds for uint8
```

This happens because of new promotion rules introduced in NEP 50: https://numpy.org/neps/nep-0050-scalar-promotion.html

To fix the problem, I've changed the test to interpret the header bytes using `struct.unpack`.

## Related Issue

Fixes #7458.
This is an alternative to #7466.

## Which blocks/areas does this affect?
Tests for Correlate Access Code

## Testing Done
I verified that the updated test passes on my machine.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
