### PR TITLE
grc: Fix warning message in fallback case

### DIFF
--- a/grc/main.py
+++ b/grc/main.py
@@ -214,7 +214,7 @@ def get_config_file_path(config_file: str = "grc.conf") -> str:
             return xdgcand
         if os.path.exists(oldpath):
             log.warn(f"Using legacy config path '{oldpath}'. Please consider moving configuration " +
-                     f"files to '{newpath}'.")
+                     f"files to '{xdgcand}'.")
             return oldpath
         # neither old, nor new path exist: create new path, return that
         path_parts = Path(xdgcand).parts[:-1]
@@ -247,7 +247,7 @@ def get_state_directory() -> str:
             return xdgcand
         if os.path.exists(oldpath):
             log.warn(f"Using legacy state path '{oldpath}'. Please consider moving state " +
-                     f"files to '{newpath}'.")
+                     f"files to '{xdgcand}'.")
             return oldpath
         # neither old, nor new path exist: create new path, return that
         os.makedirs(xdgcand, exist_ok=True)


### PR DESCRIPTION
## Description
As noted in https://github.com/gnuradio/gnuradio/pull/7455#discussion_r1694352183, the fallback code paths in `get_config_file_path` and `get_state_directory` that execute when `gr::paths` does not exist reference a non-existent variable (`newpath`), which triggers an exception. The correct variable name in both cases is `xdgcand`.

## Which blocks/areas does this affect?
GNU Radio Companion

## Testing Done
I exercised the fallback code paths by changing `from gnuradio.gr import paths` to `from gnuradio.gr import xxxxx`, and verified that exceptions occur before the changes, and warning messages appear correctly afterwards.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
