### PR TITLE
gr-blocks: Add pdu support to mute and selector blocks 

### DIFF
--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2010,2013,2018,2019 Free Software Foundation, Inc.
+ * Copyright 2004,2010,2013,2018,2019,2024 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -9,6 +9,7 @@
  */
 
 
+#include <pmt/pmt.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -36,12 +37,23 @@ mute_impl<T>::mute_impl(bool mute)
 {
     this->message_port_register_in(pmt::intern("set_mute"));
     this->set_msg_handler(pmt::intern("set_mute"),
-                          [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
+                          [this](pmt::pmt_t msg) { this->mute_message_handler(msg); });
 }
 
 template <class T>
 mute_impl<T>::~mute_impl()
 {
+}
+
+template <class T>
+void mute_impl<T>::mute_message_handler(pmt::pmt_t msg) {
+    if (pmt::is_pair(msg)) {
+        this->set_mute(
+                pmt::to_bool(pmt::cdr(msg))
+        ); 
+    } else {
+        this->set_mute(pmt::to_bool(msg));
+    }
 }
 
 template <class T>

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -46,11 +46,10 @@ mute_impl<T>::~mute_impl()
 }
 
 template <class T>
-void mute_impl<T>::mute_message_handler(pmt::pmt_t msg) {
+void mute_impl<T>::mute_message_handler(pmt::pmt_t msg)
+{
     if (pmt::is_pair(msg)) {
-        this->set_mute(
-                pmt::to_bool(pmt::cdr(msg))
-        ); 
+        this->set_mute(pmt::to_bool(pmt::cdr(msg)));
     } else {
         this->set_mute(pmt::to_bool(msg));
     }
@@ -62,7 +61,7 @@ int mute_impl<T>::work(int noutput_items,
                        gr_vector_void_star& output_items)
 {
     const T* in = (const T*)input_items[0];
-    T* out = (T*) output_items[0];
+    T* out = (T*)output_items[0];
 
     if (d_mute) {
         std::fill_n(out, noutput_items, 0);

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -61,28 +61,13 @@ int mute_impl<T>::work(int noutput_items,
                        gr_vector_const_void_star& input_items,
                        gr_vector_void_star& output_items)
 {
-    const T* iptr = (const T*)input_items[0];
-    T* optr = (T*)output_items[0];
-
-    int size = noutput_items;
+    const T* in = (const T*)input_items[0];
+    T* out = (T*) output_items[0];
 
     if (d_mute) {
-        std::fill_n(optr, noutput_items, 0);
+        std::fill_n(out, noutput_items, 0);
     } else {
-        while (size >= 8) {
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            *optr++ = *iptr++;
-            size -= 8;
-        }
-
-        while (size-- > 0)
-            *optr++ = *iptr++;
+        std::copy_n(in, noutput_items, out);
     }
 
     return noutput_items;

--- a/gr-blocks/lib/mute_impl.h
+++ b/gr-blocks/lib/mute_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2013,2018 Free Software Foundation, Inc.
+ * Copyright 2004,2013,2018,2024 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -13,6 +13,7 @@
 #define MUTE_IMPL_H
 
 #include <gnuradio/blocks/mute.h>
+#include <pmt/pmt.h>
 
 namespace gr {
 namespace blocks {
@@ -29,7 +30,7 @@ public:
 
     bool mute() const override { return d_mute; }
     void set_mute(bool mute) override { d_mute = mute; }
-    void set_mute_pmt(pmt::pmt_t msg) { set_mute(pmt::to_bool(msg)); }
+    void mute_message_handler(pmt::pmt_t msg);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -127,11 +127,12 @@ void selector_impl::handle_enable(const pmt::pmt_t& msg)
         gr::thread::scoped_lock l(d_mutex);
         d_enabled = en;
     } else if (pmt::is_pair(msg)) {
-        const bool en = pmt::to_bool(pmt::cdr(msg)); 
+        const bool en = pmt::to_bool(pmt::cdr(msg));
         gr::thread::scoped_lock l(d_mutex);
         d_enabled = en;
     } else {
-        d_logger->warn("handle_enable: Non-PMT type received, expecting Boolean PMT or PDU");
+        d_logger->warn(
+            "handle_enable: Non-PMT type received, expecting Boolean PMT or PDU");
     }
 }
 

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2019 Free Software Foundation, Inc.
+ * Copyright 2019,2024 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -8,6 +8,7 @@
  *
  */
 
+#include "pmt/pmt.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -122,11 +123,15 @@ void selector_impl::handle_msg_output_index(const pmt::pmt_t& msg)
 void selector_impl::handle_enable(const pmt::pmt_t& msg)
 {
     if (pmt::is_bool(msg)) {
-        bool en = pmt::to_bool(msg);
+        const bool en = pmt::to_bool(msg);
+        gr::thread::scoped_lock l(d_mutex);
+        d_enabled = en;
+    } else if (pmt::is_pair(msg)) {
+        const bool en = pmt::to_bool(pmt::cdr(msg)); 
         gr::thread::scoped_lock l(d_mutex);
         d_enabled = en;
     } else {
-        d_logger->warn("handle_enable: Non-PMT type received, expecting Boolean PMT");
+        d_logger->warn("handle_enable: Non-PMT type received, expecting Boolean PMT or PDU");
     }
 }
 

--- a/gr-blocks/python/blocks/qa_mute.py
+++ b/gr-blocks/python/blocks/qa_mute.py
@@ -75,7 +75,6 @@ class test_mute(gr_unittest.TestCase):
         op = blocks.mute_cc(True)
         self.help_cc((src_data,), expected_result, op)
 
-
     def test_unmute_ff(self):
         src_data = [1.5, 2.5, 3.5, 4.5, 5.5]
         expected_result = [1.5, 2.5, 3.5, 4.5, 5.5]

--- a/gr-blocks/python/blocks/qa_mute.py
+++ b/gr-blocks/python/blocks/qa_mute.py
@@ -10,6 +10,7 @@
 
 
 from gnuradio import gr, gr_unittest, blocks
+import pmt
 
 
 class test_mute(gr_unittest.TestCase):
@@ -73,6 +74,19 @@ class test_mute(gr_unittest.TestCase):
         expected_result = [0 + 0j, 0 + 0j, 0 + 0j, 0 + 0j, 0 + 0j]
         op = blocks.mute_cc(True)
         self.help_cc((src_data,), expected_result, op)
+
+
+    def test_unmute_ff(self):
+        src_data = [1.5, 2.5, 3.5, 4.5, 5.5]
+        expected_result = [1.5, 2.5, 3.5, 4.5, 5.5]
+        op = blocks.mute_ff(False)
+        self.help_ff((src_data,), expected_result, op)
+
+    def test_mute_ff(self):
+        src_data = [1.5, 2.5, 3.5, 4.5, 5.5]
+        expected_result = [0.0, 0.0, 0.0, 0.0, 0.0]
+        op = blocks.mute_ff(True)
+        self.help_ff((src_data,), expected_result, op)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
In this pull request the message handlers of the blocks are modified so they can accept both raw-value messages and PDUs.
 It also modifies the code in the work function of the mute block to hopefully make it more readable and adds tests for floating point numbers to the qa code for the mute block.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5099.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Affects the mute block and selector blocks. The _enable_ port of the selector block and the _set-mute_ port of the mute block can now receive both raw pmt messages and PDU messsages.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Manual

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
