### PR TITLE
analog: add end-to-end test for quadrature demod block

### DIFF
--- a/gr-analog/python/analog/qa_quadrature_demod.py
+++ b/gr-analog/python/analog/qa_quadrature_demod.py
@@ -48,6 +48,24 @@ class test_quadrature_demod(gr_unittest.TestCase):
         result_data = dst.data()
         self.assertComplexTuplesAlmostEqual(expected_result, result_data, 5)
 
+    def test_fm_end_to_end_002(self):
+        f = 1000.0
+        fs = 8000.0
+        src = analog.sig_source_f(fs, analog.gr_waveform_t.GR_COS_WAVE, f, 1.0)
+        head = blocks.head(gr.sizeof_float, 100)
+        sensitivity = cmath.pi / 4
+        fm = analog.frequency_modulator_fc(sensitivity)
+        quad_demod = analog.quadrature_demod_cf(1.0 / sensitivity)
+        sink_signal = blocks.vector_sink_f()
+        sink_demod = blocks.vector_sink_f()
+        self.tb.connect(src, head, sink_signal)
+        self.tb.connect(head, fm, quad_demod, sink_demod)
+        self.tb.run()
+        expected_result = sink_signal.data()
+        expected_result[0] = 0.0
+        result_data = sink_demod.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, result_data, 5)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_quadrature_demod)


### PR DESCRIPTION
## Description
Add unit test for the quadrature demod block to verify that it can decode frequency modulated signals.

## Related Issue
Fixes #2020

## Which blocks/areas does this affect?
analog.quadrature_demod_cf

## Testing Done
Ran "make test" before and after changes to ensure all tests pass

## Checklist
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
