### PR TITLE
GRC Qt: Prevent redundant undo actions

### DIFF
--- a/grc/gui_qt/components/canvas/flowgraph.py
+++ b/grc/gui_qt/components/canvas/flowgraph.py
@@ -341,6 +341,7 @@ class FlowgraphScene(QtWidgets.QGraphicsScene, base.Component):
                 self.start_port = None
                 self.end_port = None
         self.mousePressed = False
+        self.moving_blocks = False
         super(FlowgraphScene, self).mouseReleaseEvent(event)
 
     def createActions(self, actions):

--- a/grc/gui_qt/components/undoable_actions.py
+++ b/grc/gui_qt/components/undoable_actions.py
@@ -61,6 +61,9 @@ class RotateAction(QUndoCommand):
 
 class MoveAction(QUndoCommand):
     def __init__(self, scene: FlowgraphScene, diff: QPointF):
+        # Prevent empty undo actions if the block hasn't moved
+        if diff.isNull():
+            return
         QUndoCommand.__init__(self)
         log.debug("init MoveAction")
         self.setText('Move')
@@ -87,6 +90,7 @@ class MoveAction(QUndoCommand):
         for g_block in self.g_blocks:
             g_block.move(-self.x, -self.y)
         self.scene.update()
+
 
 
 class EnableAction(ChangeStateAction):

--- a/grc/gui_qt/components/undoable_actions.py
+++ b/grc/gui_qt/components/undoable_actions.py
@@ -92,7 +92,6 @@ class MoveAction(QUndoCommand):
         self.scene.update()
 
 
-
 class EnableAction(ChangeStateAction):
     def __init__(self, scene: FlowgraphScene):
         ChangeStateAction.__init__(self, scene)


### PR DESCRIPTION
## Description
Fixes the issue where two undo actions were added when moving blocks in GRC Qt. This occurred because an empty undo action was being added if the block was deselected after moving it.

## Related Issue
Fixes #7611  

## Which blocks/areas does this affect?
- Affects the **MoveAction** functionality in the **undoable_actions.py** file.
- This fix affects the undo/redo behavior in the GRC Qt interface, specifically preventing redundant actions from being added to the undo stack when blocks are moved.

## Testing Done
- Tested by moving blocks in the GRC Qt interface, deselecting the blocks, and using Ctrl+Z to undo the action.
- Verified that only one undo action is added, and that it correctly reverts the block movement.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit.
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed).
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
