### PR TITLE
blocks: Fix test_read_wav_1024 on Windows

### DIFF
--- a/gr-blocks/python/blocks/qa_wavfile.py
+++ b/gr-blocks/python/blocks/qa_wavfile.py
@@ -190,13 +190,14 @@ class test_wavefile(gr_unittest.TestCase):
 
     def test_read_wav_1024(self):
         for expected_len in range(1024, 32768, 1024):
-            with tempfile.NamedTemporaryFile(suffix=".wav") as tf:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
                 with wave.open(tf.name, "w") as wf:
                     wf.setnchannels(1)
                     wf.setsampwidth(2)
                     wf.setframerate(8000)
                     wf.writeframes(bytes([0, 0] * expected_len))
 
+                self.tb = gr.top_block()
                 src = blocks.wavfile_source(tf.name)
                 dst = blocks.vector_sink_f()
                 self.tb.connect(src, dst)
@@ -204,7 +205,12 @@ class test_wavefile(gr_unittest.TestCase):
 
                 result = dst.data()
 
+                del src
+                del self.tb
+
                 self.assertEqual(len(result), expected_len)
+
+            os.unlink(tf.name)
 
     @unittest.skip("skipped due to bug in libsndfile < 1.2.1")
     def test_read_mp3(self):


### PR DESCRIPTION
## Description
In #7497 I added a new test (`test_read_wav_1024`) which fails on Windows.

According to the [documentation for `NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html), the temporary file cannot be opened a second time on Windows unless `delete=False` is used. (Elsewhere in GNU Radio's test suite, this approach is used.) Since the file is not automatically deleted, I've also added an `os.unlink()` call to clean up the temporary file.

## Which blocks/areas does this affect?
Tests for Wav File Source.

## Testing Done
Once the test suite runs, we'll see whether the failing test passes across all platforms.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
