### PR TITLE
runtime: fix qa_tags using C++ too modern for MSVC

### DIFF
--- a/gnuradio-runtime/lib/qa_tags.cc
+++ b/gnuradio-runtime/lib/qa_tags.cc
@@ -8,6 +8,7 @@
  *
  */
 
+#include "pmt/pmt.h"
 #include "pmt/pmt_sugar.h"
 #include "gnuradio/tags.h"
 #include <type_traits>
@@ -27,10 +28,11 @@ BOOST_AUTO_TEST_CASE(t2_moveabilitly)
 
 BOOST_AUTO_TEST_CASE(t3_comparison)
 {
-    gr::tag_t t_early{ .offset = 1234 };
-    gr::tag_t t_late{ .offset = 9999 };
-    gr::tag_t t_also_late{ .offset = 9999,
-                           .value = pmt::mp("can I still retreat from this exam?") };
+    gr::tag_t t_early{ 1234 };
+    gr::tag_t t_late{ 9999 };
+    gr::tag_t t_also_late{ 9999,
+                           pmt::get_PMT_NIL(),
+                           pmt::mp("can I still retreat from this exam?") };
     BOOST_CHECK(t_early < t_late);
     BOOST_CHECK(!(t_late < t_early));
     BOOST_CHECK(!(t_late < t_late));


### PR DESCRIPTION
## Description

Due to a terrible mistake on my end, I used C++20 aggregate initialization with *designated* initializers. Can't do that in C++17 with MSVC !

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

should build on MSVC now, let's watch the CI

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
