### PR TITLE
grc: Fix documentation showing wrong block

### DIFF
--- a/grc/core/utils/extract_docs.py
+++ b/grc/core/utils/extract_docs.py
@@ -55,8 +55,8 @@ def docstring_guess_from_key(key):
     else:
         return doc_strings
 
-    pattern = re.compile(
-        '^' + init_name.replace('_', '_*').replace('x', r'\w') + r'\w*$')
+    pattern = re.compile(get_block_regex(init_name))
+
     for match in filter(pattern.match, dir(module)):
         try:
             doc_strings[match] = getattr(module, match).__doc__
@@ -64,6 +64,24 @@ def docstring_guess_from_key(key):
             continue
 
     return doc_strings
+
+
+def get_block_regex(block_name):
+    """
+    Helper function to create regular expression for a given block name
+    Assumes variable type blocks ends with '_x', '_xx', '_xxx', '_vxx',
+    or "_xx_ts"
+    """
+
+    regex = "^" + block_name + r"\w*$"
+    variable_suffixes = ["_x", "_xx", "_xxx", "_vxx", "_xx_ts"]
+    for suffix in variable_suffixes:
+        if block_name.endswith(suffix):
+            base_name, _, _ = block_name.rpartition(suffix)
+            var_suffix = suffix.replace("x", r"\w")
+            regex = "^" + base_name + var_suffix + r"\w*$"
+            break
+    return regex
 
 
 def docstring_from_make(key, imports, make):


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This commit fixes issues where the documentation tab shows the wrong block. This was first noticed when the max block showed documentation for magphase_to_complex and matrix_interleaver.

This fix changes the docstring search for each block, using an improved regular expression. This change does a better job of handling variable types that end with "_x", "_xx", "_xxx", and "_xx_ts". Previously, a wholesale replacement of "x" with "\w" was made on the regular expression. However, this affected the docstring search for blocks that contain "x" as part of the name and not the variable type. For example, blocks max_xx and xor_xx were affected before this fix.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
fixes #7265
PR #7271 
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
This fix affects the documentation portion of all grc blocks. It specifically corrects issues seen in max blocks and xor blocks.
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Max Block Before:
<img width="338" alt="max-before" src="https://github.com/user-attachments/assets/9670c8e3-6389-4258-a5c7-26c0a25607ca" />
Max Block After:
<img width="300" alt="max-after" src="https://github.com/user-attachments/assets/a24d3378-9d54-4607-87dc-de306b9996b0" />
Xor Block Before:
<img width="397" alt="xor-before" src="https://github.com/user-attachments/assets/c95c593b-f0b9-4e4e-a690-f5c332d4a3ab" />
Xor Block After:
<img width="300" alt="xor-after" src="https://github.com/user-attachments/assets/8033e6c2-fbfc-45fe-9988-7a3298efd198" />

I've also reviewed the documentation for all blocks by running this script:
```
from gnuradio.grc.gui.Platform import Platform
from gnuradio import gr

plat = Platform(
    version=gr.version(),
    prefs=gr.prefs(),
    install_prefix=gr.prefix(),
)
plat.build_library()
plat._docstring_extractor.wait()
for k, v in plat.blocks.items():
    print(k)
    print(v.documentation)
```
I ran this script before and after changes and saved the output to file. I performed a diff between the files to make sure other blocks were not affected.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
