### PR TITLE
uhd: rfnoc: Remove ce_clk input from split_stream

### DIFF
--- a/gr-uhd/grc/uhd_fpga_split_stream.block.yml
+++ b/gr-uhd/grc/uhd_fpga_split_stream.block.yml
@@ -25,9 +25,6 @@ parameters:
     hide: part
 
 inputs:
--   domain: rfnoc.clk
-    id: ce_clk
-    dtype: message
 -   domain: rfnoc.data
     id: in_
     dtype: fc32


### PR DESCRIPTION
In the image builder version, the split_stream block erroneously defined a ce_clk input. However, the split-stream block operates at rfnoc_clk and thus does not require this input.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description

This is the bad input:

![image](https://github.com/user-attachments/assets/e3f8f149-dc61-4749-a22f-810bbf15de33)


## Which blocks/areas does this affect?

Only affects trying to build FPGA bitfiles for RFNoC devices out of GRC using the split stream block.


## Testing Done

Building bitfiles now works.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
