### PR TITLE
Document that tags are already sorted, don't sort them

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -852,6 +852,8 @@ protected:
      *
      * Range of counts is from start to end-1.
      *
+     * The vector is sorted ascendingly by the offset of the tags.
+     *
      * Tags are tuples of:
      *      (item count, source id, key, value)
      *
@@ -870,6 +872,8 @@ protected:
      * range with a given key.
      *
      * Range of counts is from start to end-1.
+     *
+     * The vector is sorted ascendingly by the offset of the tags.
      *
      * Tags are tuples of:
      *      (item count, source id, key, value)
@@ -898,6 +902,8 @@ protected:
      *
      * Range of items counts from \p rel_start to \p rel_end-1 within
      * current window.
+     *
+     * The vector is sorted ascendingly by the offset of the tags.
      *
      * Tags are tuples of:
      *      (item count, source id, key, value)

--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -137,6 +137,8 @@ public:
      * a secondary filter to the tags to extract only tags with the
      * given 'key'.
      *
+     * The vector is sorted ascendingly by the offset of the tags.
+     *
      * Tags are tuples of:
      *      (item count, source id, key, value)
      *

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -168,7 +168,7 @@ void block_detail::add_item_tag(unsigned int which_output, const tag_t& tag)
     if (!pmt::is_symbol(tag.key)) {
         throw pmt::wrong_type("block_detail::add_item_tag key", tag.key);
     } else {
-        // Add tag to gr_buffer's deque tags
+        // add tag to gr_buffer_reader's (multi) map of tags
         d_output[which_output]->add_item_tag(tag);
     }
 }
@@ -178,7 +178,7 @@ void block_detail::get_tags_in_range(std::vector<tag_t>& v,
                                      uint64_t abs_start,
                                      uint64_t abs_end)
 {
-    // get from gr_buffer_reader's deque of tags
+    // get from gr_buffer_reader's (multi) map of tags
     d_input[which_input]->get_tags_in_range(v, abs_start, abs_end);
 }
 
@@ -192,7 +192,7 @@ void block_detail::get_tags_in_range(std::vector<tag_t>& v,
 
     v.resize(0);
 
-    // get from gr_buffer_reader's deque of tags
+    // get from gr_buffer_reader's (multi) map of tags
     d_input[which_input]->get_tags_in_range(found_items, abs_start, abs_end);
 
     // Filter further by key name

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(745e706ac4988d6d63e0ca5dd21e59cd)                     */
+/* BINDTOOL_HEADER_FILE_HASH(35fc0a5a9d85b84b81d15db7c96c8faa)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -214,7 +214,6 @@ void symbol_sync_cc_impl::collect_tags(uint64_t nitems_rd, int count)
     d_new_tags.clear();
     get_tags_in_range(d_new_tags, 0, nitems_rd, nitems_rd + count);
     d_tags.insert(d_tags.end(), d_new_tags.begin(), d_new_tags.end());
-    std::sort(d_tags.begin(), d_tags.end(), tag_t::offset_compare);
 }
 
 bool symbol_sync_cc_impl::find_sync_tag(uint64_t nitems_rd,

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -217,7 +217,6 @@ void symbol_sync_ff_impl::collect_tags(uint64_t nitems_rd, int count)
     d_new_tags.clear();
     get_tags_in_range(d_new_tags, 0, nitems_rd, nitems_rd + count);
     d_tags.insert(d_tags.end(), d_new_tags.begin(), d_new_tags.end());
-    std::sort(d_tags.begin(), d_tags.end(), tag_t::offset_compare);
 }
 
 bool symbol_sync_ff_impl::find_sync_tag(uint64_t nitems_rd,


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

`block::get_tags_in_range` fills the passed vector in a sorted manner. That became the case after we replaced the deque implementation with a `std::multimap<uint64_t offset, tag_t tag>` somewhen after GRCon'14.

`gr-uhd` definitely already depends on that, and a lot of other places do, as well. So, we should document this behaviour.

Also, we should remove the remaining places where we still sorted the vector.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Closes #7621

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Only documentation

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
