### PR TITLE
Fix image ratio in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # GNU Radio
 
-<table>
+<table align="center">
     <tr>
         <td>
             <img src="./docs/grc_eg.png" height="200px" />

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@
 
 # GNU Radio
 
-<table align="center">
+<table>
     <tr>
         <td>
-            <img src="./docs/grc_eg.png" height="300px" />
+            <img src="./docs/grc_eg.png" height="200px" />
         </td>
         <td>
-            <img src="./docs/grc_eg_code.png" height="300px" />
+            <img src="./docs/grc_eg_code.png" height="200px" />
         </td>
         <td>
-            <img src="./docs/grc_eg_out.png" height="300px" />
+            <img src="./docs/grc_eg_out.png" height="200px" />
         </td>
     </tr>
 </table>


### PR DESCRIPTION
(before change) images look stretched

![image](https://github.com/user-attachments/assets/71d4169d-0183-4e4e-a7dd-4feb70799d4e)
