### PR TITLE
uhd: rfnoc: Remove enum block type from image builder blocks

### DIFF
--- a/gr-uhd/grc/uhd_fpga_addsub.block.yml
+++ b/gr-uhd/grc/uhd_fpga_addsub.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Add/Subtract
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_chdr_dma_ta.block.yml
+++ b/gr-uhd/grc/uhd_fpga_chdr_dma_ta.block.yml
@@ -4,9 +4,8 @@ label: CHDR DMA Transport Adapter
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'transport_adapter'
-    options: ['block', 'sep', 'device', 'transport_adapter']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_ddc.block.yml
+++ b/gr-uhd/grc/uhd_fpga_ddc.block.yml
@@ -4,9 +4,8 @@ label: RFNoC DDC
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_device_bsp.block.yml
+++ b/gr-uhd/grc/uhd_fpga_device_bsp.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Device BSP
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'device'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: chdr_width
     label: CHDR Width

--- a/gr-uhd/grc/uhd_fpga_device_none.block.yml
+++ b/gr-uhd/grc/uhd_fpga_device_none.block.yml
@@ -5,9 +5,8 @@ flags: [ python ]
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'term'
-    options: ['block', 'sep', 'device', 'term']
     hide: all
 -   id: in_out
     label: Direction

--- a/gr-uhd/grc/uhd_fpga_duc.block.yml
+++ b/gr-uhd/grc/uhd_fpga_duc.block.yml
@@ -4,9 +4,8 @@ label: RFNoC DUC
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_eth_ta.block.yml
+++ b/gr-uhd/grc/uhd_fpga_eth_ta.block.yml
@@ -4,9 +4,8 @@ label: Ethernet Transport Adapter
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'transport_adapter'
-    options: ['block', 'sep', 'device', 'transport_adapter']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_fosphor.block.yml
+++ b/gr-uhd/grc/uhd_fpga_fosphor.block.yml
@@ -4,9 +4,8 @@ label: RFNoC F15 (FPGA Fosphor)
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_keep_one_in_n.block.yml
+++ b/gr-uhd/grc/uhd_fpga_keep_one_in_n.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Keep One-in-N
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_null_src_sink.block.yml
+++ b/gr-uhd/grc/uhd_fpga_null_src_sink.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Null Source/Sink
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_radio.block.yml
+++ b/gr-uhd/grc/uhd_fpga_radio.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Radio
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_replay.block.yml
+++ b/gr-uhd/grc/uhd_fpga_replay.block.yml
@@ -4,9 +4,8 @@ label: RFNoC DRAM Replay/Capture
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: priority
     label: Priority

--- a/gr-uhd/grc/uhd_fpga_sep.block.yml
+++ b/gr-uhd/grc/uhd_fpga_sep.block.yml
@@ -5,9 +5,8 @@ flags: [ python ]
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'sep'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: ctrl
     label: Pass Control Traffic

--- a/gr-uhd/grc/uhd_fpga_siggen.block.yml
+++ b/gr-uhd/grc/uhd_fpga_siggen.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Signal Generator
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_split_stream.block.yml
+++ b/gr-uhd/grc/uhd_fpga_split_stream.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Split Stream
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor

--- a/gr-uhd/grc/uhd_fpga_switchboard.block.yml
+++ b/gr-uhd/grc/uhd_fpga_switchboard.block.yml
@@ -4,9 +4,8 @@ label: RFNoC Switchboard
 parameters:
 -   id: type
     label: RFNoC Block Type
-    dtype: enum
+    dtype: string
     default: 'block'
-    options: ['block', 'sep', 'device']
     hide: all
 -   id: desc
     label: Block Descriptor


### PR DESCRIPTION
The image builder GRC bindings all have a 'type' parameter, which is hidden, and is used by `rfnoc_image_builder` to identify the block type. It was defined as an enum, to limit (and document) the available options.

However, in GRC, when you push the down or up keys on the keyboard while selecting a block, you change the first parameter that is an enum. For example, if you selected the terminator block and push down, it changes the 'type' to 'block', which confuses `rfnoc_image_builder`.

The "fix" is to simply make all of these 'type' parameters strings.

## Description

To understand the bug, if you're interested, try this:
- Open x310_image_core.grc from gr-uhd (in GTK-GRC)
- Select one of the "No connect" blocks
- Push down-arrow
- Save
- Look at the diff of `x310_image_core.grc`. You have now changed the type of this block from 'term' to 'block'.
- `rfnoc_image_builder` will no longer work on this file.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
