### PR TITLE
runtime: block gets get_first_tag_in_range(…, predicate) and …, tag)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -153,6 +153,44 @@ public:
                            const pmt::pmt_t& key);
 
     /*!
+     * \brief Get the first tag in specified range (if any), fulfilling criterion
+     *
+     * \details
+     * This function returns the lowest-offset tag in the range for whom the predicate
+     * function returns true.
+     *
+     * The predicate function hence needs to map tags to booleans; its signature is
+     * bool function(const tag_t& tag_to check);
+     *
+     * A sensible choice is a side-effect-free lambda, e.g., you'd use this as:
+     *
+     * auto timestamp = get_first_tag_in_range(
+     *     0,                          // which input
+     *     nitems_read(0),             // start index
+     *     nitems_read(0) + something, // end
+     *     [this](const gr::tag_t& tag) {
+     *         return pmt::eqv(tag.key, d_time_tag) && !pmt::is_null(tag.value)
+     *     });
+     * if (timestamp) {
+     *     d_logger->info("got time tag {} at offset {}",
+     *                    timestamp.value.value,
+     *                    timestamp.value.offset);
+     * }
+     *
+     * \param which_input  an integer of which input stream to pull from
+     * \param start        a uint64 count of the start of the range of interest
+     * \param end          a uint64 count of the end of the range of interest
+     * \param predicate    a function of tag_t, returning a boolean
+     */
+    [[nodiscard]] std::optional<gr::tag_t> get_first_tag_in_range(
+        unsigned which_input,
+        uint64_t start,
+        uint64_t end,
+        std::function<bool(const gr::tag_t&)> predicate = [](const gr::tag_t&) {
+            return true;
+        });
+
+    /*!
      * \brief Set core affinity of block to the cores in the vector
      * mask.
      *

--- a/gnuradio-runtime/include/gnuradio/buffer_reader.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader.h
@@ -17,7 +17,11 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <gnuradio/thread/thread.h>
+#include <type_traits>
+#include <cstdint>
 #include <memory>
+#include <optional>
+#include <tuple>
 
 namespace gr {
 
@@ -47,6 +51,10 @@ GR_RUNTIME_API long buffer_ncurrently_allocated();
  */
 class GR_RUNTIME_API buffer_reader
 {
+private:
+    //! \brief converts absolute offsets to bounds for tag vectors
+    std::tuple<uint64_t, uint64_t> offsets_to_bounds(uint64_t start, uint64_t end) const;
+
 public:
 #ifdef BUFFER_DEBUG
     gr::logger_ptr d_logger;
@@ -135,6 +143,52 @@ public:
      * are not returned
      */
     void get_tags_in_range(std::vector<tag_t>& v, uint64_t abs_start, uint64_t abs_end);
+
+    /*!
+     * \brief Get the first tag in specified range (if any), fulfilling criterion
+     *
+     * \see gr::block::get_first_tag_in_range
+     *
+     * \details
+     * This function returns the lowest-offset tag in the range for whom the predicate
+     * function returns true.
+     *
+     * The predicate function hence needs to map tags to booleans; its signature is
+     * bool function(const tag_t& tag_to check);
+     *
+     * We're doing this here as a template in the block detail; allows inlining of the
+     * predicate check.
+     *
+     * \param start        a uint64 count of the start of the range of interest
+     * \param end          a uint64 count of the end of the range of interest
+     * \param predicate    a function of tag_t, returning a boolean
+     */
+    template <typename predicate_t>
+    [[nodiscard]] std::optional<gr::tag_t>
+    get_first_tag_in_range(uint64_t start, uint64_t end, predicate_t predicate)
+    {
+        // SFINAE these conditions; constraints/contexts are a C++20 thing, and we're on
+        // C++17; might as well make the compiler error indicative of what's wrong.
+        static_assert(std::is_invocable_v<predicate_t, const gr::tag_t&>,
+                      "predicate is not invocable");
+        static_assert(
+            std::is_convertible_v<std::invoke_result_t<predicate_t, const gr::tag_t&>,
+                                  bool>,
+            "predicate result can't be converted to boolean");
+
+        auto [lower, upper] = offsets_to_bounds(start, end);
+
+        gr::thread::scoped_lock guard(*mutex());
+        for (auto iterator = d_buffer->get_tags_lower_bound(lower);
+             iterator != d_buffer->get_tags_end() && iterator->second.offset <= end;
+             ++iterator) {
+            const gr::tag_t& tag = iterator->second;
+            if (predicate(tag)) {
+                return { tag };
+            }
+        }
+        return std::nullopt;
+    }
 
     /*!
      * \brief Returns true when the current thread is ready to call the callback,

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -257,6 +257,25 @@ void block::get_tags_in_window(std::vector<tag_t>& v,
                                 key);
 }
 
+std::optional<gr::tag_t>
+block::get_first_tag_in_range(unsigned which_input,
+                              uint64_t start,
+                              uint64_t end,
+                              std::function<bool(const gr::tag_t&)> predicate)
+{
+    return d_detail->get_first_tag_in_range(which_input, start, end, predicate);
+}
+
+std::optional<gr::tag_t> block::get_first_tag_in_range(unsigned which_input,
+                                                       uint64_t start,
+                                                       uint64_t end,
+                                                       const pmt::pmt_t& key)
+{
+    return get_first_tag_in_range(which_input, start, end, [key](const gr::tag_t& tag) {
+        return pmt::eqv(key, tag.key);
+    });
+}
+
 block::tag_propagation_policy_t block::tag_propagation_policy()
 {
     return d_tag_propagation_policy;

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -205,7 +205,14 @@ void block_detail::get_tags_in_range(std::vector<tag_t>& v,
         }
     }
 }
-
+std::optional<gr::tag_t>
+block_detail::get_first_tag_in_range(unsigned which_input,
+                                     uint64_t start,
+                                     uint64_t end,
+                                     std::function<bool(const gr::tag_t&)> predicate)
+{
+    return d_input.at(which_input)->get_first_tag_in_range(start, end, predicate);
+}
 void block_detail::set_processor_affinity(const std::vector<int>& mask)
 {
     if (threaded) {

--- a/gnuradio-runtime/lib/buffer_reader.cc
+++ b/gnuradio-runtime/lib/buffer_reader.cc
@@ -16,9 +16,7 @@
 #include <gnuradio/buffer_reader.h>
 #include <gnuradio/buffer_reader_sm.h>
 #include <gnuradio/math.h>
-#include <assert.h>
 #include <algorithm>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {
@@ -139,18 +137,9 @@ void buffer_reader::get_tags_in_range(std::vector<tag_t>& v,
                                       uint64_t abs_start,
                                       uint64_t abs_end)
 {
-    gr::thread::scoped_lock guard(*mutex());
-
-    uint64_t lower_bound = abs_start - d_attr_delay;
-    // check for underflow and if so saturate at 0
-    if (lower_bound > abs_start)
-        lower_bound = 0;
-    uint64_t upper_bound = abs_end - d_attr_delay;
-    // check for underflow and if so saturate at 0
-    if (upper_bound > abs_end)
-        upper_bound = 0;
-
     v.clear();
+    gr::thread::scoped_lock guard(*mutex());
+    auto [lower_bound, upper_bound] = offsets_to_bounds(abs_start, abs_end);
     std::multimap<uint64_t, tag_t>::iterator itr =
         d_buffer->get_tags_lower_bound(lower_bound);
     std::multimap<uint64_t, tag_t>::iterator itr_end =
@@ -166,6 +155,20 @@ void buffer_reader::get_tags_in_range(std::vector<tag_t>& v,
         }
         itr++;
     }
+}
+
+std::tuple<uint64_t, uint64_t> buffer_reader::offsets_to_bounds(uint64_t start,
+                                                                uint64_t end) const
+{
+    uint64_t lower_bound = start - d_attr_delay;
+    uint64_t upper_bound = end - d_attr_delay;
+    // check for underflow and if so saturate at 0
+    if (lower_bound > start)
+        lower_bound = 0;
+    // check for underflow and if so saturate at 0
+    if (upper_bound > end)
+        upper_bound = 0;
+    return { lower_bound, upper_bound };
 }
 
 long buffer_reader_ncurrently_allocated() { return s_buffer_reader_count; }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_gateway.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_gateway.h
@@ -18,6 +18,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -87,6 +88,14 @@ public:
                                                uint64_t rel_start,
                                                uint64_t rel_end,
                                                const pmt::pmt_t& key);
+
+    [[nodiscard]] std::optional<gr::tag_t> _get_first_tag_in_range(
+        unsigned int which_input, uint64_t start, uint64_t end, const pmt::pmt_t& key);
+    [[nodiscard]] std::optional<gr::tag_t>
+    _get_first_tag_in_range(unsigned int which_input,
+                            uint64_t start,
+                            uint64_t end,
+                            std::function<bool(const gr::tag_t&)>);
 
     /*******************************************************************
      * Overloads for various scheduler-called functions

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(befb15f15624225699b5862a9b162100)                     */
+/* BINDTOOL_HEADER_FILE_HASH(745e706ac4988d6d63e0ca5dd21e59cd)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer_reader.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(e6545a99d2409009f9c96c848a77e21c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(dab561c6a8aff86593168837af6f25c2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tagged_stream_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tagged_stream_block_python.cc
@@ -17,8 +17,10 @@
 /* BINDTOOL_HEADER_FILE_HASH(37d14d880835b3194c17dfdf513580a7)                     */
 /***********************************************************************************/
 
-#include <pybind11/complex.h>
 #include <pybind11/pybind11.h>
+
+#include <pybind11/complex.h>
+#include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;

--- a/gnuradio-runtime/python/gnuradio/gr/qa_tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_tag_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2007,2010 Free Software Foundation, Inc.
-# Copyright 2021 Marcus Müller
+# Copyright 2021,2025 Marcus Müller <mmueller@gnuradio.org>
 #
 # This file is part of GNU Radio
 #
@@ -12,6 +12,82 @@
 
 from gnuradio import gr, gr_unittest
 import pmt
+import numpy
+
+MULTIPLE = 100
+KEY = pmt.string_to_symbol("key")
+
+
+class first_tag_key(gr.sync_block):
+    def __init__(self, assert_function):
+        gr.sync_block.__init__(
+            self, "test block", out_sig=[], in_sig=[numpy.float32])
+        self.assert_function = assert_function
+        self.set_output_multiple(MULTIPLE)
+        self.counter = 0
+
+    def work(self, input_items, _):
+        read = self.nitems_read(0)
+        tag = self.get_first_tag_in_range(0,
+                                          read,
+                                          read + MULTIPLE,
+                                          KEY)
+        self.assert_function(
+            tag is not None, "got no tag")
+
+        self.assert_function(pmt.to_long(tag.value) == MULTIPLE * self.counter,
+                             f"value at {tag.offset} wrong ({tag.value})")
+        self.assert_function(tag.offset % MULTIPLE == 12,
+                             f"offset {tag.offset} wrong")
+        tag = self.get_first_tag_in_range(0,
+                                          tag.offset + 1,
+                                          read + MULTIPLE,
+                                          KEY)
+        self.assert_function(not tag, f"should only have one tag, got second at {tag.offset if tag else '???'}")
+        self.counter += 1
+        return MULTIPLE
+
+
+class first_tag_predicate(gr.sync_block):
+    def __init__(self, assert_function):
+        gr.sync_block.__init__(
+            self, "test block", out_sig=[], in_sig=[numpy.float32])
+        self.assert_function = assert_function
+        self.set_output_multiple(MULTIPLE)
+
+    def work(self, input_items, _):
+        read = self.nitems_read(0)
+        tag = self.get_first_tag_in_range(0,
+                                          read,
+                                          read + MULTIPLE,
+                                          lambda tag: tag.key == KEY and tag.offset % MULTIPLE == 12)
+        definitely_no_tag = self.get_first_tag_in_range(0,
+                                                        read,
+                                                        read + MULTIPLE,
+                                                        lambda tag: False)
+        self.assert_function(tag is not None, "got no tag, though there should be one")
+        self.assert_function(definitely_no_tag is None, "got a tag where I definitely shouldn't")
+        return MULTIPLE
+
+
+class source_block(gr.sync_block):
+    def __init__(self):
+        gr.sync_block.__init__(
+            self, "test block", in_sig=[], out_sig=[numpy.float32])
+
+    def work(self, _, output_items):
+        if self.nitems_written(0) > 100000:
+            return -1
+        nout = len(output_items[0])
+        for idx in range(self.nitems_written(0), self.nitems_written(0) + nout):
+            counter = idx // MULTIPLE
+            if idx % MULTIPLE == 12:
+                tag = gr.tag_t()
+                tag.offset = idx
+                tag.key = KEY
+                tag.value = pmt.from_long(counter * MULTIPLE)
+                self.add_item_tag(0, tag)
+        return nout
 
 
 class test_tag_utils (gr_unittest.TestCase):
@@ -111,6 +187,15 @@ class test_tag_utils (gr_unittest.TestCase):
         self.assertTrue(pmt.equal(tmax.key, key))
         self.assertTrue(pmt.equal(tmax.value, pmt.from_long(max(offsets))))
         self.assertTrue(pmt.equal(tmax.srcid, srcid))
+
+    def test_004_get_first_tag_in_range(self):
+        tb = gr.top_block(catch_exceptions=False)
+        src = source_block()
+        sink = first_tag_key(lambda truth, msg: self.assertTrue(truth, msg))
+        sink2 = first_tag_predicate(lambda truth, msg: self.assertTrue(truth, msg))
+        tb.connect(src, sink)
+        tb.connect(src, sink2)
+        tb.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

All to common is a scheme where a consumer of tags needs to do this
dance:

```c++
std::vector<gr::tag_t> tags;
get_tags_in_range(tags, 0, start, end, d_phase_est_key);
if(!tags.empty) {
  float phase = pmt::to_float(tags[0].value);
  if(phase >= -M_PI && phase < M_PI) {
    d_phase = phase;
  }
}
```

but no more with `get_first_tag_in_range`!

```c++
auto tag = get_first_tag_in_range(0, start, end, d_phase_est_key);
if(tag) {
  float phase = pmt::to_float(tag.value.value);
  if(phase >= -M_PI && phase < M_PI) {
    d_phase = phase;
  }
}
```

But wait! It gets even better! You can *filter with a predicate*:

```c++
auto tag = get_first_tag_in_range(0,
                                  start,
                                  end,
                                  [this](const gr::tag_t& tag) {
                                    if(tag.key != d_phase_est_key)
                                      return false;
                                    float phase = pmt::to_float(
                                      tag.value.value);
                                    return phase >= -M_PI
                                      && phase < M_PI;
                                  });
if(tag) {
  float phase = pmt::to_float(tag.value.value);
  if(phase >= -M_PI && phase < M_PI) {
    d_phase = phase;
  }
}
```

This also works in python (in both variants), feel free to use python
callables as predicate, or your usual PMT key.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Long-standing annoyences

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

block, block_gateway

block_detail

and their python bindings

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

added a Python test case to check functionality.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
