### PR TITLE
Avoid using namespace for std all larger namespaces (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/pmt/qa_pmt_unv.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_unv.cc
@@ -13,7 +13,6 @@
 #include <pmt/pmt.h>
 #include <boost/test/unit_test.hpp>
 
-using namespace pmt;
 BOOST_AUTO_TEST_CASE(test_u8vector)
 {
     static const size_t N = 3;

--- a/gr-audio/examples/c++/dial_tone.cc
+++ b/gr-audio/examples/c++/dial_tone.cc
@@ -29,8 +29,6 @@
 #include <gnuradio/audio/sink.h>
 #include <gnuradio/top_block.h>
 
-using namespace gr;
-
 int main(int argc, char** argv)
 {
     int rate = 48000; // Audio card sample rate
@@ -39,16 +37,16 @@ int main(int argc, char** argv)
     // Construct a top block that will contain flowgraph blocks.  Alternatively,
     // one may create a derived class from top_block and hold instantiated blocks
     // as member data for later manipulation.
-    top_block_sptr tb = make_top_block("dial_tone");
+    gr::top_block_sptr tb = gr::make_top_block("dial_tone");
 
     // Construct a real-valued signal source for each tone, at given sample rate
-    analog::sig_source_f::sptr src0 =
-        analog::sig_source_f::make(rate, analog::GR_SIN_WAVE, 350, ampl);
-    analog::sig_source_f::sptr src1 =
-        analog::sig_source_f::make(rate, analog::GR_SIN_WAVE, 440, ampl);
+    gr::analog::sig_source_f::sptr src0 =
+        gr::analog::sig_source_f::make(rate, gr::analog::GR_SIN_WAVE, 350, ampl);
+    gr::analog::sig_source_f::sptr src1 =
+        gr::analog::sig_source_f::make(rate, gr::analog::GR_SIN_WAVE, 440, ampl);
 
     // Construct an audio sink to accept audio tones
-    audio::sink::sptr sink = audio::sink::make(rate);
+    gr::audio::sink::sptr sink = gr::audio::sink::make(rate);
 
     // Connect output #0 of src0 to input #0 of sink (left channel)
     tb->connect(src0, 0, sink, 0);

--- a/gr-blocks/lib/annotator_raw_impl.cc
+++ b/gr-blocks/lib/annotator_raw_impl.cc
@@ -17,8 +17,6 @@
 #include <cstring>
 #include <stdexcept>
 
-using namespace pmt;
-
 namespace gr {
 namespace blocks {
 
@@ -39,7 +37,7 @@ annotator_raw_impl::annotator_raw_impl(size_t sizeof_stream_item)
 
 annotator_raw_impl::~annotator_raw_impl() {}
 
-void annotator_raw_impl::add_tag(uint64_t offset, pmt_t key, pmt_t val)
+void annotator_raw_impl::add_tag(uint64_t offset, pmt::pmt_t key, pmt::pmt_t val)
 {
     gr::thread::scoped_lock l(d_mutex);
 

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -41,6 +41,7 @@
 namespace gr {
 namespace blocks {
 
+using pmt::mp;
 
 file_meta_sink::sptr file_meta_sink::make(size_t itemsize,
                                           const std::string& filename,

--- a/gr-blocks/lib/file_meta_sink_impl.h
+++ b/gr-blocks/lib/file_meta_sink_impl.h
@@ -14,7 +14,7 @@
 #include <gnuradio/blocks/file_meta_sink.h>
 #include <pmt/pmt.h>
 
-using namespace pmt;
+using pmt::pmt_t;
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/file_meta_source_impl.h
+++ b/gr-blocks/lib/file_meta_source_impl.h
@@ -18,8 +18,7 @@
 
 #include <gnuradio/blocks/file_meta_sink.h>
 
-using namespace pmt;
-
+using pmt::pmt_t;
 namespace gr {
 namespace blocks {
 

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/xoroshiro128p.h>
 #include <cstdint>
 
-using namespace pmt;
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/tests/benchmark_common.h
+++ b/gr-blocks/tests/benchmark_common.h
@@ -27,7 +27,6 @@
 template <typename functor>
 [[nodiscard]] auto benchmark(functor test, size_t block_size)
 {
-    using namespace std::chrono;
     std::vector<float> outp(2 * block_size);
     float* output = outp.data();
     float *x = &output[0], *y = &output[block_size];
@@ -38,14 +37,16 @@ template <typename functor>
         value = rng() / static_cast<double>(1ULL << 32) - (1ULL << 32);
     }
 
-    auto before = high_resolution_clock::now();
+    auto before = std::chrono::high_resolution_clock::now();
     // do the actual work
 
     test(x, y);
 
-    auto after = high_resolution_clock::now();
+    auto after = std::chrono::high_resolution_clock::now();
     // get ending CPU usage
-    auto dur = duration_cast<duration<double, std::ratio<1, 1>>>(after - before);
+    auto dur =
+        std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1>>>(
+            after - before);
 
     // prevent the compiler from discarding the output, not doing the calculations.
     volatile auto sum = std::accumulate(outp.cbegin(), outp.cend(), 0.0f);

--- a/gr-digital/lib/corr_est_cc_impl.h
+++ b/gr-digital/lib/corr_est_cc_impl.h
@@ -14,8 +14,6 @@
 #include <gnuradio/digital/corr_est_cc.h>
 #include <gnuradio/filter/fft_filter.h>
 
-using namespace gr::filter;
-
 namespace gr {
 namespace digital {
 
@@ -27,7 +25,7 @@ private:
     const float d_sps;
     unsigned int d_mark_delay, d_stashed_mark_delay;
     float d_thresh, d_stashed_threshold;
-    kernel::fft_filter_ccc d_filter;
+    filter::kernel::fft_filter_ccc d_filter;
 
     volk::vector<gr_complex> d_corr;
     volk::vector<float> d_corr_mag;

--- a/gr-digital/lib/decision_feedback_equalizer_impl.cc
+++ b/gr-digital/lib/decision_feedback_equalizer_impl.cc
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <memory>
 
-using namespace std;
 namespace gr {
 namespace digital {
 
@@ -63,8 +62,8 @@ decision_feedback_equalizer_impl::decision_feedback_equalizer_impl(
                                                                      sizeof(gr_complex)),
                                                                sizeof(unsigned short) }),
                          sps),
-      filter::kernel::fir_filter_ccc(
-          vector<gr_complex>(num_taps_forward + num_taps_feedback, gr_complex(0, 0))),
+      filter::kernel::fir_filter_ccc(std::vector<gr_complex>(
+          num_taps_forward + num_taps_feedback, gr_complex(0, 0))),
       d_num_taps_fwd(num_taps_forward),
       d_num_taps_rev(num_taps_feedback),
       d_sps(sps),
@@ -116,9 +115,9 @@ int decision_feedback_equalizer_impl::work(int noutput_items,
     }
 
     unsigned long int nread = nitems_read(0);
-    vector<tag_t> tags;
+    std::vector<tag_t> tags;
     get_tags_in_window(tags, 0, 0, noutput_items * decimation(), d_training_start_tag);
-    vector<unsigned int> training_start_samples(tags.size());
+    std::vector<unsigned int> training_start_samples(tags.size());
     unsigned int tag_index = 0;
     for (const auto& tag : tags) {
         training_start_samples[tag_index++] = tag.offset - nread;
@@ -146,14 +145,14 @@ int decision_feedback_equalizer_impl::work(int noutput_items,
                     state);
 }
 
-void decision_feedback_equalizer_impl::set_taps(const vector<gr_complex>& taps)
+void decision_feedback_equalizer_impl::set_taps(const std::vector<gr_complex>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
     d_new_taps = taps;
     d_updated = true;
 }
 
-vector<gr_complex> decision_feedback_equalizer_impl::taps() const
+std::vector<gr_complex> decision_feedback_equalizer_impl::taps() const
 {
     gr::thread::scoped_lock guard(d_mutex);
     return d_taps;

--- a/gr-digital/lib/linear_equalizer_impl.cc
+++ b/gr-digital/lib/linear_equalizer_impl.cc
@@ -21,7 +21,6 @@
 #include "adaptive_algorithms.h"
 
 using namespace pmt;
-using namespace std;
 
 namespace gr {
 namespace digital {
@@ -54,7 +53,7 @@ linear_equalizer_impl::linear_equalizer_impl(unsigned num_taps,
                                              num_taps * sizeof(gr_complex),
                                              sizeof(unsigned short)),
                          sps),
-      filter::kernel::fir_filter_ccc(vector<gr_complex>(num_taps, gr_complex(0, 0))),
+      filter::kernel::fir_filter_ccc(std::vector<gr_complex>(num_taps, gr_complex(0, 0))),
       d_num_taps(num_taps),
       d_sps(sps),
       d_alg(alg),
@@ -76,18 +75,18 @@ linear_equalizer_impl::linear_equalizer_impl(unsigned num_taps,
     filter::kernel::fir_filter_ccc::set_taps(d_new_taps);
 
     const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
-    set_alignment(max(1, alignment_multiple));
+    set_alignment(std::max(1, alignment_multiple));
     set_history(num_taps);
 }
 
-void linear_equalizer_impl::set_taps(const vector<gr_complex>& taps)
+void linear_equalizer_impl::set_taps(const std::vector<gr_complex>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
     d_new_taps = taps;
     d_updated = true;
 }
 
-vector<gr_complex> linear_equalizer_impl::taps() const
+std::vector<gr_complex> linear_equalizer_impl::taps() const
 {
     gr::thread::scoped_lock guard(d_mutex);
     return d_taps;
@@ -197,9 +196,9 @@ int linear_equalizer_impl::work(int noutput_items,
     }
 
     unsigned long int nread = nitems_read(0);
-    vector<tag_t> tags;
+    std::vector<tag_t> tags;
     get_tags_in_window(tags, 0, 0, noutput_items * decimation(), d_training_start_tag);
-    vector<unsigned int> training_start_samples(tags.size());
+    std::vector<unsigned int> training_start_samples(tags.size());
     unsigned int tag_index = 0;
     for (const auto& tag : tags) {
         training_start_samples[tag_index++] = tag.offset - nread;

--- a/gr-digital/lib/linear_equalizer_impl.cc
+++ b/gr-digital/lib/linear_equalizer_impl.cc
@@ -20,8 +20,6 @@
 
 #include "adaptive_algorithms.h"
 
-using namespace pmt;
-
 namespace gr {
 namespace digital {
 

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 
-#include <algorithm>
 #include <cmath>
 #include <cstdio>
 
@@ -191,9 +190,10 @@ void pfb_clock_sync_ccf_impl::update_gains()
     d_beta = (4 * d_loop_bw * d_loop_bw) / denom;
 }
 
-void pfb_clock_sync_ccf_impl::set_taps(const std::vector<float>& newtaps,
-                                       std::vector<std::vector<float>>& ourtaps,
-                                       std::vector<kernel::fir_filter_ccf>& ourfilter)
+void pfb_clock_sync_ccf_impl::set_taps(
+    const std::vector<float>& newtaps,
+    std::vector<std::vector<float>>& ourtaps,
+    std::vector<filter::kernel::fir_filter_ccf>& ourfilter)
 {
     int i, j;
 

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.h
@@ -13,7 +13,6 @@
 
 #include <gnuradio/digital/pfb_clock_sync_ccf.h>
 
-using namespace gr::filter;
 
 namespace gr {
 namespace digital {
@@ -30,8 +29,8 @@ private:
 
     const int d_nfilters;
     int d_taps_per_filter;
-    std::vector<kernel::fir_filter_ccf> d_filters;
-    std::vector<kernel::fir_filter_ccf> d_diff_filters;
+    std::vector<filter::kernel::fir_filter_ccf> d_filters;
+    std::vector<filter::kernel::fir_filter_ccf> d_diff_filters;
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_dtaps;
     std::vector<float> d_updated_taps;
@@ -52,7 +51,7 @@ private:
 
     void set_taps(const std::vector<float>& taps,
                   std::vector<std::vector<float>>& ourtaps,
-                  std::vector<kernel::fir_filter_ccf>& ourfilter);
+                  std::vector<filter::kernel::fir_filter_ccf>& ourfilter);
 
 public:
     pfb_clock_sync_ccf_impl(double sps,

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -180,9 +180,10 @@ void pfb_clock_sync_fff_impl::update_gains()
     d_beta = (4 * d_loop_bw * d_loop_bw) / denom;
 }
 
-void pfb_clock_sync_fff_impl::set_taps(const std::vector<float>& newtaps,
-                                       std::vector<std::vector<float>>& ourtaps,
-                                       std::vector<kernel::fir_filter_fff>& ourfilter)
+void pfb_clock_sync_fff_impl::set_taps(
+    const std::vector<float>& newtaps,
+    std::vector<std::vector<float>>& ourtaps,
+    std::vector<filter::kernel::fir_filter_fff>& ourfilter)
 {
     int i, j;
 

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.h
@@ -13,7 +13,6 @@
 
 #include <gnuradio/digital/pfb_clock_sync_fff.h>
 
-using namespace gr::filter;
 
 namespace gr {
 namespace digital {
@@ -30,8 +29,8 @@ private:
 
     const int d_nfilters;
     int d_taps_per_filter;
-    std::vector<kernel::fir_filter_fff> d_filters;
-    std::vector<kernel::fir_filter_fff> d_diff_filters;
+    std::vector<filter::kernel::fir_filter_fff> d_filters;
+    std::vector<filter::kernel::fir_filter_fff> d_diff_filters;
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_dtaps;
     std::vector<float> d_updated_taps;
@@ -50,7 +49,7 @@ private:
 
     void set_taps(const std::vector<float>& taps,
                   std::vector<std::vector<float>>& ourtaps,
-                  std::vector<kernel::fir_filter_fff>& ourfilter);
+                  std::vector<filter::kernel::fir_filter_fff>& ourfilter);
 
 public:
     pfb_clock_sync_fff_impl(double sps,

--- a/gr-qtgui/examples/c++/display_qt.cc
+++ b/gr-qtgui/examples/c++/display_qt.cc
@@ -32,22 +32,23 @@ mywindow::mywindow() : QWidget()
     int rate = 48000;
 
     // Create the GNU Radio top block
-    tb = make_top_block("display_qt");
+    tb = gr::make_top_block("display_qt");
 
     // Source will be sine wave in noise
-    src0 = analog::sig_source_f::make(rate, analog::GR_SIN_WAVE, 1500, 1);
-    src1 = analog::noise_source_f::make(analog::GR_GAUSSIAN, 0.1);
+    src0 = gr::analog::sig_source_f::make(rate, gr::analog::GR_SIN_WAVE, 1500, 1);
+    src1 = gr::analog::noise_source_f::make(gr::analog::GR_GAUSSIAN, 0.1);
 
     // Combine signal and noise; add throttle
-    src = blocks::add_ff::make();
-    thr = blocks::throttle::make(sizeof(float), rate);
+    src = gr::blocks::add_ff::make();
+    thr = gr::blocks::throttle::make(sizeof(float), rate);
 
     // Create the QTGUI sinks
     // Time, Freq, Waterfall, and Histogram sinks
-    tsnk = qtgui::time_sink_f::make(1024, rate, "", 1);
-    fsnk = qtgui::freq_sink_f::make(1024, fft::window::WIN_HANN, 0, rate, "", 1);
-    wsnk = qtgui::waterfall_sink_f::make(1024, fft::window::WIN_HANN, 0, rate, "", 1);
-    hsnk = qtgui::histogram_sink_f::make(1024, 100, -2, 2, "", 1);
+    tsnk = gr::qtgui::time_sink_f::make(1024, rate, "", 1);
+    fsnk = gr::qtgui::freq_sink_f::make(1024, gr::fft::window::WIN_HANN, 0, rate, "", 1);
+    wsnk = gr::qtgui::waterfall_sink_f::make(
+        1024, gr::fft::window::WIN_HANN, 0, rate, "", 1);
+    hsnk = gr::qtgui::histogram_sink_f::make(1024, 100, -2, 2, "", 1);
 
     // Turn off the legend on these plots
     tsnk->disable_legend();

--- a/gr-qtgui/examples/c++/display_qt.h
+++ b/gr-qtgui/examples/c++/display_qt.h
@@ -25,8 +25,6 @@
 #include <QTabWidget>
 #include <QWidget>
 
-using namespace gr;
-
 class mywindow : public QWidget
 {
     Q_OBJECT
@@ -41,15 +39,15 @@ private:
     QWidget* qtgui_histogram_sink_win;
 
 #ifndef Q_MOC_RUN
-    top_block_sptr tb;
-    analog::sig_source_f::sptr src0;
-    analog::noise_source_f::sptr src1;
-    blocks::add_ff::sptr src;
-    blocks::throttle::sptr thr;
-    qtgui::time_sink_f::sptr tsnk;
-    qtgui::freq_sink_f::sptr fsnk;
-    qtgui::waterfall_sink_f::sptr wsnk;
-    qtgui::histogram_sink_f::sptr hsnk;
+    gr::top_block_sptr tb;
+    gr::analog::sig_source_f::sptr src0;
+    gr::analog::noise_source_f::sptr src1;
+    gr::blocks::add_ff::sptr src;
+    gr::blocks::throttle::sptr thr;
+    gr::qtgui::time_sink_f::sptr tsnk;
+    gr::qtgui::freq_sink_f::sptr fsnk;
+    gr::qtgui::waterfall_sink_f::sptr wsnk;
+    gr::qtgui::histogram_sink_f::sptr hsnk;
 #endif
 
 public slots:

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -9,10 +9,12 @@
  */
 
 #include "usrp_block_impl.h"
+#include "gnuradio/uhd/usrp_block.h"
 #include <chrono>
 #include <thread>
 
-using namespace gr::uhd;
+using gr::uhd::usrp_block;
+using gr::uhd::usrp_block_impl;
 using namespace std::chrono_literals;
 
 namespace {


### PR DESCRIPTION
Backport #6969 (needed for merge conflict)
Backport #7524
Backport #7526

The first PR was originally left (a year ago) out due to issues with certain compilers.