### PR TITLE
Tagged Stream Block: don't remove item tags from input, don't show them internally instead

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -75,8 +75,11 @@ public:
                                takes care of that. */
         TPP_ONE_TO_ONE = 2, /*!< Propagate tags from n. input to n. output. Requires same
                                number of in- and outputs */
-        TPP_CUSTOM = 3      /*!< Like TPP_DONT, but signals the block it should implement
-                               application-specific forwarding behaviour. */
+        TPP_CUSTOM = 3,     /*!< Like TPP_DONT, but signals the block it should implement
+                              application-specific forwarding behaviour. */
+        TPP_TSB = 4 /*!< like TPP_ALL_TO_ALL, but specific to tagged stream blocks. If
+                       your TSB needs to control its own tag copying, use
+                       set_tag_propagation_policy(TPP_CUSTOM) or TPP_DONT. */
     };
 
     ~block() override;

--- a/gnuradio-runtime/include/gnuradio/tagged_stream_block.h
+++ b/gnuradio-runtime/include/gnuradio/tagged_stream_block.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2013 Free Software Foundation, Inc.
+ * Copyright 2025 Marcus Müller <mmueller@gnuradio.org>
  *
  * This file is part of GNU Radio
  *
@@ -37,6 +38,98 @@ protected:
                         gr::io_signature::sptr input_signature,
                         gr::io_signature::sptr output_signature,
                         const std::string& length_tag_key);
+
+    /*!
+     * \brief Given a [start,end), returns a vector of all tags in the range.
+     *
+     * \see block::get_tags_in_range
+     *
+     * Does the same as block::get_tags_in_range, but omits the length_tag_key-tagged
+     * tags.
+     *
+     * In context of a class derived from tagged_stream_block, `get_tags_in_range` gets
+     * resolved to this implementation. Cast to the `gr::block` base class to access the
+     * original (i.e., length tag key-including) `block::get_tags_in_range`.
+     *
+     * \param v            a vector reference to return tags into
+     * \param which_input  an integer of which input stream to pull from
+     * \param abs_start    a uint64 count of the start of the range of interest
+     * \param abs_end      a uint64 count of the end of the range of interest
+     */
+    void get_tags_in_range(std::vector<tag_t>& v,
+                           unsigned int which_input,
+                           uint64_t abs_start,
+                           uint64_t abs_end);
+    /*!
+     * \brief Given a [start,end), returns a vector of all tags in the range.
+     *
+     * \see block::get_tags_in_range
+     *
+     * Does the same as block::get_tags_in_range, but omits the length_tag_key-tagged
+     * tags.
+     *
+     * In context of a class derived from tagged_stream_block, `get_tags_in_range` gets
+     * resolved to this implementation. Cast to the `gr::block` base class to access the
+     * original (i.e., length tag key-including) `block::get_tags_in_range`.
+     *
+     * \param v            a vector reference to return tags into
+     * \param which_input  an integer of which input stream to pull from
+     * \param abs_start    a uint64 count of the start of the range of interest
+     * \param abs_end      a uint64 count of the end of the range of interest
+     * \param key          a PMT symbol key to filter only tags of this key
+     */
+    void get_tags_in_range(std::vector<tag_t>& v,
+                           unsigned int which_input,
+                           uint64_t abs_start,
+                           uint64_t abs_end,
+                           const pmt::pmt_t& key);
+    /*!
+     * \brief Gets all tags within the relative window of the current call to work.
+     *
+     * \see block::get_tags_in_window
+     *
+     * Does the same as block::get_tags_in_window, but omits the length_tag_key-tagged
+     * tags.
+     *
+     * In context of a class derived from tagged_stream_block, `get_tags_in_window` gets
+     * resolved to this implementation. Cast to the `gr::block` base class to access the
+     * original (i.e., length tag key-including) `block::get_tags_in_window`.
+     *
+     *
+     * \param v            a vector reference to return tags into
+     * \param which_input  an integer of which input stream to pull from
+     * \param rel_start    a uint64 count of the start of the range of interest
+     * \param rel_end      a uint64 count of the end of the range of interest
+     */
+    void get_tags_in_window(std::vector<tag_t>& v,
+                            unsigned int which_input,
+                            uint64_t rel_start,
+                            uint64_t rel_end);
+
+    /*!
+     * \brief Gets all tags within the relative window of the current call to work,
+     * matching \p key
+     *
+     * \see block::get_tags_in_window
+     *
+     * Does the same as block::get_tags_in_window, but omits the length_tag_key-tagged
+     * tags.
+     *
+     * In context of a class derived from tagged_stream_block, `get_tags_in_window` gets
+     * resolved to this implementation. Cast to the `gr::block` base class to access the
+     * original (i.e., length tag key-including) `block::get_tags_in_window`.
+     *
+     * \param v            a vector reference to return tags into
+     * \param which_input  an integer of which input stream to pull from
+     * \param rel_start    a uint64 count of the start of the range of interest
+     * \param rel_end      a uint64 count of the end of the range of interest
+     * \param key          a PMT symbol key to filter only tags of this key
+     */
+    void get_tags_in_window(std::vector<tag_t>& v,
+                            unsigned int which_input,
+                            uint64_t rel_start,
+                            uint64_t rel_end,
+                            const pmt::pmt_t& key);
 
     /*!
      * \brief Parse all tags on the first sample of a PDU, return the

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -128,6 +128,10 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
     switch (policy) {
     case block::TPP_DONT:
     case block::TPP_CUSTOM:
+    case block::TPP_TSB:
+        /* Don't copy anything.
+         TPP_TSB: tagged stream blocks: tag copying handled by gr::tagged_stream_block
+         superclass */
         return true;
     case block::TPP_ALL_TO_ALL: {
         // every tag on every input propagates to everyone downstream

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(b29641dca27a2281f96841bbfcb9943d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(bd0fac229c18f88eb264147b4ee34ebb)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -499,5 +499,6 @@ void bind_block(py::module& m)
         .value("TPP_ALL_TO_ALL", gr::block::TPP_ALL_TO_ALL) // 1
         .value("TPP_ONE_TO_ONE", gr::block::TPP_ONE_TO_ONE) // 2
         .value("TPP_CUSTOM", gr::block::TPP_CUSTOM)         // 3
+        .value("TPP_TSB", gr::block::TPP_TSB)               // 4
         .export_values();
 }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tagged_stream_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tagged_stream_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tagged_stream_block.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(635b767c5146a5d65f0757f7fb26a904)                     */
+/* BINDTOOL_HEADER_FILE_HASH(37d14d880835b3194c17dfdf513580a7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/lib/tagged_stream_mux_impl.cc
+++ b/gr-blocks/lib/tagged_stream_mux_impl.cc
@@ -72,6 +72,7 @@ int tagged_stream_mux_impl::work(int noutput_items,
             if (i == d_tag_preserve_head_pos && tags[j].offset == nitems_read(i)) {
                 offset -= n_produced;
             }
+            d_logger->trace("adding tag {}", tags[j]);
             add_item_tag(0, offset, tags[j].key, tags[j].value);
         }
         memcpy((void*)out, (const void*)in, ninput_items[i] * d_itemsize);

--- a/gr-digital/lib/packet_headergenerator_bb_impl.cc
+++ b/gr-digital/lib/packet_headergenerator_bb_impl.cc
@@ -75,7 +75,12 @@ int packet_headergenerator_bb_impl::work(int noutput_items,
                         nitems_read(0));
         throw std::runtime_error("header formatter returned false.");
     }
-
+    for (auto& tag : tags) {
+        const auto new_offset = nitems_written(0);
+        d_logger->trace("Forwarding tag {} to new offset {}", tag, new_offset);
+        tag.offset = new_offset;
+        add_item_tag(0, tag);
+    }
     return d_formatter->header_len();
 }
 

--- a/gr-digital/python/digital/qa_ofdm_txrx.py
+++ b/gr-digital/python/digital/qa_ofdm_txrx.py
@@ -14,7 +14,6 @@ import numpy
 
 import pmt
 from gnuradio import gr, gr_unittest
-from gnuradio import digital
 from gnuradio import blocks
 from gnuradio import channels
 from gnuradio.digital.ofdm_txrx import ofdm_tx, ofdm_rx
@@ -91,7 +90,7 @@ class test_ofdm_txrx (gr_unittest.TestCase):
         timing_tag.value = pmt.to_pmt('now')
         len_tag_key = 'frame_len'
         n_bytes = 52
-        n_samples_expected = (numpy.ceil(1.0 * (n_bytes + 4) / 6) + 3) * 80
+        n_samples_expected = int(numpy.ceil(1.0 * (n_bytes + 4) / 6) + 3) * 80
         test_data = [random.randint(0, 255) for x in range(n_bytes)]
         tx_fg = ofdm_tx_fg(
             test_data,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Before, the TSB superclass used to modify the contents input buffer tags
vector, adding itself to the list of blocks whom to not show the tag on
tags with the length tag key.

Now, instead of doing that, it simply "filters" what TSBs see by
(non-virtually) overriding get_tags_in_{range,window}.

This removes a contention point, avoids adding complex data to the
oft-copied blocks, and removes the usage of the deprecated
`block::remove_item_tag`. It was the last consumer of that function, so
that can now be retired.

Fixes a small problem with `qa_ofdm_txrx` (1040.0 is not exactly the
same as 1040), and correctly copies tags from in- to output in
`digital::packet_headergenerator_bb_impl`.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Closes #7627

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

TSBs

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Full test suite, covering same functionality, which lead to the fixing of `packet_headergenerator_bb_impl`

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
  - https://wiki.gnuradio.org/index.php?title=Tagged_Stream_Blocks#A_note_on_tag_propagation currently can't mention `TPP_TSB` yet
- [x] I have added tests to cover my changes, and all previous tests pass.
