### PR TITLE
grc-qt: Fix properties dialog in variable editor, alternativ solution

### DIFF
--- a/grc/gui_qt/components/variable_editor.py
+++ b/grc/gui_qt/components/variable_editor.py
@@ -232,7 +232,14 @@ class VariableEditor(QDockWidget, base.Component):
             self.all_editor_actions.emit(action)
             return
         elif action == VariableEditorAction.OPEN_PROPERTIES:
-            # TODO: Disabled in GRC Gtk. Enable?
+            if self._tree.currentItem().type() == 2:  # Import or Variable header line was selected
+                return
+            self.scene.clearSelection()
+            if self._tree.currentItem().type() == 0:
+                to_handle = self.scene.core.blocks.index(self._imports[self._tree.currentIndex().row()])
+            else:
+                to_handle = self.scene.core.blocks.index(self._variables[self._tree.currentIndex().row()])
+            self.scene.core.blocks[to_handle].gui.setSelected(True)
             self.all_editor_actions.emit(action)
             return
 

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -223,6 +223,8 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
             self.currentFlowgraphScene.add_block('variable', pos)
         elif key == VariableEditorAction.ADD_IMPORT:
             self.currentFlowgraphScene.add_block('import', pos)
+        elif key == VariableEditorAction.OPEN_PROPERTIES:
+            self.currentFlowgraphScene.selected_blocks()[0].open_properties()
         else:
             log.debug(f"{key} not implemented yet")
         self.currentFlowgraphScene.clearSelection()


### PR DESCRIPTION
Add the property dialog to the variable_editor contextmenu

Partially fixes #7615

The missing context sensitivity should be handled  in an other pr.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Add the property dialog to the variable_editor contextmenu
This is an alternative solution for #7690

The missing context sensitivity should be handled  in an other pr.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Partially fixes #7615
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Just open an existing fg and right click in the variable editor and open properties
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
