### PR TITLE
runtime: add configure-time version.h[.in] with GR_VERSION_{MAJOR,API,MINOR,MAINT}

### DIFF
--- a/cmake/Modules/GrVersion.cmake
+++ b/cmake/Modules/GrVersion.cmake
@@ -64,6 +64,12 @@ endif()
 ########################################################################
 # Use the logic below to set the version constants
 ########################################################################
+## HEADER VARIABLES -- see include/gnuradio/version.h.in
+set(GR_VERSION_MAJOR "${VERSION_MAJOR}")
+set(GR_VERSION_API "${VERSION_API}")
+set(GR_VERSION_MINOR "${VERSION_ABI}")
+set(GR_VERSION_MAINT "${VERSION_PATCH}")
+## Main Variables
 if("${MINOR_VERSION}" STREQUAL "git")
     # VERSION: 3.3git-xxx-gxxxxxxxx
     # DOCVER:  3.3git
@@ -73,6 +79,7 @@ if("${MINOR_VERSION}" STREQUAL "git")
     set(LIBVER "${MAJOR_VERSION}.${API_COMPAT}${MINOR_VERSION}")
     set(RC_MINOR_VERSION "0")
     set(RC_MAINT_VERSION "0")
+    set(GR_VERSION_MINOR "1023")
 elseif("${MAINT_VERSION}" STREQUAL "git")
     # VERSION: 3.3.1git-xxx-gxxxxxxxx
     # DOCVER:  3.3.1git
@@ -82,6 +89,7 @@ elseif("${MAINT_VERSION}" STREQUAL "git")
     set(LIBVER "${MAJOR_VERSION}.${API_COMPAT}.${MINOR_VERSION}${MAINT_VERSION}")
     math(EXPR RC_MINOR_VERSION "${MINOR_VERSION} - 1")
     set(RC_MAINT_VERSION "0")
+    set(GR_VERSION_MAINT "1023")
 else()
     # This is a numbered release.
     # VERSION: 3.3.1{.x}

--- a/gnuradio-runtime/include/gnuradio/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/CMakeLists.txt
@@ -8,6 +8,12 @@
 add_subdirectory(messages)
 add_subdirectory(thread)
 
+# Create a version.h with the project version
+configure_file(version.h.in
+               version.h)
+# Install version.h in include/gnuradio
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version.h
+        DESTINATION ${GR_INCLUDE_DIR}/gnuradio)
 ########################################################################
 # Install header files
 ########################################################################
@@ -79,4 +85,6 @@ install(
 if(ENABLE_CTRLPORT_THRIFT)
     install(FILES rpcserver_booter_thrift.h thrift_application_base.h
                   thrift_server_template.h DESTINATION ${GR_INCLUDE_DIR}/gnuradio)
+
+
 endif(ENABLE_CTRLPORT_THRIFT)

--- a/gnuradio-runtime/include/gnuradio/version.h.in
+++ b/gnuradio-runtime/include/gnuradio/version.h.in
@@ -1,0 +1,14 @@
+#ifndef INCLUDED_GR_VERSION
+#define INCLUDED_GR_VERSION
+// clang-format off
+#define GR_VERSION_MAJOR @GR_VERSION_MAJOR@
+#define GR_VERSION_API   @GR_VERSION_API@
+#define GR_VERSION_MINOR @GR_VERSION_MINOR@
+#define GR_VERSION_MAINT @GR_VERSION_MAINT@
+// clang-format on
+//! \brief macro to convert versions to comparable integers
+#define GR_MAKE_VERSION(major, api, minor, maint) \
+    ((maint) + ((minor) << 10) + ((api) << 20) + ((major) << 30))
+#define GR_VERSION \
+    GR_MAKE_VERSION(GR_VERSION_MAJOR, GR_VERSION_API, GR_VERSION_MINOR, GR_VERSION_MAINT)
+#endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
As discussed in #Development, it seems a common and desirable thing to have a version preprocessor statement.

Short survey of /usr/include suggests that gnuradio/version.h is a good name.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Needed this to be able to future-remove features in the source code. 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

none, unless you want to use it


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
