### PR TITLE
qtgui: don't include block detail! You're not even using that.

### DIFF
--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -13,7 +13,6 @@
 
 #include "eye_sink_c_impl.h"
 
-#include <gnuradio/block_detail.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -13,7 +13,6 @@
 
 #include "eye_sink_f_impl.h"
 
-#include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/io_signature.h>

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -14,7 +14,6 @@
 
 #include "time_sink_f_impl.h"
 
-#include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/io_signature.h>


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
See title.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
I take issue with a header called `something_detail.h` being included outside `something` and its QA.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
My pride.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
builds.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
