### PR TITLE
Avoid "using namespace std*"

### DIFF
--- a/gr-blocks/tests/benchmark_common.h
+++ b/gr-blocks/tests/benchmark_common.h
@@ -27,7 +27,6 @@
 template <typename functor>
 [[nodiscard]] auto benchmark(functor test, size_t block_size)
 {
-    using namespace std::chrono;
     std::vector<float> outp(2 * block_size);
     float* output = outp.data();
     float *x = &output[0], *y = &output[block_size];
@@ -38,14 +37,16 @@ template <typename functor>
         value = rng() / static_cast<double>(1ULL << 32) - (1ULL << 32);
     }
 
-    auto before = high_resolution_clock::now();
+    auto before = std::chrono::high_resolution_clock::now();
     // do the actual work
 
     test(x, y);
 
-    auto after = high_resolution_clock::now();
+    auto after = std::chrono::high_resolution_clock::now();
     // get ending CPU usage
-    auto dur = duration_cast<duration<double, std::ratio<1, 1>>>(after - before);
+    auto dur =
+        std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1>>>(
+            after - before);
 
     // prevent the compiler from discarding the output, not doing the calculations.
     volatile auto sum = std::accumulate(outp.cbegin(), outp.cend(), 0.0f);

--- a/gr-digital/lib/decision_feedback_equalizer_impl.cc
+++ b/gr-digital/lib/decision_feedback_equalizer_impl.cc
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <memory>
 
-using namespace std;
 namespace gr {
 namespace digital {
 
@@ -63,8 +62,8 @@ decision_feedback_equalizer_impl::decision_feedback_equalizer_impl(
                                                                      sizeof(gr_complex)),
                                                                sizeof(unsigned short) }),
                          sps),
-      filter::kernel::fir_filter_ccc(
-          vector<gr_complex>(num_taps_forward + num_taps_feedback, gr_complex(0, 0))),
+      filter::kernel::fir_filter_ccc(std::vector<gr_complex>(
+          num_taps_forward + num_taps_feedback, gr_complex(0, 0))),
       d_num_taps_fwd(num_taps_forward),
       d_num_taps_rev(num_taps_feedback),
       d_sps(sps),
@@ -116,9 +115,9 @@ int decision_feedback_equalizer_impl::work(int noutput_items,
     }
 
     unsigned long int nread = nitems_read(0);
-    vector<tag_t> tags;
+    std::vector<tag_t> tags;
     get_tags_in_window(tags, 0, 0, noutput_items * decimation(), d_training_start_tag);
-    vector<unsigned int> training_start_samples(tags.size());
+    std::vector<unsigned int> training_start_samples(tags.size());
     unsigned int tag_index = 0;
     for (const auto& tag : tags) {
         training_start_samples[tag_index++] = tag.offset - nread;
@@ -146,14 +145,14 @@ int decision_feedback_equalizer_impl::work(int noutput_items,
                     state);
 }
 
-void decision_feedback_equalizer_impl::set_taps(const vector<gr_complex>& taps)
+void decision_feedback_equalizer_impl::set_taps(const std::vector<gr_complex>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
     d_new_taps = taps;
     d_updated = true;
 }
 
-vector<gr_complex> decision_feedback_equalizer_impl::taps() const
+std::vector<gr_complex> decision_feedback_equalizer_impl::taps() const
 {
     gr::thread::scoped_lock guard(d_mutex);
     return d_taps;

--- a/gr-digital/lib/linear_equalizer_impl.cc
+++ b/gr-digital/lib/linear_equalizer_impl.cc
@@ -21,7 +21,6 @@
 #include "adaptive_algorithms.h"
 
 using namespace pmt;
-using namespace std;
 
 namespace gr {
 namespace digital {
@@ -54,7 +53,7 @@ linear_equalizer_impl::linear_equalizer_impl(unsigned num_taps,
                                              num_taps * sizeof(gr_complex),
                                              sizeof(unsigned short)),
                          sps),
-      filter::kernel::fir_filter_ccc(vector<gr_complex>(num_taps, gr_complex(0, 0))),
+      filter::kernel::fir_filter_ccc(std::vector<gr_complex>(num_taps, gr_complex(0, 0))),
       d_num_taps(num_taps),
       d_sps(sps),
       d_alg(alg),
@@ -76,18 +75,18 @@ linear_equalizer_impl::linear_equalizer_impl(unsigned num_taps,
     filter::kernel::fir_filter_ccc::set_taps(d_new_taps);
 
     const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
-    set_alignment(max(1, alignment_multiple));
+    set_alignment(std::max(1, alignment_multiple));
     set_history(num_taps);
 }
 
-void linear_equalizer_impl::set_taps(const vector<gr_complex>& taps)
+void linear_equalizer_impl::set_taps(const std::vector<gr_complex>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
     d_new_taps = taps;
     d_updated = true;
 }
 
-vector<gr_complex> linear_equalizer_impl::taps() const
+std::vector<gr_complex> linear_equalizer_impl::taps() const
 {
     gr::thread::scoped_lock guard(d_mutex);
     return d_taps;
@@ -197,9 +196,9 @@ int linear_equalizer_impl::work(int noutput_items,
     }
 
     unsigned long int nread = nitems_read(0);
-    vector<tag_t> tags;
+    std::vector<tag_t> tags;
     get_tags_in_window(tags, 0, 0, noutput_items * decimation(), d_training_start_tag);
-    vector<unsigned int> training_start_samples(tags.size());
+    std::vector<unsigned int> training_start_samples(tags.size());
     unsigned int tag_index = 0;
     for (const auto& tag : tags) {
         training_start_samples[tag_index++] = tag.offset - nread;


### PR DESCRIPTION
## Description
`using namespace std;` is discouraged, because it can lead to namespace conflicts when updating to a newer version of the standard C++ library. Here I have removed the handful of usages that were in GNU Radio.

## Which blocks/areas does this affect?
* Decision Feedback Equalizer
* Linear Equalizer
* Benchmarking code for NCO & VCO

## Testing Done
None yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
