### PR TITLE
blocks: Use a fresh flow graph for part 3 of append test

### DIFF
--- a/gr-blocks/python/blocks/qa_wavfile.py
+++ b/gr-blocks/python/blocks/qa_wavfile.py
@@ -104,6 +104,7 @@ class test_wavefile(gr_unittest.TestCase):
         wf_out.close()
 
         # 3. append halved copy
+        self.tb.disconnect_all()
         wf_in = blocks.wavfile_source(infile)
         halver = blocks.multiply_const_ff(0.5)
         wf_out = blocks.wavfile_sink(outfile,


### PR DESCRIPTION
## Description
As noted in #7685, `test_003_checkwav_append_copy` is flaky because it accidentally runs two Wav File Sinks in parallel, which can stomp on each other. Starting from a fresh flow graph in part 3 of the test solves the problem.

## Related Issue
Fixes #7685.

## Which blocks/areas does this affect?
Tests for Wav File Source & Wav File Sink.

## Testing Done
I ran `qa_wavfile.py` in a loop (`while gr-blocks/python/blocks/qa_wavfile_test.sh; do :; done`) in parallel with `stress -c 32`. Prior to this change, `test_003_checkwav_append_copy` readily fails, and afterwards it runs without fail.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
