### PR TITLE
spelling for 3.10.12.0

### DIFF
--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -149,7 +149,7 @@ void thread_unbind(gr_thread_t thread)
     int ret = pthread_setaffinity_np(thread, len, &set);
     if (ret != 0) {
         auto msg = fmt::format(
-            "{}: pthread_setaffinity_np failed with errror {}", __func__, ret);
+            "{}: pthread_setaffinity_np failed with error {}", __func__, ret);
         thread_logger().error(msg);
         throw std::runtime_error(msg);
     }

--- a/gr-trellis/include/gnuradio/trellis/interleaver.h
+++ b/gr-trellis/include/gnuradio/trellis/interleaver.h
@@ -68,7 +68,7 @@ public:
      */
     interleaver(unsigned int k, int seed);
 
-    //! \brief return lenght of interleaver
+    //! \brief return length of interleaver
     unsigned int k() const { return d_interleaver_indices.size(); }
     //! \brief return interleaver index vector reference
     const std::vector<int>& interleaver_indices() const { return d_interleaver_indices; }
@@ -79,7 +79,7 @@ public:
     }
 
     // TODO in GR 3.11, remove K, INTER and DEINTER
-    //! \brief return lenght of interleaver
+    //! \brief return length of interleaver
     [[deprecated("Will be removed in 3.11")]] unsigned int K() const
     {
         return d_interleaver_indices.size();

--- a/gr-trellis/python/trellis/bindings/interleaver_python.cc
+++ b/gr-trellis/python/trellis/bindings/interleaver_python.cc
@@ -14,8 +14,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(interleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(59c2736b12495c8f86f6cd868e524fc4)                     */
+/* BINDTOOL_HEADER_FILE(interleaver.h)                                             */
+/* BINDTOOL_HEADER_FILE_HASH(3563a5c4bff31076d1ad4d851d1e6712)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description

In preparing Debian packages, Lintian found spelling errors.

## Testing Done

Patch also includes change in HASH value caused by this correction.

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [N/A] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [N/A] I have added tests to cover my changes, and all previous tests pass.
