### PR TITLE
soapy: fix hackrf RF gain value

### DIFF
--- a/gr-soapy/grc/soapy_hackrf_source.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_source.block.yml
@@ -36,7 +36,7 @@ parameters:
     default: 'freq'
 
   - id: amp
-    label: 'Amp On (+14 dB)'
+    label: 'Amp On (+11 dB)'
     category: RF Options
     dtype: bool
     default: 'False'


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The RF gain was erroneously quoted to be 14 dB but in fact this is around 11 dB.
**Source:** https://hackrf.readthedocs.io/en/latest/faq.html#what-gain-controls-are-provided-by-hackrf

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Soapy HackRF Source

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X ] I have squashed my commits to have one significant change per commit. 
- [ X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
