### PR TITLE
cmake: suppressed clang++ warnings that -fcx-limited-range wasn't used (backport to maint-3.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,11 @@ endif(UNIX)
 check_cxx_compiler_flag(-fcx-limited-range HAVE_CX_LIMITED_RANGE)
 if(HAVE_CX_LIMITED_RANGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcx-limited-range")
+    check_cxx_compiler_flag(-Wno-unused-command-line-argument
+                            HAVE_WNO_UNUSED_CMD_LINE_ARG)
+    if(HAVE_WNO_UNUSED_CMD_LINE_ARG)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
+    endif(HAVE_WNO_UNUSED_CMD_LINE_ARG)
 endif(HAVE_CX_LIMITED_RANGE)
 
 ########################################################################


### PR DESCRIPTION
Backport #7679