### PR TITLE
runtime: fix OpenBSD doesn't have prctl()

### DIFF
--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -135,7 +135,7 @@ void set_thread_name(gr_thread_t thread, std::string name)
 
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) ||     \
     defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
-    defined(__NetBSD__)
+    defined(__NetBSD__) || defined(__OpenBSD__)
 
 namespace gr {
 namespace thread {

--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -137,6 +137,10 @@ void set_thread_name(gr_thread_t thread, std::string name)
     defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
     defined(__NetBSD__) || defined(__OpenBSD__)
 
+#include <pthread.h>
+#ifdef __OpenBSD__
+#include <pthread_np.h>
+#endif
 namespace gr {
 namespace thread {
 
@@ -199,6 +203,9 @@ int set_thread_priority(gr_thread_t thread, int priority)
 void set_thread_name(gr_thread_t thread, std::string name)
 {
     // Not implemented on OSX
+#ifdef __OpenBSD__
+    pthread_set_name_np(thread, name.c_str());
+#endif
 }
 
 } /* namespace thread */


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description

working on updating our aging gnuradio port from 3.8.2 to 3.10.11, upstreaming the patches we have that make sense..

## Which blocks/areas does this affect?
gnuradio-runtime
## Testing Done

zero runtime testing, patch builds in the context of the 3.10.11 release.

i've called out SDR users on OpenBSD to test the port update.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
