### PR TITLE
blocktool: Resolve circular import

### DIFF
--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -26,8 +26,7 @@ try:
     from pygccxml import parser, declarations, utils
     PYGCCXML_AVAILABLE = True
 except:
-    from ...modtool.tools import ParserCCBlock
-    from ...modtool.cli import ModToolException
+    from gnuradio.modtool.tools import ParserCCBlock
 
 
 class GenericHeaderParser(BlockTool):
@@ -113,7 +112,7 @@ class GenericHeaderParser(BlockTool):
                                    '39'
                                    )
         except IOError:
-            raise ModToolException(
+            raise BlockToolException(
                 "Can't open some of the files necessary to parse {}.".format(fname_cc))
 
         if contains_modulename:


### PR DESCRIPTION
## Description
Module `modtool.cli` imports `ModToolAdd`, among other modules. `ModToolAdd` uses `BindingGenerator`, which uses `GenericHeaderParser`. However, `GenericHeaderParser` imports `ModToolException` from `modtool.cli`, and that creates a circular import scenario. Using `BlockToolException` instead of `modtool.cli.ModToolException` in `GenericHeaderParser._parse_cc_h` avoids importing `modtool.cli`.

## Related Issue
https://github.com/gnuradio/gnuradio/pull/7474#issuecomment-2315803861

## Which blocks/areas does this affect?
blocktool

## Testing Done
- [`blocktool/tests/test_blocktool.py`](https://github.com/gnuradio/gnuradio/blob/30a0aa916b227d7409238f7451f10e9786403955/gr-utils/blocktool/tests/test_blocktool.py)
- Conda CI

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
