### PR TITLE
runtime: fix OpenBSD doesn't have prctl() (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -135,7 +135,7 @@ void set_thread_name(gr_thread_t thread, std::string name)
 
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) ||     \
     defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
-    defined(__NetBSD__)
+    defined(__NetBSD__) || defined(__OpenBSD__)
 
 namespace gr {
 namespace thread {

--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -137,6 +137,10 @@ void set_thread_name(gr_thread_t thread, std::string name)
     defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
     defined(__NetBSD__) || defined(__OpenBSD__)
 
+#include <pthread.h>
+#ifdef __OpenBSD__
+#include <pthread_np.h>
+#endif
 namespace gr {
 namespace thread {
 
@@ -199,6 +203,9 @@ int set_thread_priority(gr_thread_t thread, int priority)
 void set_thread_name(gr_thread_t thread, std::string name)
 {
     // Not implemented on OSX
+#ifdef __OpenBSD__
+    pthread_set_name_np(thread, name.c_str());
+#endif
 }
 
 } /* namespace thread */


### PR DESCRIPTION
Backport #7553