### PR TITLE
grc: follow up to #7455

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -154,6 +154,7 @@ class TopBlockGenerator(object):
             output.insert(0, textwrap.dedent("""\
                 import os
                 import sys
+                import logging as log
 
                 def get_state_directory() -> str:
                     oldpath = os.path.expanduser("~/.grc_gnuradio")
@@ -163,7 +164,7 @@ class TopBlockGenerator(object):
                         if os.path.exists(newpath):
                             return newpath
                         if os.path.exists(oldpath):
-                            log.warn(f"Found persistent state path '{newpath}', but file does not exist. " +
+                            log.warning(f"Found persistent state path '{newpath}', but file does not exist. " +
                                      f"Old default persistent state path '{oldpath}' exists; using that. " +
                                      "Please consider moving state to new location.")
                             return oldpath
@@ -172,15 +173,15 @@ class TopBlockGenerator(object):
                         os.makedirs(newpath, exist_ok=True)
                         return newpath
                     except (ImportError, NameError):
-                        log.warn("Could not retrieve GNU Radio persistent state directory from GNU Radio." +
+                        log.warning("Could not retrieve GNU Radio persistent state directory from GNU Radio. " +
                                  "Trying defaults.")
                         xdgstate = os.getenv("XDG_STATE_HOME", os.path.expanduser("~/.local/state"))
                         xdgcand = os.path.join(xdgstate, "gnuradio")
                         if os.path.exists(xdgcand):
                             return xdgcand
                         if os.path.exists(oldpath):
-                            log.warn(f"Using legacy state path '{oldpath}'. Please consider moving state " +
-                                     f"files to '{newpath}'.")
+                            log.warning(f"Using legacy state path '{oldpath}'. Please consider moving state " +
+                                     f"files to '{xdgcand}'.")
                             return oldpath
                         # neither old, nor new path exist: create new path, return that
                         os.makedirs(xdgcand, exist_ok=True)


### PR DESCRIPTION


<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Running a flowgraph may fail  with

Traceback (most recent call last):
  File "/home/schroer/gnuradiocomponents/Test/./callhier.py", line 24, in get_state_directory
    log.warn(f"Found persistent state path '{newpath}', but file does not exist. " +
    ^^^
NameError: name 'log' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/schroer/gnuradiocomponents/Test/./callhier.py", line 47, in <module>
    sys.path.append(os.environ.get('GRC_HIER_PATH', get_state_directory()))
                                                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/schroer/gnuradiocomponents/Test/./callhier.py", line 33, in get_state_directory
    log.warn("Could not retrieve GNU Radio persistent state directory from GNU Radio." +
    ^^^
NameError: name 'log' is not defined

This depends on which directories exist.

**After applying this pr we get:**

Found specification for persistent state path '/home/schroer/.local/state/gnuradio', but file does not exist. Old default persistent state path '/home/schroer/.grc_gnuradio' exists; using that. Please consider moving state to new location.
log :warning: Matplotlib is a required dependency to use DistanceRadar and AzElPlot.  Please install matplotlib to use these blocks (https://matplotlib.org/)

Executing: /usr/bin/python3 -u /home/schroer/gnuradiocomponents/Test/callhier.py

log :warning: Matplotlib is a required dependency to use DistanceRadar and AzElPlot.  Please install matplotlib to use these blocks (https://matplotlib.org/)
WARNING:root:Found persistent state path '/home/schroer/.local/state/gnuradio', but file does not exist. Old default persistent state path '/home/schroer/.grc_gnuradio' exists; using that. Please consider moving state to new location.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
