### PR TITLE
modtool: (modtool bind) help, replace precompiler with preprocessor

### DIFF
--- a/gr-utils/modtool/cli/bind.py
+++ b/gr-utils/modtool/cli/bind.py
@@ -31,7 +31,7 @@ from .base import common_params, block_name, run, cli_input
 @click.option('--addl_includes', default=None,
               help='Comma separated list of additional include directories (default None)')
 @click.option('-D', '--define_symbols', multiple=True, default=None,
-              help='Set precompiler defines')
+              help='Set preprocessor defines')
 @click.option('-u', '--update-hash-only', is_flag=True,
               help='If given, only the hash in the binding will be updated')
 @common_params

--- a/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
@@ -16,7 +16,7 @@ parser.add_argument(
     '--filename', help="File to be parsed")
 
 parser.add_argument(
-    '--defines', help='Set additional defines for precompiler', default=(), nargs='*')
+    '--defines', help='Set additional defines for preprocessor', default=(), nargs='*')
 parser.add_argument(
     '--include', help='Additional Include Dirs, separated', default=(), nargs='*')
 


### PR DESCRIPTION

## Description
modtool bind helper text correction, replace precompiler with preprocessor
Closes #7655 


## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
