### PR TITLE
gr-blocks: Add PDU support to mute and selector blocks

### DIFF
--- a/gr-blocks/lib/mute_impl.h
+++ b/gr-blocks/lib/mute_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2013,2018 Free Software Foundation, Inc.
+ * Copyright 2024 Skandalis Georgios
  *
  * This file is part of GNU Radio
  *
@@ -13,6 +14,7 @@
 #define MUTE_IMPL_H
 
 #include <gnuradio/blocks/mute.h>
+#include <pmt/pmt.h>
 
 namespace gr {
 namespace blocks {
@@ -29,7 +31,7 @@ public:
 
     bool mute() const override { return d_mute; }
     void set_mute(bool mute) override { d_mute = mute; }
-    void set_mute_pmt(pmt::pmt_t msg) { set_mute(pmt::to_bool(msg)); }
+    void mute_message_handler(const pmt::pmt_t& msg);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2019 Free Software Foundation, Inc.
+ * Copyright 2024 Skandalis Georgios
  *
  * This file is part of GNU Radio
  *
@@ -8,6 +9,7 @@
  *
  */
 
+#include "pmt/pmt.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -122,11 +124,16 @@ void selector_impl::handle_msg_output_index(const pmt::pmt_t& msg)
 void selector_impl::handle_enable(const pmt::pmt_t& msg)
 {
     if (pmt::is_bool(msg)) {
-        bool en = pmt::to_bool(msg);
+        const bool en = pmt::to_bool(msg);
+        gr::thread::scoped_lock l(d_mutex);
+        d_enabled = en;
+    } else if (pmt::is_pair(msg)) {
+        const bool en = pmt::to_bool(pmt::cdr(msg));
         gr::thread::scoped_lock l(d_mutex);
         d_enabled = en;
     } else {
-        d_logger->warn("handle_enable: Non-PMT type received, expecting Boolean PMT");
+        d_logger->warn(
+            "handle_enable: Invalid message type received, expected Boolean PMT or PDU");
     }
 }
 

--- a/gr-blocks/python/blocks/qa_mute.py
+++ b/gr-blocks/python/blocks/qa_mute.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2004,2005,2007,2010,2013 Free Software Foundation, Inc.
+# Copyright 2024 Skandalis Georgios
 #
 # This file is part of GNU Radio
 #
@@ -10,6 +11,7 @@
 
 
 from gnuradio import gr, gr_unittest, blocks
+import pmt
 
 
 class test_mute(gr_unittest.TestCase):
@@ -19,6 +21,70 @@ class test_mute(gr_unittest.TestCase):
 
     def tearDown(self):
         self.tb = None
+
+    def test_ff_mute(self):
+        src_arr = [1.0 for i in range(50)]
+        src = blocks.vector_source_f(src_arr, False)
+        dst = blocks.vector_sink_f()
+        mute = blocks.mute_ff(False)
+
+        self.tb.connect(src, mute, dst)
+
+        mute._post(pmt.intern("set_mute"), pmt.from_bool(True))
+
+        self.tb.run()
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertFalse(1.0 in dst.data())
+
+    def test_ff_unmute(self):
+        src_arr = [1.0 for i in range(50)]
+        src = blocks.vector_source_f(src_arr, False)
+        dst = blocks.vector_sink_f()
+        mute = blocks.mute_ff(False)
+
+        self.tb.connect(src, mute, dst)
+
+        mute._post(pmt.intern("set_mute"), pmt.from_bool(False))
+
+        self.tb.run()
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertFalse(0.0 in dst.data())
+
+    def test_ff_mute_pdu(self):
+        src_arr = [1.0 for i in range(50)]
+        src = blocks.vector_source_f(src_arr, False)
+        dst = blocks.vector_sink_f()
+        mute = blocks.mute_ff(False)
+
+        self.tb.connect(src, mute, dst)
+
+        mute._post(pmt.intern("set_mute"), pmt.cons(pmt.PMT_NIL, pmt.from_bool(True)))
+
+        self.tb.run()
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertFalse(1.0 in dst.data())
+
+    def test_ff_unmute_pdu(self):
+        src_arr = [1.0 for i in range(50)]
+        src = blocks.vector_source_f(src_arr, False)
+        dst = blocks.vector_sink_f()
+        mute = blocks.mute_ff(True)
+
+        self.tb.connect(src, mute, dst)
+
+        mute._post(pmt.intern("set_mute"), pmt.cons(pmt.PMT_NIL, pmt.from_bool(False)))
+
+        self.tb.run()
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertFalse(0.0 in dst.data())
 
     def help_ii(self, src_data, exp_data, op):
         for s in zip(list(range(len(src_data))), src_data):
@@ -30,11 +96,11 @@ class test_mute(gr_unittest.TestCase):
         result_data = dst.data()
         self.assertEqual(exp_data, result_data)
 
-    def help_ff(self, src_data, exp_data, op):
+    def help_ss(self, src_data, exp_data, op):
         for s in zip(list(range(len(src_data))), src_data):
-            src = blocks.vector_source_f(s[1])
+            src = blocks.vector_source_s(s[1])
             self.tb.connect(src, (op, s[0]))
-        dst = blocks.vector_sink_f()
+        dst = blocks.vector_sink_s()
         self.tb.connect(op, dst)
         self.tb.run()
         result_data = dst.data()
@@ -61,6 +127,18 @@ class test_mute(gr_unittest.TestCase):
         expected_result = [0, 0, 0, 0, 0]
         op = blocks.mute_ii(True)
         self.help_ii((src_data,), expected_result, op)
+
+    def test_unmute_cc(self):
+        src_data = [1, 2, 3, 4, 5]
+        expected_result = [1, 2, 3, 4, 5]
+        op = blocks.mute_ss(False)
+        self.help_ss((src_data,), expected_result, op)
+
+    def test_mute_cc(self):
+        src_data = [1, 2, 3, 4, 5]
+        expected_result = [1, 2, 3, 4, 5]
+        op = blocks.mute_ss(True)
+        self.help_ss((src_data,), expected_result, op)
 
     def test_unmute_cc(self):
         src_data = [1 + 5j, 2 + 5j, 3 + 5j, 4 + 5j, 5 + 5j]


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
 Changed the message handlers of the mute and selector blocks so they can receive pdu messages.
Also added a qa test for floats for the mute block and simplified the work function of the mute block
in an attempt to make it more readable.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5099 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
The _set-mute_ port of the mute block and the _en_ port of the selector block now 
can receive both raw PMT values and PDUs as messages.
The work function of the mute block was simplified as the old version was not easy to read,
specifically the code that handled forwarding the input values.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Manual

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
