### PR TITLE
blocks: Fix useless sample size functions in wavfile_sink.

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
@@ -66,10 +66,8 @@ public:
     virtual void set_sample_rate(unsigned int sample_rate) = 0;
 
     /*!
-     * \brief Set bits per sample. This will not affect the WAV file
-     * currently opened (see set_sample_rate()). If the value is
-     * neither 8 nor 16, the call is ignored and the current value
-     * is kept.
+     * \brief Currently, this function does nothing. Bits per sample
+     * are controlled by the subformat.
      */
     virtual void set_bits_per_sample(int bits_per_sample) = 0;
 

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -301,8 +301,8 @@ int wavfile_sink_impl::work(int noutput_items,
 
 void wavfile_sink_impl::set_bits_per_sample(int bits_per_sample)
 {
-    d_logger->warn(
-        "set_bits_per_sample() does nothing. Sample size is controlled by the subformat.");
+    d_logger->warn("set_bits_per_sample() does nothing. Sample size is controlled by the "
+                   "subformat.");
 }
 
 void wavfile_sink_impl::set_append(bool append)

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -302,7 +302,7 @@ int wavfile_sink_impl::work(int noutput_items,
 void wavfile_sink_impl::set_bits_per_sample(int bits_per_sample)
 {
     d_logger->warn(
-        "set_bits_per_sample() does nothing. Bit size is controlled by the subformat.");
+        "set_bits_per_sample() does nothing. Sample size is controlled by the subformat.");
 }
 
 void wavfile_sink_impl::set_append(bool append)

--- a/gr-blocks/lib/wavfile_sink_impl.h
+++ b/gr-blocks/lib/wavfile_sink_impl.h
@@ -23,7 +23,6 @@ class wavfile_sink_impl : public wavfile_sink
 {
 private:
     wav_header_info d_h;
-    int d_bytes_per_sample_new;
     bool d_append;
 
     std::vector<float> d_buffer;
@@ -42,11 +41,6 @@ private:
      * hand.
      */
     void do_update();
-
-    /*!
-     * \brief Implementation of set_bits_per_sample without mutex lock.
-     */
-    void set_bits_per_sample_unlocked(int bits_per_sample);
 
     /*!
      * \brief Writes information to the WAV header which is not available

--- a/gr-blocks/python/blocks/bindings/wavfile_sink_python.cc
+++ b/gr-blocks/python/blocks/bindings/wavfile_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(wavfile_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(22c6a3912c7f989ac2a701baa6581e9c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8c1882e99e61201369b0d102174a42cc)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
The current wavfile_sink block API has getter and
setter functions for the sample bit size. However, the setter function's
value is ignored because the sample size is fully determined 
by the file format and subformat. Additionally, the code is inconsistent, 
as the getter returns bytes instead of bits, and there is a risk 
of using uninitialized memory.

This update removes unnecessary operations and
resolves the inconsistency between bits and bytes.

## Related Issue
This is preparation before solving 
https://github.com/gnuradio/gnuradio/issues/7456 

## Which blocks/areas does this affect?
wawfile_sink

## Testing Done
make test

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
