### PR TITLE
grc: Fix block overlapping on HiDPI screens

### DIFF
--- a/grc/gui_qt/Constants.py
+++ b/grc/gui_qt/Constants.py
@@ -87,10 +87,17 @@ Please consider contacting OOT module maintainer for any block in here \
 and kindly ask to update their GRC Block Descriptions or Block Tree to include a module name."""
 
 
-# _SCREEN = Gdk.Screen.get_default()
-# _SCREEN_RESOLUTION = _SCREEN.get_resolution() if _SCREEN else -1
-# DPI_SCALING = _SCREEN_RESOLUTION / 96.0 if _SCREEN_RESOLUTION > 0 else 1.0
-DPI_SCALING = 1.0  # todo: figure out the GTK3 way (maybe cairo does this for us
+from qtpy.QtWidgets import QApplication
+
+def get_dpi_scaling():
+    if not QApplication.instance():
+        return 1.0
+    screen = QApplication.instance().primaryScreen()
+    if not screen:
+        return 1.0
+    return screen.logicalDotsPerInch() / 96.0
+
+DPI_SCALING = get_dpi_scaling()  # Get proper scaling factor from Qt
 
 '''
 # Gtk-themes classified as dark
@@ -119,3 +126,4 @@ def update_font_size(font_size):
 
 
 update_font_size(DEFAULT_FONT_SIZE)
+

--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -77,8 +77,6 @@ class GUIBlock(QGraphicsItem):
         font_size = int(10 * Constants.DPI_SCALING)
         self.font = QFont("Helvetica", font_size)
 
-
-
         self.create_shapes_and_labels()
 
         if "coordinate" not in self.core.states.keys():
@@ -148,9 +146,6 @@ class GUIBlock(QGraphicsItem):
                     min_height -= ports[-1].gui.height
             return min_height
 
-                if ports:
-                    min_height -= ports[-1].gui.height
-            return min_height
 
         self.height = max(
             self.height,
@@ -205,9 +200,9 @@ class GUIBlock(QGraphicsItem):
             if not ports:
                 continue
             port_separation = (
-                Constants.PORT_SEPARATION
+                int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
                 if not has_busses
-                else ports[0].gui.height + Constants.PORT_SPACING
+                else ports[0].gui.height + int(Constants.PORT_SPACING * Constants.DPI_SCALING)
             )
             offset = (
                 self.height - (len(ports) - 1) * port_separation - ports[0].gui.height
@@ -222,18 +217,15 @@ class GUIBlock(QGraphicsItem):
                 offset += (
                     int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
                     if not has_busses
-
-
-                offset += (
-                    int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
-                    if not has_busses
                     else port.gui.height + int(Constants.PORT_SPACING * Constants.DPI_SCALING)
                 )
+
 
 
         self._update_colors()
         self.create_port_labels()
         self.setTransformOriginPoint(self.width / 2, self.height / 2)
+
 
     def create_port_labels(self):
         for ports in (self.core.active_sinks, self.core.active_sources):
@@ -446,6 +438,11 @@ class GUIBlock(QGraphicsItem):
     def open_properties(self):
         self.props_dialog = PropsDialog(self.core, self.force_show_id)
         self.props_dialog.show()
+
+
+
+
+
 
 
 

--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -73,7 +73,10 @@ class GUIBlock(QGraphicsItem):
         super(GUIBlock, self).__init__()
         self.core = core
         self.parent = self.scene()
-        self.font = QFont("Helvetica", 10)
+        # Scale font size with DPI
+        font_size = int(10 * Constants.DPI_SCALING)
+        self.font = QFont("Helvetica", font_size)
+
 
         self.create_shapes_and_labels()
 
@@ -111,30 +114,32 @@ class GUIBlock(QGraphicsItem):
         self.font.setBold(True)
 
         # figure out height of block based on how many params there are
-        i = 35
+        base_height = int(35 * Constants.DPI_SCALING)
+        param_height = int(20 * Constants.DPI_SCALING)
+        i = base_height
 
         # Check if we need to increase the height to fit all the ports
         for key, item in self.core.params.items():
             value = item.value
             if (value is not None and item.hide == "none") or (item.dtype == 'id' and self.force_show_id):
-                i += 20
+                i += param_height
 
         self.height = i
 
         def get_min_height_for_ports(ports):
             min_height = (
-                2 * Constants.PORT_BORDER_SEPARATION +
-                len(ports) * Constants.PORT_SEPARATION
+                2 * int(Constants.PORT_BORDER_SEPARATION * Constants.DPI_SCALING) +
+                len(ports) * int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
             )
             # If any of the ports are bus ports - make the min height larger
             if any([p.dtype == "bus" for p in ports]):
                 min_height = (
-                    2 * Constants.PORT_BORDER_SEPARATION +
+                    2 * int(Constants.PORT_BORDER_SEPARATION * Constants.DPI_SCALING) +
                     sum(
-                        port.gui.height + Constants.PORT_SPACING
+                        port.gui.height + int(Constants.PORT_SPACING * Constants.DPI_SCALING)
                         for port in ports
                         if port.dtype == "bus"
-                    ) - Constants.PORT_SPACING
+                    ) - int(Constants.PORT_SPACING * Constants.DPI_SCALING)
                 )
 
             else:
@@ -204,16 +209,17 @@ class GUIBlock(QGraphicsItem):
             ) / 2
             for port in ports:
                 if port._dir == "sink":
-                    port.gui.setPos(-15, offset)
+                    port.gui.setPos(int(-15 * Constants.DPI_SCALING), offset)
                 else:
                     port.gui.setPos(self.width, offset)
                 port.gui.create_shapes_and_labels()
 
                 offset += (
-                    Constants.PORT_SEPARATION
+                    int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
                     if not has_busses
-                    else port.gui.height + Constants.PORT_SPACING
+                    else port.gui.height + int(Constants.PORT_SPACING * Constants.DPI_SCALING)
                 )
+
 
         self._update_colors()
         self.create_port_labels()
@@ -291,14 +297,17 @@ class GUIBlock(QGraphicsItem):
             painter.rotate(180)
             painter.translate(-self.width / 2, -self.height / 2)
 
+        # Scale text position with DPI
+        label_offset = int(15 * Constants.DPI_SCALING)
         painter.drawText(
-            QRectF(0, 0 - self.height / 2 + 15, self.width, self.height),
+            QRectF(0, 0 - self.height / 2 + label_offset, self.width, self.height),
             Qt.AlignCenter,
             self.core.label,
         )
 
-        # Draw param text
-        y_offset = 30  # params start 30 down from the top of the box
+        # Draw param text with scaled offset
+        y_offset = int(30 * Constants.DPI_SCALING)  # params start down from the top of the box
+
         for key, item in self.core.params.items():
             name = item.name
             value = item.value
@@ -427,3 +436,7 @@ class GUIBlock(QGraphicsItem):
     def open_properties(self):
         self.props_dialog = PropsDialog(self.core, self.force_show_id)
         self.props_dialog.show()
+
+
+
+

--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -78,6 +78,7 @@ class GUIBlock(QGraphicsItem):
         self.font = QFont("Helvetica", font_size)
 
 
+
         self.create_shapes_and_labels()
 
         if "coordinate" not in self.core.states.keys():
@@ -112,7 +113,6 @@ class GUIBlock(QGraphicsItem):
         self.show_param_val = qsettings.value('grc/show_param_val', type=bool)
         self.prepareGeometryChange()
         self.font.setBold(True)
-
         # figure out height of block based on how many params there are
         base_height = int(35 * Constants.DPI_SCALING)
         param_height = int(20 * Constants.DPI_SCALING)
@@ -125,6 +125,7 @@ class GUIBlock(QGraphicsItem):
                 i += param_height
 
         self.height = i
+
 
         def get_min_height_for_ports(ports):
             min_height = (
@@ -143,6 +144,10 @@ class GUIBlock(QGraphicsItem):
                 )
 
             else:
+                if ports:
+                    min_height -= ports[-1].gui.height
+            return min_height
+
                 if ports:
                     min_height -= ports[-1].gui.height
             return min_height
@@ -213,6 +218,11 @@ class GUIBlock(QGraphicsItem):
                 else:
                     port.gui.setPos(self.width, offset)
                 port.gui.create_shapes_and_labels()
+
+                offset += (
+                    int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
+                    if not has_busses
+
 
                 offset += (
                     int(Constants.PORT_SEPARATION * Constants.DPI_SCALING)
@@ -436,6 +446,11 @@ class GUIBlock(QGraphicsItem):
     def open_properties(self):
         self.props_dialog = PropsDialog(self.core, self.force_show_id)
         self.props_dialog.show()
+
+
+
+
+
 
 
 


### PR DESCRIPTION
Fix issue #7026

- Add proper DPI scaling detection using Qt's logicalDotsPerInch
- Scale block dimensions, fonts, and spacing based on DPI
- Scale port positions and text offsets

This PR fixes the block overlapping issue on HiDPI screens by properly scaling all dimensions and spacing based on the screen's DPI settings.