### PR TITLE
Update doc comments in wavsink and wavsource

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
@@ -19,10 +19,15 @@ namespace gr {
 namespace blocks {
 
 /*!
- * \brief Write stream to a Microsoft PCM (.wav) file.
+ * \brief Write stream to an audio file.
  * \ingroup audio_blk
  *
  * \details
+ * Writes to audio container from gr-blocks/lib/wavfile_sink_impl.cc
+ * .wav files can use PCM-8, PCM-16, PCM-24, PCM-32, float, or double.
+ * .flac files can use PCM-S8, PCM-16, or PCM-24.
+ * .ogg files can use vorbis or opus.
+ * .rf64 files can use PCM-u8, PCM-16, PCM-24, PCM-32, float, or double
  * Values must be floats within [-1;1].
  * Check gr_make_wavfile_sink() for extra info.
  */

--- a/gr-blocks/include/gnuradio/blocks/wavfile_source.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_source.h
@@ -18,12 +18,16 @@ namespace gr {
 namespace blocks {
 
 /*!
- * \brief Read stream from a Microsoft PCM (.wav) file, output floats
+ * Read samples from an audio file (uncompressed or compressed)
  * \ingroup audio_blk
  *
  * \details
  * Unless otherwise called, values are within [-1;1].
- * Check gr_make_wavfile_source() for extra info.
+ * Accepts audio container from gr-blocks/lib/wavfile_sink_impl.cc
+ * .wav files can use PCM-8, PCM-16, PCM-24, PCM-32, float, or double.
+ * .flac files can use PCM-S8, PCM-16, or PCM-24.
+ * .ogg files can use vorbis or opus.
+ * .rf64 files can use PCM-u8, PCM-16, PCM-24, PCM-32, float, or double
  */
 class BLOCKS_API wavfile_source : virtual public sync_block
 {


### PR DESCRIPTION
Updating the comments to show the correct file formats accepted by the file sink and source for audio files.

## Description
This should fulfill the requirements of issue 5971 by adding the comments suggested.

## Related Issue
Fixes #5971 

## Which blocks/areas does this affect?
This affects gr-blocks includes header files.
These affect the sink and source files for audio.

## Testing Done
Only changed the comments.

## Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
