### PR TITLE
Get rid of block::remove_item_tag and related infrastructure, checks

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -846,40 +846,6 @@ protected:
     void add_item_tag(unsigned int which_output, const tag_t& tag);
 
     /*!
-     * \brief DEPRECATED. Will be removed in 3.8.
-     *
-     * \param which_input an integer of which input stream to remove the tag from
-     * \param abs_offset   a uint64 number of the absolute item number
-     *                     associated with the tag. Can get from nitems_written.
-     * \param key          the tag key as a PMT symbol
-     * \param value        any PMT holding any value for the given key
-     * \param srcid        optional source ID specifier; defaults to PMT_F
-     *
-     * If no such tag is found, does nothing.
-     */
-    inline void remove_item_tag(unsigned int which_input,
-                                uint64_t abs_offset,
-                                const pmt::pmt_t& key,
-                                const pmt::pmt_t& value,
-                                const pmt::pmt_t& srcid = pmt::PMT_F)
-    {
-        tag_t tag;
-        tag.offset = abs_offset;
-        tag.key = key;
-        tag.value = value;
-        tag.srcid = srcid;
-        this->remove_item_tag(which_input, tag);
-    }
-
-    /*!
-     * \brief DEPRECATED. Will be removed in 3.8.
-     *
-     * \param which_input an integer of which input stream to remove the tag from
-     * \param tag the tag object to remove
-     */
-    void remove_item_tag(unsigned int which_input, const tag_t& tag);
-
-    /*!
      * \brief Given a [start,end), returns a vector of all tags in the range.
      *
      * Range of counts is from start to end-1.

--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -110,19 +110,6 @@ public:
     void add_item_tag(unsigned int which_output, const tag_t& tag);
 
     /*!
-     * \brief  Removes a tag from the given input stream.
-     *
-     * Calls gr::buffer::remove_item_tag().
-     * The tag in question will then no longer appear on subsequent calls of
-     * get_tags_in_range().
-     *
-     * \param which_input  an integer of which input stream to remove the tag from
-     * \param tag the tag object to add
-     * \param id The unique block ID (use gr::block::unique_id())
-     */
-    void remove_item_tag(unsigned int which_input, const tag_t& tag, long id);
-
-    /*!
      * \brief Given a [start,end), returns a vector of all tags in the range.
      *
      * Pass-through function to gr::buffer_reader to get a vector of
@@ -135,13 +122,11 @@ public:
      * \param which_input  an integer of which input stream to pull from
      * \param abs_start    a uint64 count of the start of the range of interest
      * \param abs_end      a uint64 count of the end of the range of interest
-     * \param id           Block ID
      */
     void get_tags_in_range(std::vector<tag_t>& v,
                            unsigned int which_input,
                            uint64_t abs_start,
-                           uint64_t abs_end,
-                           long id);
+                           uint64_t abs_end);
 
     /*!
      * \brief Given a [start,end), returns a vector of all tags in the
@@ -160,14 +145,12 @@ public:
      * \param abs_start    a uint64 count of the start of the range of interest
      * \param abs_end      a uint64 count of the end of the range of interest
      * \param key          a PMT symbol to select only tags of this key
-     * \param id           Block ID
      */
     void get_tags_in_range(std::vector<tag_t>& v,
                            unsigned int which_input,
                            uint64_t abs_start,
                            uint64_t abs_end,
-                           const pmt::pmt_t& key,
-                           long id);
+                           const pmt::pmt_t& key);
 
     /*!
      * \brief Set core affinity of block to the cores in the vector

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -152,20 +152,6 @@ public:
     void add_item_tag(const tag_t& tag);
 
     /*!
-     * \brief  Removes an existing tag from the buffer.
-     *
-     * If no such tag is found, does nothing.
-     * Note: Doesn't actually physically delete the tag, but
-     * marks it as deleted. For the user, this has the same effect:
-     * Any subsequent calls to get_tags_in_range() will not return
-     * the tag.
-     *
-     * \param tag        the tag that needs to be removed
-     * \param id         the unique ID of the block calling this function
-     */
-    void remove_item_tag(const tag_t& tag, long id);
-
-    /*!
      * \brief  Removes all tags before \p max_time from buffer
      *
      * \param max_time        the time (item number) to trim up until.

--- a/gnuradio-runtime/include/gnuradio/buffer_reader.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader.h
@@ -134,10 +134,7 @@ public:
      * \param id           the unique ID of the block to make sure already deleted tags
      * are not returned
      */
-    void get_tags_in_range(std::vector<tag_t>& v,
-                           uint64_t abs_start,
-                           uint64_t abs_end,
-                           long id);
+    void get_tags_in_range(std::vector<tag_t>& v, uint64_t abs_start, uint64_t abs_end);
 
     /*!
      * \brief Returns true when the current thread is ready to call the callback,

--- a/gnuradio-runtime/include/gnuradio/tags.h
+++ b/gnuradio-runtime/include/gnuradio/tags.h
@@ -27,16 +27,16 @@ namespace gr {
 
 struct GR_RUNTIME_API tag_t {
     //! the item \p tag occurred at (as a uint64_t)
-    uint64_t offset;
+    uint64_t offset = 0;
 
     //! the key of \p tag (as a PMT symbol)
-    pmt::pmt_t key;
+    pmt::pmt_t key = pmt::PMT_NIL;
 
     //! the value of \p tag (as a PMT)
-    pmt::pmt_t value;
+    pmt::pmt_t value = pmt::PMT_NIL;
 
     //! the source ID of \p tag (as a PMT)
-    pmt::pmt_t srcid;
+    pmt::pmt_t srcid = pmt::PMT_F;
 
     //! Used by gr_buffer to mark a tagged as deleted by a specific block. You can usually
     //! ignore this.
@@ -56,32 +56,6 @@ struct GR_RUNTIME_API tag_t {
         return (t.key == key) && (t.value == value) && (t.srcid == srcid) &&
                (t.offset == offset);
     }
-
-    tag_t()
-        : offset(0),
-          key(pmt::PMT_NIL),
-          value(pmt::PMT_NIL),
-          srcid(pmt::PMT_F) // consistent with default srcid value in block::add_item_tag
-    {
-    }
-
-    //! Copy constructor; constructs identical tag, but doesn't copy marked_delete
-    tag_t(const tag_t& rhs)
-        : offset(rhs.offset), key(rhs.key), value(rhs.value), srcid(rhs.srcid)
-    {
-    }
-    tag_t& operator=(const tag_t& rhs)
-    {
-        if (this != &rhs) {
-            offset = rhs.offset;
-            key = rhs.key;
-            value = rhs.value;
-            srcid = rhs.srcid;
-        }
-        return (*this);
-    }
-
-    ~tag_t() {}
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -218,17 +218,12 @@ void block::add_item_tag(unsigned int which_output, const tag_t& tag)
     d_detail->add_item_tag(which_output, tag);
 }
 
-void block::remove_item_tag(unsigned int which_input, const tag_t& tag)
-{
-    d_detail->remove_item_tag(which_input, tag, unique_id());
-}
-
 void block::get_tags_in_range(std::vector<tag_t>& v,
                               unsigned int which_input,
                               uint64_t start,
                               uint64_t end)
 {
-    d_detail->get_tags_in_range(v, which_input, start, end, unique_id());
+    d_detail->get_tags_in_range(v, which_input, start, end);
 }
 
 void block::get_tags_in_range(std::vector<tag_t>& v,
@@ -237,7 +232,7 @@ void block::get_tags_in_range(std::vector<tag_t>& v,
                               uint64_t end,
                               const pmt::pmt_t& key)
 {
-    d_detail->get_tags_in_range(v, which_input, start, end, key, unique_id());
+    d_detail->get_tags_in_range(v, which_input, start, end, key);
 }
 
 void block::get_tags_in_window(std::vector<tag_t>& v,
@@ -245,11 +240,8 @@ void block::get_tags_in_window(std::vector<tag_t>& v,
                                uint64_t start,
                                uint64_t end)
 {
-    d_detail->get_tags_in_range(v,
-                                which_input,
-                                nitems_read(which_input) + start,
-                                nitems_read(which_input) + end,
-                                unique_id());
+    d_detail->get_tags_in_range(
+        v, which_input, nitems_read(which_input) + start, nitems_read(which_input) + end);
 }
 
 void block::get_tags_in_window(std::vector<tag_t>& v,
@@ -262,8 +254,7 @@ void block::get_tags_in_window(std::vector<tag_t>& v,
                                 which_input,
                                 nitems_read(which_input) + start,
                                 nitems_read(which_input) + end,
-                                key,
-                                unique_id());
+                                key);
 }
 
 block::tag_propagation_policy_t block::tag_propagation_policy()

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -173,39 +173,27 @@ void block_detail::add_item_tag(unsigned int which_output, const tag_t& tag)
     }
 }
 
-void block_detail::remove_item_tag(unsigned int which_input, const tag_t& tag, long id)
-{
-    if (!pmt::is_symbol(tag.key)) {
-        throw pmt::wrong_type("block_detail::add_item_tag key", tag.key);
-    } else {
-        // Add tag to gr_buffer's deque tags
-        d_input[which_input]->buffer()->remove_item_tag(tag, id);
-    }
-}
-
 void block_detail::get_tags_in_range(std::vector<tag_t>& v,
                                      unsigned int which_input,
                                      uint64_t abs_start,
-                                     uint64_t abs_end,
-                                     long id)
+                                     uint64_t abs_end)
 {
     // get from gr_buffer_reader's deque of tags
-    d_input[which_input]->get_tags_in_range(v, abs_start, abs_end, id);
+    d_input[which_input]->get_tags_in_range(v, abs_start, abs_end);
 }
 
 void block_detail::get_tags_in_range(std::vector<tag_t>& v,
                                      unsigned int which_input,
                                      uint64_t abs_start,
                                      uint64_t abs_end,
-                                     const pmt::pmt_t& key,
-                                     long id)
+                                     const pmt::pmt_t& key)
 {
     std::vector<tag_t> found_items;
 
     v.resize(0);
 
     // get from gr_buffer_reader's deque of tags
-    d_input[which_input]->get_tags_in_range(found_items, abs_start, abs_end, id);
+    d_input[which_input]->get_tags_in_range(found_items, abs_start, abs_end);
 
     // Filter further by key name
     pmt::pmt_t itemkey;

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -138,8 +138,7 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
         std::vector<buffer_sptr> out_buf;
 
         for (int i = 0; i < d->ninputs(); i++) {
-            d->get_tags_in_range(
-                rtags, i, start_nitems_read[i], d->nitems_read(i), block_id);
+            d->get_tags_in_range(rtags, i, start_nitems_read[i], d->nitems_read(i));
 
             if (rtags.empty()) {
                 continue;
@@ -191,8 +190,7 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
             buffer_sptr out_buf;
 
             for (int i = 0; i < d->ninputs(); i++) {
-                d->get_tags_in_range(
-                    rtags, i, start_nitems_read[i], d->nitems_read(i), block_id);
+                d->get_tags_in_range(rtags, i, start_nitems_read[i], d->nitems_read(i));
 
                 if (rtags.empty()) {
                     continue;

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -166,19 +166,6 @@ void buffer::add_item_tag(const tag_t& tag)
     d_item_tags.insert(std::pair<uint64_t, tag_t>(tag.offset, tag));
 }
 
-void buffer::remove_item_tag(const tag_t& tag, long id)
-{
-    gr::thread::scoped_lock guard(*mutex());
-    for (std::multimap<uint64_t, tag_t>::iterator it =
-             d_item_tags.lower_bound(tag.offset);
-         it != d_item_tags.upper_bound(tag.offset);
-         ++it) {
-        if ((*it).second == tag) {
-            (*it).second.marked_deleted.push_back(id);
-        }
-    }
-}
-
 void buffer::prune_tags(uint64_t max_time)
 {
     /* NOTE: this function _should_ lock the mutex before editing

--- a/gnuradio-runtime/lib/buffer_reader.cc
+++ b/gnuradio-runtime/lib/buffer_reader.cc
@@ -137,8 +137,7 @@ void buffer_reader::update_read_pointer(int nitems)
 
 void buffer_reader::get_tags_in_range(std::vector<tag_t>& v,
                                       uint64_t abs_start,
-                                      uint64_t abs_end,
-                                      long id)
+                                      uint64_t abs_end)
 {
     gr::thread::scoped_lock guard(*mutex());
 
@@ -161,16 +160,9 @@ void buffer_reader::get_tags_in_range(std::vector<tag_t>& v,
     while (itr != itr_end) {
         item_time = (*itr).second.offset + d_attr_delay;
         if ((item_time >= abs_start) && (item_time < abs_end)) {
-            std::vector<long>::iterator id_itr;
-            id_itr = std::find(
-                itr->second.marked_deleted.begin(), itr->second.marked_deleted.end(), id);
-            // If id is not in the vector of marked blocks
-            if (id_itr == itr->second.marked_deleted.end()) {
-                tag_t t = (*itr).second;
-                t.offset += d_attr_delay;
-                v.push_back(t);
-                v.back().marked_deleted.clear();
-            }
+            tag_t t = (*itr).second;
+            t.offset += d_attr_delay;
+            v.push_back(t);
         }
         itr++;
     }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_detail_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_detail_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block_detail.h)                                            */
-/* BINDTOOL_HEADER_FILE_HASH(61794baf0e727516eb0eedc08753a17a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(88f1dd946e3fce3a5663b3885a62dcda)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -133,26 +133,16 @@ void bind_block_detail(py::module& m)
              D(block_detail, add_item_tag))
 
 
-        .def("remove_item_tag",
-             &block_detail::remove_item_tag,
-             py::arg("which_input"),
-             py::arg("tag"),
-             py::arg("id"),
-             D(block_detail, remove_item_tag))
-
-
         .def("get_tags_in_range",
              (void(block_detail::*)(std::vector<gr::tag_t, std::allocator<gr::tag_t>>&,
                                     unsigned int,
                                     uint64_t,
-                                    uint64_t,
-                                    long int)) &
+                                    uint64_t)) &
                  block_detail::get_tags_in_range,
              py::arg("v"),
              py::arg("which_input"),
              py::arg("abs_start"),
              py::arg("abs_end"),
-             py::arg("id"),
              D(block_detail, get_tags_in_range, 0))
 
 
@@ -161,15 +151,13 @@ void bind_block_detail(py::module& m)
                                     unsigned int,
                                     uint64_t,
                                     uint64_t,
-                                    pmt::pmt_t const&,
-                                    long int)) &
+                                    pmt::pmt_t const&)) &
                  block_detail::get_tags_in_range,
              py::arg("v"),
              py::arg("which_input"),
              py::arg("abs_start"),
              py::arg("abs_end"),
              py::arg("key"),
-             py::arg("id"),
              D(block_detail, get_tags_in_range, 1))
 
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(bd0fac229c18f88eb264147b4ee34ebb)                     */
+/* BINDTOOL_HEADER_FILE_HASH(befb15f15624225699b5862a9b162100)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(8e570cc3747473c3774ae5ffef6653aa)                     */
+/* BINDTOOL_HEADER_FILE_HASH(77dc8263ed243df0115bfa22cfdc8051)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer_reader.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(f88a20e94ad6a628f5c8c13338474220)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e6545a99d2409009f9c96c848a77e21c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -105,7 +105,6 @@ void bind_buffer_reader(py::module& m)
              py::arg("v"),
              py::arg("abs_start"),
              py::arg("abs_end"),
-             py::arg("id"),
              D(buffer_reader, get_tags_in_range))
 
         ;

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/block_detail_pydoc_template.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/block_detail_pydoc_template.h
@@ -75,9 +75,6 @@ static const char* __doc_gr_block_detail_clear_tags = R"doc()doc";
 static const char* __doc_gr_block_detail_add_item_tag = R"doc()doc";
 
 
-static const char* __doc_gr_block_detail_remove_item_tag = R"doc()doc";
-
-
 static const char* __doc_gr_block_detail_get_tags_in_range_0 = R"doc()doc";
 
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/buffer_pydoc_template.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/buffer_pydoc_template.h
@@ -63,9 +63,6 @@ static const char* __doc_gr_buffer_get_sizeof_item = R"doc()doc";
 static const char* __doc_gr_buffer_add_item_tag = R"doc()doc";
 
 
-static const char* __doc_gr_buffer_remove_item_tag = R"doc()doc";
-
-
 static const char* __doc_gr_buffer_prune_tags = R"doc()doc";
 
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tags.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(13e018b8781d7c109c8e779485b013ec)                     */
+/* BINDTOOL_HEADER_FILE_HASH(1cc50844a95c3d4eae8e827df6427566)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->


With TSBs no longer marking tags as deleted in their input buffer, we
can drop the "Will be removed in 3.8"-deprecated
`block::remove_item_tag`.

With that gone, nothing can put blocks on the "am I deleted for this
particular block?" vector of tags. Hence, the functions called from
`block::get_tags_in_range`, `block_detail::…`, and
`buffer_reader::get_tags_in_range` no longer need to check whether a
block is on that list. Hence, remove that check, and the "who is
asking?" `id` argument.

These were all long-deprecated or internal/detail API anyways, so we're
not breaking compatibility.

It'd be more than desirable to remove the deletion list from `tag_t`,
but that's an API breakage (though I **really** hope nobody was using
that public field of the struct), and should be done in a separate
commit.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Builds upon #7639

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

All blocks handling tags might now be a tiny bit faster.

This removed a method marked as to be removed in GNU Radio 3.8 (oops).

This removed methods only used runtime-internally.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

all current unit tests pass.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
