### PR TITLE
gr-blocks: Unify "Multiply Const" and "Fast Multiply Const" blocks

### DIFF
--- a/gr-blocks/grc/blocks_multiply_const_vxx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_const_vxx.block.yml
@@ -12,9 +12,16 @@ parameters:
         const_type:  [complex, real, int, int]
         fcn: [cc, ff, ii, ss]
     hide: part
+-   id: mode
+    label: Mode
+    dtype: enum
+    options: [scalar, vector]
+    option_labels: ['Scalar constant', 'Vector constant']
+    default: 'vector'
+    hide: ${ 'part' if vlen > 1 else 'all' }
 -   id: const
     label: Constant
-    dtype: ${ type.const_type if vlen == 1 else type.vconst_type }
+    dtype: ${ type.const_type if vlen == 1 or mode == 'scalar' else type.vconst_type }
     default: '1'
 -   id: vlen
     label: Vector Length
@@ -34,18 +41,28 @@ outputs:
 
 asserts:
 - ${ vlen > 0 }
-- ${ (vlen > 1 and len(const) == vlen) or (vlen == 1) }
+- ${ vlen == 1 or mode == 'scalar' or len(const) == vlen }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.multiply_const_${ 'v' if context.get('vlen')() > 1 else '' }${type.fcn}(${const})
+    make: |-
+      % if context.get("vlen")() == 1 or mode == 'scalar':
+      blocks.multiply_const_${type.fcn}(${const}, ${vlen})
+      % else:
+      blocks.multiply_const_v${type.fcn}(${const})
+      % endif
     callbacks:
     - set_k(${const})
 
 cpp_templates:
-    includes: ['#include <gnuradio/blocks/multiply_const${"_v" if context.get("vlen")() > 1 else "" }.h>']
-    declarations: 'blocks::multiply_const_${"v" if context.get("vlen")() > 1 else "" }${type.fcn}::sptr ${id};'
-    make: 'this->${id} = blocks::multiply_const_${"v" if context.get("vlen")() > 1 else "" }${type.fcn}::make(${const});'
+    includes: ['#include <gnuradio/blocks/multiply_const${ "" if context.get("vlen")() == 1 or mode == "scalar" else "_v" }.h>']
+    declarations: 'blocks::multiply_const_${ "" if context.get("vlen")() == 1 or mode == "scalar" else "v" }${type.fcn}::sptr ${id};'
+    make: |-
+      % if context.get("vlen")() == 1 or mode == 'scalar':
+      this->${id} = blocks::multiply_const_${type.fcn}::make(${const}, ${vlen});
+      % else:
+      this->${id} = blocks::multiply_const_v${type.fcn}::make(${const});
+      % endif
     callbacks:
     - set_k(${const})
 

--- a/gr-blocks/grc/blocks_multiply_const_xx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_const_xx.block.yml
@@ -1,6 +1,6 @@
 id: blocks_multiply_const_xx
 label: Fast Multiply Const
-flags: [ python, cpp ]
+flags: [ python, cpp, deprecated ]
 
 parameters:
 -   id: type


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

- Merges the functionality of  "Fast Multiply Const" block into "Multiply Const" block
- Deprecates "Fast Multiply Const"

"Multiply Const" block get's an additional parameter "mode" to select between "vector constant" (default for backwards compatibility) and "scalar constant" (functionality of Fast Multiply Const block).
If vector length is 1 (default), both "Multiply Const" and "Fast Multiply Const" already did the same thing anyways prior to this PR, and in this case the new "mode" parameter is also hidden.
For vector length > 1, the mode parameter allows to select between "vector constant" (keeping the previous behaviour of "Multiply Const" block) and "scalar constant" (the behaviour of "Fast Multiply Const" block)




## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gr-blocks "Multiply Const" and "Fast Multiply Const" blocks

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

- Confirmed that generated output for python and c++ is syntactically identical

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
