### PR TITLE
runtime: add formatter for tag_t

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tags.h
+++ b/gnuradio-runtime/include/gnuradio/tags.h
@@ -14,6 +14,15 @@
 #include <gnuradio/api.h>
 #include <pmt/pmt.h>
 
+/* ensure that tweakme.h is included before the bundled spdlog/fmt header, see
+ * https://github.com/gabime/spdlog/issues/2922 */
+#include <spdlog/tweakme.h>
+
+#include <gnuradio/api.h>
+#include <pmt/pmt.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
+
 namespace gr {
 
 struct GR_RUNTIME_API tag_t {
@@ -77,4 +86,9 @@ struct GR_RUNTIME_API tag_t {
 
 } /* namespace gr */
 
+//!\brief enables gr::tag to be formatted with fmt
+template <>
+struct GR_RUNTIME_API fmt::formatter<gr::tag_t> : formatter<std::string_view> {
+    fmt::format_context::iterator format(const gr::tag_t& tag, format_context& ctx) const;
+};
 #endif /*INCLUDED_GR_TAGS_H*/

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(
     sync_decimator.cc
     sync_interpolator.cc
     sys_paths.cc
+    tag_fmt.cc
     tagged_stream_block.cc
     terminate_handler.cc
     top_block.cc

--- a/gnuradio-runtime/lib/tag_fmt.cc
+++ b/gnuradio-runtime/lib/tag_fmt.cc
@@ -1,0 +1,25 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023, 2025 Marcus Müller
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+/* ensure that tweakme.h is included before the bundled spdlog/fmt header, see
+ * https://github.com/gabime/spdlog/issues/2922 */
+#include <spdlog/tweakme.h>
+
+#include <spdlog/fmt/fmt.h>
+
+#include <gnuradio/pmt_fmt.h>
+#include <gnuradio/tags.h>
+
+fmt::format_context::iterator
+fmt::formatter<gr::tag_t>::format(const gr::tag_t& tag, fmt::format_context& ctx) const
+{
+    return fmt::format_to(
+        ctx.out(), "@{} {{'{}': '{}'}} ⌱{}", tag.offset, tag.key, tag.value, tag.srcid);
+}

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tags.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(25435955fa46de2924e0b648c4f8dd43)                     */
+/* BINDTOOL_HEADER_FILE_HASH(13e018b8781d7c109c8e779485b013ec)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
enables direct logging of tags

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Logging tags should be easy. Now it is!

```c++
d_logger->warn("Saw unforeseen tag: {}", tag);
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
