### PR TITLE
tag_t: clean up marked_deleted

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tags.h
+++ b/gnuradio-runtime/include/gnuradio/tags.h
@@ -38,10 +38,6 @@ struct GR_RUNTIME_API tag_t {
     //! the source ID of \p tag (as a PMT)
     pmt::pmt_t srcid = pmt::PMT_F;
 
-    //! Used by gr_buffer to mark a tagged as deleted by a specific block. You can usually
-    //! ignore this.
-    std::vector<long> marked_deleted;
-
     //! Comparison function to test which tag, \p x or \p y, came first in time
     friend inline bool operator<(const tag_t& x, const tag_t& y)
     {

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -327,6 +327,7 @@ if(ENABLE_TESTING)
         qa_logger.cc
         qa_dictionary_logger.cc
         qa_host_buffer.cc
+        qa_tags.cc
         qa_vmcircbuf.cc)
     list(APPEND GR_TEST_TARGET_DEPS gnuradio-runtime gnuradio-pmt)
 

--- a/gnuradio-runtime/lib/qa_tags.cc
+++ b/gnuradio-runtime/lib/qa_tags.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012, 2018 Free Software Foundation, Inc.
+ * Copyright 2025 Marcus Müller
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include "pmt/pmt_sugar.h"
+#include "gnuradio/tags.h"
+#include <type_traits>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(t1_aggregateness)
+{
+    bool is_aggregate = std::is_aggregate<gr::tag_t>::value;
+    BOOST_CHECK(is_aggregate);
+}
+
+BOOST_AUTO_TEST_CASE(t2_moveabilitly)
+{
+    bool is_move_constructable = std::is_move_constructible<gr::tag_t>::value;
+    BOOST_CHECK(is_move_constructable);
+}
+
+BOOST_AUTO_TEST_CASE(t3_comparison)
+{
+    gr::tag_t t_early{ .offset = 1234 };
+    gr::tag_t t_late{ .offset = 9999 };
+    gr::tag_t t_also_late{ .offset = 9999,
+                           .value = pmt::mp("can I still retreat from this exam?") };
+    BOOST_CHECK(t_early < t_late);
+    BOOST_CHECK(!(t_late < t_early));
+    BOOST_CHECK(!(t_late < t_late));
+    BOOST_CHECK(!(t_late < t_also_late));
+    BOOST_CHECK(!(t_also_late < t_late));
+}

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tags.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1cc50844a95c3d4eae8e827df6427566)                     */
+/* BINDTOOL_HEADER_FILE_HASH(6283d354a0e1767eb18c66e7092f6583)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -52,7 +52,6 @@ void bind_tags(py::module& m)
         .def_readwrite("key", &tag_t::key)
         .def_readwrite("value", &tag_t::value)
         .def_readwrite("srcid", &tag_t::srcid)
-        .def_readwrite("marked_deleted", &tag_t::marked_deleted)
 
         // TODO - put in operators
         ;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

with the work done to wean tagged stream blocks off `remove_item_tag`, we can now remove the `marked_deleted` member.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Depends on 

- #7639
- #7640

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Tags; tags being among the most-handled objects, shaving up some 24-30 B for an unused `std::vector` member should actually be nice for cache locality when walking through the tag tree in gr::buffer (pending moving from a `std::multimap` to a `std::multiset` with the foreign-key `<container>::lower_bound` functionality).


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
