### PR TITLE
blocks: Reopen wavfile_sink after stop().

### DIFF
--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -99,133 +99,143 @@ wavfile_sink_impl::wavfile_sink_impl(const char* filename,
 
 bool wavfile_sink_impl::open(const char* filename)
 {
-    SF_INFO sfinfo;
-
     gr::thread::scoped_lock guard(d_mutex);
+    d_filename = filename;
 
     if (d_new_fp) { // if we've already got a new one open, close it
         sf_close(d_new_fp);
         d_new_fp = nullptr;
     }
 
-    if (d_append) {
-        // We are appending to an existing file, be extra careful here.
-        sfinfo.format = 0;
-        errno = 0;
-        if (!(d_new_fp = sf_open(filename, SFM_RDWR, &sfinfo))) {
-            if (errno) {
-                d_logger->error(
-                    "sf_open(1) failed: {:s}: {:s}", filename, strerror(errno));
-            } else {
-                d_logger->error(
-                    "sf_open(1) failed: {:s}: {:s}", filename, sf_strerror(NULL));
-            }
+    bool isOpen = d_append ? open_file_for_append() : open_file_for_rewrite();
+    return isOpen;
+}
 
-            return false;
-        }
-        if (d_h.sample_rate != sfinfo.samplerate || d_h.nchans != sfinfo.channels ||
-            d_h.format != (sfinfo.format & SF_FORMAT_TYPEMASK) ||
-            d_h.subformat != (sfinfo.format & SF_FORMAT_SUBMASK)) {
-            d_logger->error("Existing WAV file is incompatible with configured options.");
-            sf_close(d_new_fp);
-            return false;
-        }
-        if (sf_seek(d_new_fp, 0, SEEK_END) == -1) {
-            d_logger->error("Seek error.");
-            return false; // This can only happen if the file disappears under our feet.
-        }
-    } else {
-        memset(&sfinfo, 0, sizeof(sfinfo));
-        sfinfo.samplerate = d_h.sample_rate;
-        sfinfo.channels = d_h.nchans;
-        switch (d_h.format) {
-        case FORMAT_WAV:
-            switch (d_h.subformat) {
-            case FORMAT_PCM_U8:
-                sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_U8);
-                break;
-            case FORMAT_PCM_16:
-                sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_16);
-                break;
-            case FORMAT_PCM_24:
-                sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_24);
-                break;
-            case FORMAT_PCM_32:
-                sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_32);
-                break;
-            case FORMAT_FLOAT:
-                sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_FLOAT);
-                break;
-            case FORMAT_DOUBLE:
-                sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_DOUBLE);
-                break;
-            }
-            break;
-        case FORMAT_FLAC:
-            switch (d_h.subformat) {
-            case FORMAT_PCM_S8:
-                sfinfo.format = (SF_FORMAT_FLAC | SF_FORMAT_PCM_S8);
-                break;
-            case FORMAT_PCM_16:
-                sfinfo.format = (SF_FORMAT_FLAC | SF_FORMAT_PCM_16);
-                break;
-            case FORMAT_PCM_24:
-                sfinfo.format = (SF_FORMAT_FLAC | SF_FORMAT_PCM_24);
-                break;
-            }
-            break;
-        case FORMAT_OGG:
-            switch (d_h.subformat) {
-            case FORMAT_VORBIS:
-                sfinfo.format = (SF_FORMAT_OGG | SF_FORMAT_VORBIS);
-                break;
-            case FORMAT_OPUS:
-#ifdef HAVE_SF_FORMAT_OPUS
-                sfinfo.format = (SF_FORMAT_OGG | SF_FORMAT_OPUS);
-#else
-                throw std::runtime_error("libsndfile < 1.0.29 does not support Opus.");
-#endif
-                break;
-            }
-            break;
-        case FORMAT_RF64:
-            switch (d_h.subformat) {
-            case FORMAT_PCM_U8:
-                sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_U8);
-                break;
-            case FORMAT_PCM_16:
-                sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_16);
-                break;
-            case FORMAT_PCM_24:
-                sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_24);
-                break;
-            case FORMAT_PCM_32:
-                sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_32);
-                break;
-            case FORMAT_FLOAT:
-                sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_FLOAT);
-                break;
-            case FORMAT_DOUBLE:
-                sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_DOUBLE);
-                break;
-            }
-            break;
-        }
-        errno = 0;
-        if (!(d_new_fp = sf_open(filename, SFM_WRITE, &sfinfo))) {
-            if (errno) {
-                d_logger->error(
-                    "sf_open(2) failed: {:s}: {:s}", filename, strerror(errno));
-            } else {
-                d_logger->error(
-                    "sf_open(2) failed: {:s}: {:s}", filename, sf_strerror(NULL));
-            }
+bool wavfile_sink_impl::open_file_for_append()
+{
+    SF_INFO sfinfo;
 
-            return false;
+    // We are appending to an existing file, be extra careful here.
+    sfinfo.format = 0;
+    errno = 0;
+    if (!(d_new_fp = sf_open(d_filename.c_str(), SFM_RDWR, &sfinfo))) {
+        if (errno) {
+            d_logger->error("sf_open(1) failed: {:s}: {:s}", d_filename, strerror(errno));
+        } else {
+            d_logger->error(
+                "sf_open(1) failed: {:s}: {:s}", d_filename, sf_strerror(NULL));
         }
+
+        return false;
+    }
+    if (d_h.sample_rate != sfinfo.samplerate || d_h.nchans != sfinfo.channels ||
+        d_h.format != (sfinfo.format & SF_FORMAT_TYPEMASK) ||
+        d_h.subformat != (sfinfo.format & SF_FORMAT_SUBMASK)) {
+        d_logger->error("Existing WAV file is incompatible with configured options.");
+        sf_close(d_new_fp);
+        return false;
+    }
+    if (sf_seek(d_new_fp, 0, SEEK_END) == -1) {
+        d_logger->error("Seek error.");
+        return false; // This can only happen if the file disappears under our feet.
     }
     d_updated = true;
+    return true;
+}
 
+bool wavfile_sink_impl::open_file_for_rewrite()
+{
+
+    SF_INFO sfinfo;
+    memset(&sfinfo, 0, sizeof(sfinfo));
+    sfinfo.samplerate = d_h.sample_rate;
+    sfinfo.channels = d_h.nchans;
+    switch (d_h.format) {
+    case FORMAT_WAV:
+        switch (d_h.subformat) {
+        case FORMAT_PCM_U8:
+            sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_U8);
+            break;
+        case FORMAT_PCM_16:
+            sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_16);
+            break;
+        case FORMAT_PCM_24:
+            sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_24);
+            break;
+        case FORMAT_PCM_32:
+            sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_PCM_32);
+            break;
+        case FORMAT_FLOAT:
+            sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_FLOAT);
+            break;
+        case FORMAT_DOUBLE:
+            sfinfo.format = (SF_FORMAT_WAV | SF_FORMAT_DOUBLE);
+            break;
+        }
+        break;
+    case FORMAT_FLAC:
+        switch (d_h.subformat) {
+        case FORMAT_PCM_S8:
+            sfinfo.format = (SF_FORMAT_FLAC | SF_FORMAT_PCM_S8);
+            break;
+        case FORMAT_PCM_16:
+            sfinfo.format = (SF_FORMAT_FLAC | SF_FORMAT_PCM_16);
+            break;
+        case FORMAT_PCM_24:
+            sfinfo.format = (SF_FORMAT_FLAC | SF_FORMAT_PCM_24);
+            break;
+        }
+        break;
+    case FORMAT_OGG:
+        switch (d_h.subformat) {
+        case FORMAT_VORBIS:
+            sfinfo.format = (SF_FORMAT_OGG | SF_FORMAT_VORBIS);
+            break;
+        case FORMAT_OPUS:
+#ifdef HAVE_SF_FORMAT_OPUS
+            sfinfo.format = (SF_FORMAT_OGG | SF_FORMAT_OPUS);
+#else
+            throw std::runtime_error("libsndfile < 1.0.29 does not support Opus.");
+#endif
+            break;
+        }
+        break;
+    case FORMAT_RF64:
+        switch (d_h.subformat) {
+        case FORMAT_PCM_U8:
+            sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_U8);
+            break;
+        case FORMAT_PCM_16:
+            sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_16);
+            break;
+        case FORMAT_PCM_24:
+            sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_24);
+            break;
+        case FORMAT_PCM_32:
+            sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_PCM_32);
+            break;
+        case FORMAT_FLOAT:
+            sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_FLOAT);
+            break;
+        case FORMAT_DOUBLE:
+            sfinfo.format = (SF_FORMAT_RF64 | SF_FORMAT_DOUBLE);
+            break;
+        }
+        break;
+    }
+    errno = 0;
+    if (!(d_new_fp = sf_open(d_filename.c_str(), SFM_WRITE, &sfinfo))) {
+        if (errno) {
+            d_logger->error("sf_open(2) failed: {:s}: {:s}", d_filename, strerror(errno));
+        } else {
+            d_logger->error(
+                "sf_open(2) failed: {:s}: {:s}", d_filename, sf_strerror(NULL));
+        }
+
+        return false;
+    }
+
+    d_updated = true;
     return true;
 }
 
@@ -255,6 +265,21 @@ bool wavfile_sink_impl::stop()
         d_new_fp = nullptr;
     }
     close();
+    d_should_reopen = true;
+
+    return true;
+}
+
+bool wavfile_sink_impl::start()
+{
+    gr::thread::scoped_lock guard(d_mutex);
+    if (d_should_reopen) {
+        d_should_reopen = false;
+        if (!open_file_for_append()) {
+            d_logger->error("Failed to reopen output file after reconfiguration.");
+            return false;
+        }
+    }
 
     return true;
 }

--- a/gr-blocks/lib/wavfile_sink_impl.h
+++ b/gr-blocks/lib/wavfile_sink_impl.h
@@ -32,6 +32,9 @@ private:
     bool d_updated;
     gr::thread::mutex d_mutex;
 
+    bool d_should_reopen = false;
+    std::string d_filename;
+
     static constexpr int s_items_size = 8192;
     static constexpr int s_max_channels = 24;
 
@@ -50,8 +53,12 @@ private:
      */
     void close_wav();
 
+    bool open_file_for_append();
+    bool open_file_for_rewrite();
+
 protected:
     bool stop() override;
+    bool start() override;
 
 public:
     wavfile_sink_impl(const char* filename,


### PR DESCRIPTION
## Description

The flowgraph uses the stop() method of a block 
to indicate that it has been locked for
configuration. I believe the correct behavior for
file-based sinks is to write all data and headers
to disk, flush the file buffers, but avoid closing the file 
(see also #2590).

This behavior is implemented in the
file_sink. Since the file_sink is very simple and
does not require updating headers, flushing the
file is sufficient.

On the other hand, wavfile_sink can write to
several file formats, some of which include
headers. The implementation relies on libsndfile,
which provides a flush function. However, the
source code indicates that this function does not
update headers before flushing.

The current implementation of wavfile_sink calls
the close() method within the stop() method to
ensure the file on disk is correct. However, this
also closes the file.

My solution is to add a flag for automatic
reopening. When the file is opened, its filename
is stored. When the stop() method is called, the
file is closed, and the automatic reopen flag is
set. Later, within the start() method the file is
automatically reopened in append mode.

## Related Issue
Fixes #7456 .

## Which blocks/areas does this affect?
blocks/wavfile_sink

## Testing Done
- make test
- the reproduction steps from #7456

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
