### PR TITLE
grc-qt: block library follow up to #7644

### DIFF
--- a/grc/gui_qt/components/block_library.py
+++ b/grc/gui_qt/components/block_library.py
@@ -38,7 +38,10 @@ class BlockSearchBar(QLineEdit):
         QLineEdit.setClearButtonEnabled(self, True)
         self.parent = parent
         self.setObjectName("block_library::search_bar")
-        self.returnPressed.connect(self.on_return_pressed)
+        # We must use a queued connection here, otherwise
+        # the searchbar entry will not be deleted if we selected an item from
+        # the popup window by key_down and key_enter
+        self.returnPressed.connect(self.on_return_pressed, Qt.QueuedConnection)
         # Find clear Button inside QLineEdit
         clr_btn = self.findChildren(QToolButton)
         if len(clr_btn) > 0:
@@ -326,8 +329,9 @@ class BlockLibrary(QDockWidget, base.Component):
         # Call the nested function recursively to populate the block tree
         log.debug("Populating the treeview")
         _populate(block_tree, self._model.invisibleRootItem())
-        if self.blocklibrary_expanded and self._model.item(1, 0):
-            self._library.expand(self._model.item(1, 0).index())
+        if self.blocklibrary_expanded:
+            for row in range(0, self._model.rowCount()):
+                self._library.expand(self._model.item(row, 0).index())
         else:
             self._library.expand(
                 self._model.item(0, 0).index()


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
With #7644 on option was introduced to display the lib in collapsed or expanded state. But due to a bug only the first category was expanded. This is fixed now.

The search field was not cleared, if you selected a block by key_down and then pressing return.

This is fixed now, too.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
![col](https://github.com/user-attachments/assets/dd9a2527-4f17-4aa6-9f80-d243e5e2b1e7)
![exp](https://github.com/user-attachments/assets/a71db064-acde-400a-a89d-9938220a929b)

Without and with option selected


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
