### PR TITLE
uhd: Fix connecting back-edges

### DIFF
--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -49,6 +49,14 @@ public:
             if (_rx_streamers.count(dst_block_id)) {
                 throw std::runtime_error("Cannot connect RFNoC streamers directly!");
             }
+            if (is_back_edge) {
+                d_logger->warn("Back edge detected between streamer {:s}:{:d} and block "
+                               "{:s}:{:d}! Ignoring.",
+                               src_block_id,
+                               src_block_port,
+                               dst_block_id,
+                               dst_block_port);
+            }
             _graph->connect(_tx_streamers.at(src_block_id),
                             src_block_port,
                             block_id_t(dst_block_id),
@@ -57,6 +65,14 @@ public:
             return;
         }
         if (_rx_streamers.count(dst_block_id)) {
+            if (is_back_edge) {
+                d_logger->warn("Back edge detected between block {:s}:{:d} and streamer "
+                               "{:s}:{:d}! Ignoring.",
+                               src_block_id,
+                               src_block_port,
+                               dst_block_id,
+                               dst_block_port);
+            }
             _graph->connect(src_block_id,
                             src_block_port,
                             _rx_streamers.at(dst_block_id),
@@ -68,7 +84,8 @@ public:
         _graph->connect(block_id_t(src_block_id),
                         src_block_port,
                         block_id_t(dst_block_id),
-                        dst_block_port);
+                        dst_block_port,
+                        is_back_edge);
     }
 
     void connect(const std::string& block1,


### PR DESCRIPTION
## Description


gr-uhd contained a bug where back-edges were not being properly propagated into UHD (meaning, the setting was not being set in the corresponding UHD call).

In addition, we add a warning when attempting to define an edge to a streamer node as a back-edge. Because these edges are never the cause of a loop, the underlying UHD API does not allow tagging these as back-edges. If someone attempts to declare a streamer-edge as a back-edge, we will now emit a warning on the logger interface.


<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue

Fixes https://github.com/gnuradio/gnuradio/issues/7353.

## Which blocks/areas does this affect?

RFNoC applications with loops.

## Testing Done

I used `rfnoc_radio_loopback.grc` to first reproduce the error, and then test this fix. Both were straightforward. This works best on an X410 or X440, for some reason the default X310 configuration won't let you do a single-radio loopback (not that it would be useful, so that's probably more of a feature than a bug).

The irony: I did all the GRC work to enable edge properties just so that `rfnoc_radio_loopback.grc` actually did what it was supposed to, which includes this very use case. I spent weeks on that feature, so I'm pretty sure I must have tested it at some point. I can only imagine that I eventually didn't stage all the changes for the PR.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
