### PR TITLE
grc-qt: Improve readability of the PropsDialog

### DIFF
--- a/grc/gui_qt/components/dialogs.py
+++ b/grc/gui_qt/components/dialogs.py
@@ -8,7 +8,7 @@ from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import (QLineEdit, QDialog, QDialogButtonBox, QTreeView,
                             QVBoxLayout, QTabWidget, QGridLayout, QWidget, QLabel,
                             QPushButton, QListWidget, QComboBox, QPlainTextEdit, QHBoxLayout,
-                            QFileDialog, QApplication)
+                            QFileDialog, QApplication, QScrollArea)
 
 
 class ErrorsDialog(QDialog):
@@ -57,7 +57,7 @@ class ErrorsDialog(QDialog):
 class PropsDialog(QDialog):
     def __init__(self, parent_block, force_show_id):
         super().__init__()
-        self.setMinimumSize(600, 400)
+        self.setMinimumSize(700, MIN_DIALOG_HEIGHT)
         self._block = parent_block
         self.qsettings = QApplication.instance().qsettings
         self.setModal(True)
@@ -79,7 +79,6 @@ class PropsDialog(QDialog):
         self.edit_params = []
 
         self.tabs = QTabWidget()
-        error_msg = QLabel()
         ignore_dtype_labels = ["_multiline", "_multiline_python_external", "file_open", "file_save"]
 
         for cat in unique_categories():
@@ -166,7 +165,9 @@ class PropsDialog(QDialog):
                 i += 1
             tab = QWidget()
             tab.setLayout(qvb)
-            self.tabs.addTab(tab, cat)
+            scrollarea = QScrollArea()
+            scrollarea.setWidget(tab)
+            self.tabs.addTab(scrollarea, cat)
 
         # Add example tab
         self.example_tab = QWidget()
@@ -182,8 +183,11 @@ class PropsDialog(QDialog):
         self.layout = QVBoxLayout()
         self.layout.addWidget(self.tabs)
         if self._block.enabled:
+            error_msg = QLabel()
             error_msg.setText('\n'.join(self._block.get_error_messages()))
-        self.layout.addWidget(error_msg)
+            scroll_error = QScrollArea()
+            scroll_error.setWidget(error_msg)
+            self.layout.addWidget(scroll_error)
         self.layout.addWidget(self.buttonBox)
 
         self.setLayout(self.layout)


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
If a block contains many parameters, the PropsDialog is hard to read.

So this pr makes the parameter section scrollable.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
As an example take a QT GUI Frequency sink block.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
