### PR TITLE
digital: Fix soft decision lookup table

### DIFF
--- a/gr-digital/docs/digital.dox
+++ b/gr-digital/docs/digital.dox
@@ -1,6 +1,6 @@
 /*! \page page_digital Digital Modulation
 
-\section digtial_introduction Introduction
+\section digital_introduction Introduction
 This is the gr-digital package. It contains all of the digital
 modulation blocks, utilities, and examples. To use the digital blocks,
 the Python namespaces is in gnuradio.digital, which would be normally
@@ -31,15 +31,15 @@ constellation with:
 
 <pre>
     constel_points = [c0, c1, c2, c3]
-    symbols = [s0, s1, s2, s3]
+    symbol_map = [s0, s1, s2, s3]
 </pre>
 
-In this case: \f$c_i \in C\f$ and \f$s_i \in [00, 01, 10,
-11]\f$. Also, the mapping is a 1-to-1 for the items in both lists, so
-the symbol \f$s_0\f$ is positioned in complex space at the point
-\f$c_0\f$.
+In this case: c<sub>i</sub> is complex and s<sub>i</sub> is an integer
+from 0 to 3. Also, the mapping is 1-to-1 for the items in both lists,
+so given a chunk of input bits represented by n, the symbol resides in
+complex space at constel_points[symbol_map[n]].
 
-In the code itself, the symbols are referred to as the
+In the code itself, the symbol map is referred to as the
 'pre_diff_code' since this is the mapping before the application of
 differential modulation, if used.
 
@@ -165,13 +165,13 @@ similar to digital.psk_constellation.
 
 There is another Python file full of helper functions to create
 different constellations. This is found in the
-gr-digital/python/digital/psk_constellation.py file. This file
+gr-digital/python/digital/psk_constellations.py file. This file
 provides functions that build the vectors of constellation points and
 symbol mappings that can be used to create a constellation
 object. These are particularly helpful when using the Constellation
 Obj. and Constellation Rect. GUI elements in GRC.
 
-The gr-digital/python/digital/psk_constellation.py file has extensive
+The gr-digital/python/digital/psk_constellations.py file has extensive
 documentation that describes the naming scheme used for the different
 constellations that will not be repeated here. The main thing to
 understand is that these functions define constellations of the same
@@ -208,7 +208,7 @@ constellation:
 
 We provide a basis constellation map and symbol map as the fundamental
 rotation of the constellation points. This function uses the k and pi
-inputs (see the discussion in psk_constellation.py for what these
+inputs (see the discussion in psk_constellations.py for what these
 mean) to return a new rotation of the constellation's symbols. If the
 basis symbols are Gray coded than the output symbols will also be Gray
 coded. Note that this algorithm specifically depends on the
@@ -240,7 +240,7 @@ the documentation as:
         locking.
 </pre>
 
-Similarly, gr-digital/python/digital/qam_constellations.py defines a of
+Similarly, gr-digital/python/digital/qam_constellations.py defines
 QAM constellation functions that return a tuple containing the
 constellation points and the symbol mappings. The naming scheme is
 defined in depth in the module itself and is similar to the equivalent
@@ -459,12 +459,14 @@ sample and calculates the soft decisions using various methods. Plots
 the sample against the full constellation. Requires matplotlib installed.
 
 Functions:
-\li digital.sd_psk_2_*: Returns (constellation, symbol_map) lists for
+\li digital.psk_2_*: Returns (constellation, symbol_map) lists for
 different rotations for BPSK.
-\li digital.sd_psk_4_*: Returns (constellation, symbol_map) lists for
+\li digital.psk_4_*: Returns (constellation, symbol_map) lists for
 different rotations for QPSK.
-\li digital.sd_qam_16_*: Returns (constellation, symbol_map) lists for
+\li digital.qam_16_*: Returns (constellation, symbol_map) lists for
 different rotations for 16QAM.
+\li digital.sd_*: Returns the soft decision for the corresponding
+BPSK, QSK, and 16QAM constellations described above.
 \li digital.soft_dec_table_generator: Takes in a generator function
 (like the digital.sd_XXX above) and creates a LUT to a specific precision.
 \li digital.soft_dec_table: Takes in a constellation/symbol map and

--- a/gr-digital/examples/demod/constellation_soft_decoder.grc
+++ b/gr-digital/examples/demod/constellation_soft_decoder.grc
@@ -1,30 +1,26 @@
 options:
   parameters:
+    alias: ''
     author: Tom Rondeau
     catch_exceptions: 'True'
-    category: Custom
-    cmake_opt: ''
     comment: ''
     copyright: ''
     description: Explore Soft Decoding of constellations. Selec the constellation
       from the available objects.
-    gen_cmake: 'On'
     gen_linking: dynamic
     generate_options: qt_gui
+    generator_class_name: PythonQtGuiGenerator
+    generator_module: gnuradio.grc.workflows.python_qt_gui
     hier_block_src_path: '.:'
     id: constellation_soft_decoder
     max_nouts: '0'
     output_language: python
-    placement: (0,0)
     qt_qss_theme: ''
     realtime_scheduling: ''
     run: 'True'
     run_command: '{python} -u {filename}'
-    run_options: prompt
-    sizing_mode: fixed
     thread_safe_setters: ''
     title: Soft Decoder Example
-    window_size: 2000, 2000
   states:
     bus_sink: false
     bus_source: false
@@ -34,21 +30,22 @@ options:
     state: enabled
 
 blocks:
-- name: arity
+- name: axis_limit
   id: variable
   parameters:
     comment: ''
-    value: '4'
+    value: '1.25'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [173, 11]
+    coordinate: [376, 12.0]
     rotation: 0
     state: enabled
 - name: constel
   id: variable_constellation
   parameters:
+    axis_limit: '1.0'
     comment: ''
     const_points: digital.psk_4()[0]
     dims: '1'
@@ -63,12 +60,13 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [208, 540.0]
+    coordinate: [264, 956.0]
     rotation: 0
     state: enabled
 - name: constel
   id: variable_constellation
   parameters:
+    axis_limit: '1.0'
     comment: ''
     const_points: digital.psk_2()[0]
     dims: '1'
@@ -83,87 +81,91 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [384, 540.0]
+    coordinate: [520, 956.0]
     rotation: 0
     state: disabled
 - name: constel
   id: variable_constellation
   parameters:
+    axis_limit: axis_limit
     comment: ''
     const_points: digital.psk_2()[0]
     dims: '1'
     normalization: digital.constellation.AMPLITUDE_NORMALIZATION
     npwr: '1.0'
     precision: '8'
-    rot_sym: '4'
-    soft_dec_lut: digital.soft_dec_table_generator(digital.sd_psk_2, 8, 1)
+    rot_sym: '2'
+    soft_dec_lut: digital.soft_dec_table_generator(digital.sd_psk_2, 8, axis_limit)
     sym_map: digital.psk_2()[1]
     type: calcdist
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1040, 540.0]
+    coordinate: [1296, 956.0]
     rotation: 0
     state: disabled
 - name: constel
   id: variable_constellation
   parameters:
+    axis_limit: axis_limit
     comment: ''
     const_points: digital.psk_4()[0]
     dims: '1'
-    normalization: digital.constellation.AMPLITUDE_NORMALIZATION
+    normalization: digital.constellation.NO_NORMALIZATION
     npwr: '1.0'
     precision: '8'
     rot_sym: '4'
-    soft_dec_lut: digital.soft_dec_table_generator(digital.sd_psk_4, 8, 1)
+    soft_dec_lut: digital.soft_dec_table_generator(digital.sd_psk_4, 8, axis_limit)
     sym_map: digital.psk_4()[1]
     type: calcdist
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [864, 540.0]
+    coordinate: [1040, 956.0]
     rotation: 0
     state: disabled
 - name: constel
   id: variable_constellation
   parameters:
+    axis_limit: axis_limit
     comment: ''
     const_points: digital.qam_16()[0]
     dims: '1'
-    normalization: digital.constellation.AMPLITUDE_NORMALIZATION
+    normalization: digital.constellation.NO_NORMALIZATION
     npwr: '1.0'
     precision: '8'
     rot_sym: '4'
-    soft_dec_lut: digital.soft_dec_table_generator(digital.sd_qam_16, 8, 1)
+    soft_dec_lut: digital.soft_dec_table_generator(digital.sd_qam_16, 8, axis_limit)
     sym_map: digital.qam_16()[1]
     type: calcdist
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [688, 540.0]
+    coordinate: [784, 956.0]
     rotation: 0
     state: disabled
 - name: constel
   id: variable_constellation
   parameters:
+    axis_limit: '1.0'
     comment: ''
-    const_points: digital.qam_16()[0]
+    const_points: digital.qam_16_1()[0]
     dims: '1'
-    normalization: digital.constellation.AMPLITUDE_NORMALIZATION
+    normalization: digital.constellation.NO_NORMALIZATION
     npwr: '1.0'
     precision: '8'
     rot_sym: '4'
     soft_dec_lut: '''auto'''
-    sym_map: digital.qam_16()[1]
+    sym_map: digital.qam_16_1()[1]
     type: calcdist
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [32, 540.0]
+    coordinate: [16, 956.0]
     rotation: 0
     state: disabled
 - name: delay
@@ -187,13 +189,13 @@ blocks:
     options: '[0, 1, 2]'
     orient: Qt.QVBoxLayout
     type: int
-    value: '29'
+    value: '{1:29, 2:58, 4:116}[constel.bits_per_symbol()]'
     widget: combo_box
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1464, 260.0]
+    coordinate: [728, 12.0]
     rotation: 0
     state: enabled
 - name: nfilts
@@ -205,7 +207,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [840, 268.0]
+    coordinate: [648, 12.0]
     rotation: 0
     state: enabled
 - name: noise_volt
@@ -221,12 +223,12 @@ blocks:
     step: '0.01'
     stop: '1'
     value: '0.0001'
-    widget: slider
+    widget: eng_slider
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [32, 348.0]
+    coordinate: [864, 12.0]
     rotation: 0
     state: enabled
 - name: rrc_taps
@@ -238,7 +240,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [680, 268.0]
+    coordinate: [480, 12.0]
     rotation: 0
     state: enabled
 - name: samp_rate
@@ -250,7 +252,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [312, 11]
+    coordinate: [264, 12.0]
     rotation: 0
     state: enabled
 - name: sps
@@ -262,7 +264,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [239, 11]
+    coordinate: [184, 12.0]
     rotation: 0
     state: enabled
 - name: analog_random_source_x_0
@@ -282,7 +284,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [80, 244.0]
+    coordinate: [80, 412.0]
     rotation: 180
     state: enabled
 - name: blocks_char_to_float_0
@@ -299,7 +301,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1272, 180.0]
+    coordinate: [880, 740.0]
     rotation: 0
     state: enabled
 - name: blocks_char_to_float_0_0
@@ -316,7 +318,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1272, 124.0]
+    coordinate: [752, 644.0]
     rotation: 0
     state: enabled
 - name: blocks_char_to_float_0_0_0
@@ -333,7 +335,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1280, 340.0]
+    coordinate: [576, 460.0]
     rotation: 0
     state: enabled
 - name: blocks_delay_0
@@ -353,7 +355,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [784, 340.0]
+    coordinate: [440, 460.0]
     rotation: 0
     state: enabled
 - name: blocks_throttle2_0
@@ -374,7 +376,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [80, 164.0]
+    coordinate: [80, 308.0]
     rotation: 0
     state: enabled
 - name: blocks_unpack_k_bits_bb_0
@@ -390,7 +392,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1136, 180.0]
+    coordinate: [720, 740.0]
     rotation: 0
     state: enabled
 - name: blocks_unpack_k_bits_bb_0_0
@@ -406,7 +408,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [312, 340.0]
+    coordinate: [272, 460.0]
     rotation: 0
     state: enabled
 - name: channels_channel_model_0
@@ -427,7 +429,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [472, 132.0]
+    coordinate: [488, 276.0]
     rotation: 0
     state: enabled
 - name: digital_binary_slicer_fb_0
@@ -442,7 +444,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1144, 128.0]
+    coordinate: [552, 648.0]
     rotation: 0
     state: enabled
 - name: digital_constellation_decoder_cb_0
@@ -458,7 +460,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1120, 284.0]
+    coordinate: [264, 740.0]
     rotation: 0
     state: enabled
 - name: digital_constellation_modulator_0
@@ -480,7 +482,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [256, 148.0]
+    coordinate: [256, 292.0]
     rotation: 0
     state: enabled
 - name: digital_constellation_soft_decoder_cf_0
@@ -497,7 +499,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [928, 124.0]
+    coordinate: [280, 636.0]
     rotation: 0
     state: enabled
 - name: digital_map_bb_0_0
@@ -506,15 +508,15 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    map: constel.pre_diff_code()
+    map: constel.pre_diff_decode()
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1136, 236.0]
-    rotation: 180
+    coordinate: [512, 740.0]
+    rotation: 0
     state: enabled
 - name: digital_pfb_clock_sync_xxx_0
   id: digital_pfb_clock_sync_xxx
@@ -536,33 +538,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [672, 124.0]
-    rotation: 0
-    state: enabled
-- name: import_cmath
-  id: import
-  parameters:
-    alias: ''
-    comment: ''
-    imports: import cmath
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [488, 11]
-    rotation: 0
-    state: enabled
-- name: import_math
-  id: import
-  parameters:
-    alias: ''
-    comment: ''
-    imports: import math
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [400, 11]
+    coordinate: [704, 268.0]
     rotation: 0
     state: enabled
 - name: note_auto
@@ -575,7 +551,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [32, 492.0]
+    coordinate: [16, 892.0]
     rotation: 0
     state: enabled
 - name: note_py
@@ -588,7 +564,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [688, 492.0]
+    coordinate: [784, 892.0]
     rotation: 0
     state: enabled
 - name: qtgui_const_sink_x_1
@@ -680,7 +656,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [928, 52.0]
+    coordinate: [280, 548.0]
     rotation: 0
     state: enabled
 - name: qtgui_time_sink_x_0
@@ -777,7 +753,59 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1464, 128.0]
+    coordinate: [1096, 648.0]
+    rotation: 0
+    state: enabled
+- name: virtual_sink_0
+  id: virtual_sink
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: clock_sync
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [976, 268.0]
+    rotation: 0
+    state: enabled
+- name: virtual_sink_1
+  id: virtual_sink
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: input_bits
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [744, 460.0]
+    rotation: 0
+    state: enabled
+- name: virtual_source_0
+  id: virtual_source
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: clock_sync
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [56, 644.0]
+    rotation: 0
+    state: enabled
+- name: virtual_source_1
+  id: virtual_source
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: input_bits
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [864, 804.0]
     rotation: 0
     state: enabled
 
@@ -785,7 +813,7 @@ connections:
 - [analog_random_source_x_0, '0', blocks_throttle2_0, '0']
 - [blocks_char_to_float_0, '0', qtgui_time_sink_x_0, '1']
 - [blocks_char_to_float_0_0, '0', qtgui_time_sink_x_0, '0']
-- [blocks_char_to_float_0_0_0, '0', qtgui_time_sink_x_0, '2']
+- [blocks_char_to_float_0_0_0, '0', virtual_sink_1, '0']
 - [blocks_delay_0, '0', blocks_char_to_float_0_0_0, '0']
 - [blocks_throttle2_0, '0', blocks_unpack_k_bits_bb_0_0, '0']
 - [blocks_throttle2_0, '0', digital_constellation_modulator_0, '0']
@@ -797,10 +825,12 @@ connections:
 - [digital_constellation_modulator_0, '0', channels_channel_model_0, '0']
 - [digital_constellation_soft_decoder_cf_0, '0', digital_binary_slicer_fb_0, '0']
 - [digital_map_bb_0_0, '0', blocks_unpack_k_bits_bb_0, '0']
-- [digital_pfb_clock_sync_xxx_0, '0', digital_constellation_decoder_cb_0, '0']
-- [digital_pfb_clock_sync_xxx_0, '0', digital_constellation_soft_decoder_cf_0, '0']
-- [digital_pfb_clock_sync_xxx_0, '0', qtgui_const_sink_x_1, '0']
+- [digital_pfb_clock_sync_xxx_0, '0', virtual_sink_0, '0']
+- [virtual_source_0, '0', digital_constellation_decoder_cb_0, '0']
+- [virtual_source_0, '0', digital_constellation_soft_decoder_cf_0, '0']
+- [virtual_source_0, '0', qtgui_const_sink_x_1, '0']
+- [virtual_source_1, '0', qtgui_time_sink_x_0, '2']
 
 metadata:
   file_format: 1
-  grc_version: 3.10.10.0
+  grc_version: g8303f6db8

--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -51,6 +51,12 @@ parameters:
     default: None
     hide: ${ ('part' if str(soft_dec_lut) == 'None' else 'none') }
 
+-   id: axis_limit
+    label: LUT Axis Limit
+    dtype: float
+    default: 1.0
+    hide: ${'all' if str(soft_dec_lut).lower() == 'auto' or str(soft_dec_lut) == 'None' else 'part'}
+
 value: ${ digital.constellation_calcdist(const_points, sym_map, rot_sym, dims, normalization) if (str(type) == "calcdist") else getattr(digital,'constellation_'+str(type))()  }
 
 
@@ -67,7 +73,7 @@ templates:
         % if str(soft_dec_lut).lower() == '"auto"' or str(soft_dec_lut).lower() == "'auto'":
         self.${id}.gen_soft_dec_lut(${precision})
         % elif str(soft_dec_lut) != "None":
-        self.${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision})
+        self.${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision}, ${axis_limit})
         % endif
 
 cpp_templates:
@@ -86,7 +92,7 @@ cpp_templates:
         % if str(soft_dec_lut).lower() == '"auto"' or str(soft_dec_lut).lower() == "'auto'":
         this->${id}.gen_soft_dec_lut(${precision});
         % elif str(soft_dec_lut) != "None":
-        this->${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision});
+        this->${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision}, ${axis_limit});
         % endif
     link: ['gnuradio::gnuradio-digital']
 

--- a/gr-digital/grc/digital_constellation_rect.block.yml
+++ b/gr-digital/grc/digital_constellation_rect.block.yml
@@ -42,6 +42,12 @@ parameters:
     dtype: raw
     default: None
     hide: ${ ('part' if str(soft_dec_lut) == 'None' else 'none') }
+-   id: axis_limit
+    label: LUT Axis Limit
+    dtype: float
+    default: 1.0
+    hide: ${'all' if str(soft_dec_lut).lower() == 'auto' or str(soft_dec_lut) == 'None' else 'part'}
+
 value: ${ digital.constellation_rect(const_points, sym_map, rot_sym, real_sect, imag_sect,
     w_real_sect, w_imag_sect) }
 
@@ -53,7 +59,7 @@ templates:
         % if str(soft_dec_lut).lower() == '"auto"' or str(soft_dec_lut).lower() == "'auto'":
         self.${id}.gen_soft_dec_lut(${precision})
         % elif str(soft_dec_lut) != "None":
-        self.${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision})
+        self.${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision}, ${axis_limit})
         % endif
 
 file_format: 1

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -103,6 +103,8 @@ public:
     void set_pre_diff_code(bool a) { d_apply_pre_diff_code = a; }
     //! Returns the encoding to apply before differential encoding.
     std::vector<int> pre_diff_code() { return d_pre_diff_code; }
+    //! Returns the inverse of pre_diff_code
+    std::vector<int> pre_diff_decode() { return d_pre_diff_decode; }
     //! Returns the order of rotational symmetry.
     unsigned int rotational_symmetry() { return d_rotational_symmetry; }
     //! Returns the number of complex numbers in a single symbol.
@@ -173,9 +175,11 @@ public:
      *        there are k bits/sample in the constellation).
      * \param precision The number of bits of precision used when
      *        generating the LUT.
+     * \param axis_limit The maximum axis coordinate of the LUT
      */
     void set_soft_dec_lut(const std::vector<std::vector<float>>& soft_dec_lut,
-                          int precision);
+                          int precision,
+                          float axis_limit);
 
     /*! \brief Sets the constellation noise power and recalculates LUT given \p npwr.
      *
@@ -211,27 +215,27 @@ public:
 protected:
     std::vector<gr_complex> d_constellation;
     std::vector<int> d_pre_diff_code;
+    std::vector<int> d_pre_diff_decode;
     bool d_apply_pre_diff_code;
     unsigned int d_rotational_symmetry;
     unsigned int d_dimensionality;
     unsigned int d_arity;
     //! The factor by which the user given constellation points were
     //! scaled by to achieve an average amplitude of 1.
-    float d_scalefactor, d_maxamp;
-    float d_re_min, d_re_max, d_im_min, d_im_max;
+    float d_scalefactor;
 
     std::vector<std::vector<float>> d_soft_dec_lut;
     int d_lut_precision;
-    float d_lut_scale;
     float d_npwr;
-    float d_padding;
+    float d_lut_padding;
+    float d_lut_axis_limit;
     bool d_use_external_lut;
 
     float get_distance(unsigned int index, const gr_complex* sample);
     unsigned int get_closest_point(const gr_complex* sample);
     void calc_arity();
-
-    void max_min_axes();
+    float max_axis();
+    std::vector<int> invert_code(const std::vector<int>& code);
 };
 
 /************************************************************/

--- a/gr-digital/python/digital/bindings/constellation_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constellation.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(db216c4298d744fde5e8f7449bb8c8e4)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0a7037f35318fda5a6afed827b32e036)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -134,6 +134,11 @@ void bind_constellation(py::module& m)
              D(constellation, pre_diff_code))
 
 
+        .def("pre_diff_decode",
+             &constellation::pre_diff_decode,
+             D(constellation, pre_diff_decode))
+
+
         .def("rotational_symmetry",
              &constellation::rotational_symmetry,
              D(constellation, rotational_symmetry))
@@ -176,6 +181,7 @@ void bind_constellation(py::module& m)
              &constellation::set_soft_dec_lut,
              py::arg("soft_dec_lut"),
              py::arg("precision"),
+             py::arg("axis_limit"),
              D(constellation, set_soft_dec_lut))
 
 

--- a/gr-digital/python/digital/bindings/docstrings/constellation_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/constellation_pydoc_template.h
@@ -69,6 +69,9 @@ static const char* __doc_gr_digital_constellation_set_pre_diff_code = R"doc()doc
 static const char* __doc_gr_digital_constellation_pre_diff_code = R"doc()doc";
 
 
+static const char* __doc_gr_digital_constellation_pre_diff_decode = R"doc()doc";
+
+
 static const char* __doc_gr_digital_constellation_rotational_symmetry = R"doc()doc";
 
 

--- a/gr-digital/python/digital/psk_constellations.py
+++ b/gr-digital/python/digital/psk_constellations.py
@@ -8,7 +8,7 @@
 #
 #
 
-import numpy
+from .utils.mod_codes import invert_code
 from .constellation_map_generator import constellation_map_generator
 
 '''
@@ -82,26 +82,22 @@ psk_2_1 = psk_2_0x1
 # BPSK Soft bit LUT generators
 ############################################################
 
-def sd_psk_2_0x0(x, Es=1):
+def sd_psk_2_0x0(x):
     '''
     0 | 1
     '''
-    x_re = x.real
-    dist = Es * numpy.sqrt(2)
-    return [dist * x_re, ]
+    return [x.real, ]
 
 
 sd_psk_2 = sd_psk_2_0x0  # Basic BPSK rotation
 sd_psk_2_0 = sd_psk_2    # First ID for BPSK rotations
 
 
-def sd_psk_2_0x1(x, Es=1):
+def sd_psk_2_0x1(x):
     '''
     1 | 0
     '''
-    x_re = [x.real, ]
-    dist = Es * numpy.sqrt(2)
-    return -dist * x_re
+    return [-x.real]
 
 
 sd_psk_2_1 = sd_psk_2_0x1
@@ -120,7 +116,7 @@ def psk_4_0x0_0_1():
     const_points = [-1 - 1j, 1 - 1j,
                     -1 + 1j, 1 + 1j]
     symbols = [0, 1, 2, 3]
-    return (const_points, symbols)
+    return const_points, invert_code(symbols)
 
 
 psk_4 = psk_4_0x0_0_1
@@ -135,7 +131,8 @@ def psk_4_0x1_0_1():
     '''
     k = 0x1
     pi = [0, 1]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_1 = psk_4_0x1_0_1
@@ -149,7 +146,8 @@ def psk_4_0x2_0_1():
     '''
     k = 0x2
     pi = [0, 1]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_2 = psk_4_0x2_0_1
@@ -163,7 +161,8 @@ def psk_4_0x3_0_1():
     '''
     k = 0x3
     pi = [0, 1]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_3 = psk_4_0x3_0_1
@@ -177,7 +176,8 @@ def psk_4_0x0_1_0():
     '''
     k = 0x0
     pi = [1, 0]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_4 = psk_4_0x0_1_0
@@ -191,7 +191,8 @@ def psk_4_0x1_1_0():
     '''
     k = 0x1
     pi = [1, 0]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_5 = psk_4_0x1_1_0
@@ -205,7 +206,8 @@ def psk_4_0x2_1_0():
     '''
     k = 0x2
     pi = [1, 0]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_6 = psk_4_0x2_1_0
@@ -219,7 +221,8 @@ def psk_4_0x3_1_0():
     '''
     k = 0x3
     pi = [1, 0]
-    return constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(psk_4()[0], psk_4()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 psk_4_7 = psk_4_0x3_1_0
@@ -229,7 +232,7 @@ psk_4_7 = psk_4_0x3_1_0
 # QPSK Constellation Softbit LUT generators
 ############################################################
 
-def sd_psk_4_0x0_0_1(x, Es=1):
+def sd_psk_4_0x0_0_1(x):
     '''
     | 10 | 11
     | -------
@@ -237,15 +240,14 @@ def sd_psk_4_0x0_0_1(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [dist * x_im, dist * x_re]
+    return [x_im, x_re]
 
 
 sd_psk_4 = sd_psk_4_0x0_0_1
 sd_psk_4_0 = sd_psk_4
 
 
-def sd_psk_4_0x1_0_1(x, Es=1):
+def sd_psk_4_0x1_0_1(x):
     '''
     | 11 | 10
     | -------
@@ -253,14 +255,13 @@ def sd_psk_4_0x1_0_1(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [dist * x_im, -dist * x_re]
+    return [x_im, -x_re]
 
 
 sd_psk_4_1 = sd_psk_4_0x1_0_1
 
 
-def sd_psk_4_0x2_0_1(x, Es=1):
+def sd_psk_4_0x2_0_1(x):
     '''
     | 00 | 01
     | -------
@@ -268,14 +269,13 @@ def sd_psk_4_0x2_0_1(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [-dist * x_im, dist * x_re]
+    return [-x_im, x_re]
 
 
 sd_psk_4_2 = sd_psk_4_0x2_0_1
 
 
-def sd_psk_4_0x3_0_1(x, Es=1):
+def sd_psk_4_0x3_0_1(x):
     '''
     | 01 | 00
     | -------
@@ -283,14 +283,13 @@ def sd_psk_4_0x3_0_1(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [-dist * x_im, -dist * x_re]
+    return [-x_im, -x_re]
 
 
 sd_psk_4_3 = sd_psk_4_0x3_0_1
 
 
-def sd_psk_4_0x0_1_0(x, Es=1):
+def sd_psk_4_0x0_1_0(x):
     '''
     | 01 | 11
     | -------
@@ -298,14 +297,13 @@ def sd_psk_4_0x0_1_0(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [dist * x_re, dist * x_im]
+    return [x_re, x_im]
 
 
 sd_psk_4_4 = sd_psk_4_0x0_1_0
 
 
-def sd_psk_4_0x1_1_0(x, Es=1):
+def sd_psk_4_0x1_1_0(x):
     '''
     | 00 | 10
     | -------
@@ -313,14 +311,13 @@ def sd_psk_4_0x1_1_0(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [dist * x_re, -dist * x_im]
+    return [x_re, -x_im]
 
 
 sd_psk_4_5 = sd_psk_4_0x1_1_0
 
 
-def sd_psk_4_0x2_1_0(x, Es=1):
+def sd_psk_4_0x2_1_0(x):
     '''
     | 11 | 01
     | -------
@@ -328,14 +325,13 @@ def sd_psk_4_0x2_1_0(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [-dist * x_re, dist * x_im]
+    return [-x_re, x_im]
 
 
 sd_psk_4_6 = sd_psk_4_0x2_1_0
 
 
-def sd_psk_4_0x3_1_0(x, Es=1):
+def sd_psk_4_0x3_1_0(x):
     '''
     | 10 | 00
     | -------
@@ -343,8 +339,7 @@ def sd_psk_4_0x3_1_0(x, Es=1):
     '''
     x_re = x.real
     x_im = x.imag
-    dist = Es * numpy.sqrt(2)
-    return [-dist * x_re, -dist * x_im]
+    return [-x_re, -x_im]
 
 
 sd_psk_4_7 = sd_psk_4_0x3_1_0

--- a/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
+++ b/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
@@ -8,214 +8,280 @@
 #
 #
 
-
 from gnuradio import gr, gr_unittest, digital, blocks
-from math import sqrt
-from numpy import random, vectorize
+from gnuradio.digital import soft_dec_table_generator
+from gnuradio.digital import psk_constellations, qam_constellations
+import numpy as np
+
+NO_NORM = digital.constellation.NO_NORMALIZATION
 
 
 class test_constellation_soft_decoder(gr_unittest.TestCase):
-
     def setUp(self):
-        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):
         self.tb = None
 
-    def helper_with_lut(self, prec, src_data, const_gen, const_sd_gen, decimals=5):
-        cnst_pts, code = const_gen()
-        Es = 1.0
-        lut = digital.soft_dec_table(cnst_pts, code, prec, Es)
-
-        constel = digital.const_normalization(cnst_pts, "POWER")
-        maxamp = digital.min_max_axes(constel)
-
-        expected_result = list()
-        for s in src_data:
-            res = digital.calc_soft_dec_from_table(s, lut, prec, maxamp)
-            expected_result += res
-
-        cnst = digital.constellation_calcdist(cnst_pts, code, 4, 1, digital.constellation.POWER_NORMALIZATION)
-        cnst.set_soft_dec_lut(lut, int(prec))
-        cnst.normalize(digital.constellation.POWER_NORMALIZATION)
-        src = blocks.vector_source_c(src_data)
-        op = digital.constellation_soft_decoder_cf(cnst.base())
-        dst = blocks.vector_sink_f()
-
-        self.tb.connect(src, op)
-        self.tb.connect(op, dst)
+    def run_test(self, constel, src_data, expected, places):
+        self.src = blocks.vector_source_c(src_data)
+        self.snk = blocks.vector_sink_f()
+        self.soft_decoder = digital.constellation_soft_decoder_cf(constel)
+        self.tb.connect(self.src, self.soft_decoder, self.snk)
         self.tb.run()
+        result = self.snk.data()
+        self.assertFloatTuplesAlmostEqual(result, expected, places)
 
-        actual_result = dst.data()  # fetch the contents of the sink
-        # print "actual result", actual_result
-        # print "expected result", expected_result
-        self.assertFloatTuplesAlmostEqual(expected_result, actual_result, decimals)
+    def flatten(self, list_of_lists):
+        return [i for inner_list in list_of_lists for i in inner_list]
 
-    def helper_no_lut(self, prec, src_data, const_gen, const_sd_gen):
-        cnst_pts, code = const_gen()
-        cnst = digital.constellation_calcdist(cnst_pts, code, 2, 1)
-        expected_result = list()
-        for s in src_data:
-            res = digital.calc_soft_dec(s, cnst.points(), code)
-            expected_result += res
+    def llr_bpsk(self, samp, npwr, Es=1.0):
+        """Calculate log-likelihood ratio for BPSK signal"""
+        noise_i = npwr / 2
+        return [2.0 * np.sqrt(Es) * samp.real / noise_i]
 
-        src = blocks.vector_source_c(src_data)
-        op = digital.constellation_soft_decoder_cf(cnst.base())
-        dst = blocks.vector_sink_f()
+    def lut_index_to_complex(self, re, im, precision, axis_limit):
+        """Conversion of lut indices to the complex plane, for testing
+        the lookup table at exact points"""
+        step = 2 * axis_limit / (2**precision - 1)
+        return [
+            complex(-axis_limit + r * step, -axis_limit + i * step)
+            for r, i in zip(re, im)
+        ]
 
-        self.tb.connect(src, op)
-        self.tb.connect(op, dst)
+    def test_custom_qpsk(self):
+        """
+        Use custom qpsk constellation with symbol map that is not involution
+        01|11
+        -----
+        00|10
+        """
+        points = [1 + 1j, -1 + 1j, -1 - 1j, 1 - 1j]
+        # decode = [3, 1, 0, 2]
+        symbol_map = [2, 1, 3, 0]
+        # Input is constel points in reverse order
+        inputs = [1 - 1j, -1 - 1j, -1 + 1j, 1 + 1j]
+        # Expected output is the decoded chunks in reverse order
+        expected = [2, 0, 1, 3]
+        constel = digital.constellation_calcdist(points, symbol_map, 4, 1,
+                                                 NO_NORM)
+        src = blocks.vector_source_c(inputs)
+        softdecoder = digital.constellation_soft_decoder_cf(constel)
+        slicer = digital.binary_slicer_fb()
+        pack2 = blocks.pack_k_bits_bb(2)
+        snk = blocks.vector_sink_b()
+        self.tb.connect(src, softdecoder, slicer, pack2, snk)
         self.tb.run()
+        out = snk.data()
+        self.assertListEqual(out, expected)
 
-        actual_result = dst.data()  # fetch the contents of the sink
-        # print "actual result", actual_result
-        # print "expected result", expected_result
+    def test_bpsk_no_lut(self):
+        points, coding = digital.psk_2()
+        bpsk = digital.constellation_calcdist(points, coding, 2, 1)
+        npwr = 0.5
+        bpsk.set_npwr(0.5)
+        src_data = [-0.5 + 0.2j, -1 + 1j, -1.25 - 0.4j, 0.3 - 0.8j]
+        expected = self.flatten([self.llr_bpsk(s, npwr) for s in src_data])
+        self.run_test(bpsk, src_data, expected, 5)
 
-        # Double vs. float precision issues between Python and C++, so
-        # use only 4 decimals in comparisons.
-        self.assertFloatTuplesAlmostEqual(expected_result, actual_result, 4)
+    def test_bpsk_lut(self):
+        points, coding = digital.psk_2()
+        bpsk = digital.constellation_calcdist(points, coding, 2, 1)
+        npwr = 2
+        bpsk.set_npwr(npwr)
+        prec = 8
+        bpsk.gen_soft_dec_lut(prec)
+        # use lut indices to test exact sample points in lut
+        re = [0, 30, 60, 0, 150, 255, 180, 255]
+        im = [0, 45, 145, 255, 190, 255, 12, 0]
+        max_axis = digital.min_max_axes(bpsk.points())
+        PADDING = 2
+        axis_limit = PADDING * max_axis
+        src_data = self.lut_index_to_complex(re, im, prec, axis_limit)
+        expected = self.flatten([self.llr_bpsk(s, npwr) for s in src_data])
+        self.run_test(bpsk, src_data, expected, 5)
 
-    def test_constellation_soft_decoder_cf_bpsk_3(self):
-        prec = 3
+    def test_bpsk_lut_external_sd(self):
+        points, coding = digital.psk_2()
+        bpsk = digital.constellation_calcdist(points, coding, 2, 1)
+        prec = 8
+        axlimit = 2
+        lut = soft_dec_table_generator(digital.sd_psk_2, prec, axlimit)
+        bpsk.set_soft_dec_lut(lut, prec, axlimit)
+
         src_data = (-1.0 - 1.0j, 1.0 - 1.0j, -1.0 + 1.0j, 1.0 + 1.0j,
                     -2.0 - 2.0j, 2.0 - 2.0j, -2.0 + 2.0j, 2.0 + 2.0j,
                     -0.2 - 0.2j, 0.2 - 0.2j, -0.2 + 0.2j, 0.2 + 0.2j,
                     0.3 + 0.4j, 0.1 - 1.2j, -0.8 - 0.1j, -0.4 + 0.8j,
                     0.8 + 1.0j, -0.5 + 0.1j, 0.1 + 1.2j, -1.7 - 0.9j)
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.psk_2_0x0,
-            digital.sd_psk_2_0x0)
+        expected = self.flatten([digital.sd_psk_2(s) for s in src_data])
+        # relax number of places; the src_data do not map to
+        # exact points in the lookup table
+        self.run_test(bpsk, src_data, expected, 1)
 
-    def test_constellation_soft_decoder_cf_bpsk_8(self):
-        prec = 8
+    def test_bpsk_python_no_lut(self):
+        """ show that python soft decision is same as cpp constel """
+        points, coding = digital.psk_2()
+        bpsk = digital.constellation_calcdist(points, coding, 2, 1)
+        npwr = 1.5
+        bpsk.set_npwr(1.5)
         src_data = (-1.0 - 1.0j, 1.0 - 1.0j, -1.0 + 1.0j, 1.0 + 1.0j,
                     -2.0 - 2.0j, 2.0 - 2.0j, -2.0 + 2.0j, 2.0 + 2.0j,
                     -0.2 - 0.2j, 0.2 - 0.2j, -0.2 + 0.2j, 0.2 + 0.2j,
                     0.3 + 0.4j, 0.1 - 1.2j, -0.8 - 0.1j, -0.4 + 0.8j,
                     0.8 + 1.0j, -0.5 + 0.1j, 0.1 + 1.2j, -1.7 - 0.9j)
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.psk_2_0x0,
-            digital.sd_psk_2_0x0)
+        expected = self.flatten([digital.calc_soft_dec(s, points, coding, npwr)
+                                 for s in src_data])
+        self.run_test(bpsk, src_data, expected, 5)
 
-    def test_constellation_soft_decoder_cf_bpsk_8_rand(self):
+    def test_bpsk_python_lut(self):
+        """ show that python table lookup is same as cpp constel """
+        points, coding = digital.psk_2()
+        bpsk = digital.constellation_calcdist(points, coding, 2, 1)
+        npwr = 1.2
         prec = 8
-        src_data = vectorize(complex)(
-            2 * random.randn(100), 2 * random.randn(100))
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.psk_2_0x0,
-            digital.sd_psk_2_0x0)
-
-    def test_constellation_soft_decoder_cf_bpsk_8_rand2(self):
-        prec = 8
-        src_data = vectorize(complex)(
-            2 * random.randn(100), 2 * random.randn(100))
-        self.helper_no_lut(
-            prec,
-            src_data,
-            digital.psk_2_0x0,
-            digital.sd_psk_2_0x0)
-
-    def test_constellation_soft_decoder_cf_qpsk_3(self):
-        prec = 3
+        lut = digital.soft_dec_table(points, coding, prec, npwr)
+        PADDING = 2
+        max_axis = digital.min_max_axes(points)
+        axlimit = PADDING * max_axis
+        bpsk.set_soft_dec_lut(lut, prec, axlimit)
         src_data = (-1.0 - 1.0j, 1.0 - 1.0j, -1.0 + 1.0j, 1.0 + 1.0j,
                     -2.0 - 2.0j, 2.0 - 2.0j, -2.0 + 2.0j, 2.0 + 2.0j,
                     -0.2 - 0.2j, 0.2 - 0.2j, -0.2 + 0.2j, 0.2 + 0.2j,
                     0.3 + 0.4j, 0.1 - 1.2j, -0.8 - 0.1j, -0.4 + 0.8j,
                     0.8 + 1.0j, -0.5 + 0.1j, 0.1 + 1.2j, -1.7 - 0.9j)
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.psk_4_0x0_0_1,
-            digital.sd_psk_4_0x0_0_1)
 
-    def test_constellation_soft_decoder_cf_qpsk_8(self):
+        expected = self.flatten(
+            [
+                digital.calc_soft_dec_from_table(s, lut, prec, axlimit)
+                for s in src_data
+            ]
+        )
+        self.run_test(bpsk, src_data, expected, 6)
+
+    def llr_qpsk(self, samp, npwr, Es):
+        """ Loglikelihood ratio for digital.psk_4 constellation """
+        dist_from_axis = np.sqrt(Es) / np.sqrt(2)
+        npwr_i = npwr_q = npwr / 2
+        llr_bit1 = 2 * dist_from_axis * samp.imag / npwr_q
+        llr_bit0 = 2 * dist_from_axis * samp.real / npwr_i
+        return [llr_bit1, llr_bit0]
+
+    def test_qpsk_no_lut(self):
+        points, coding = digital.psk_4()
+        qpsk = digital.constellation_calcdist(points, coding, 4, 1, NO_NORM)
+        src_data = [-0.5 - 0.5j, -1 + 1j, -1.25 + 0.8j, 0.3 - 0.1j]
+        npwr = 0.75
+        qpsk.set_npwr(npwr)
+        Es = max(np.abs(qpsk.points())) ** 2
+        expected = self.flatten([self.llr_qpsk(x, npwr, Es) for x in src_data])
+        self.run_test(qpsk, src_data, expected, 5)
+
+    def test_qpsk_lut(self):
+        points, coding = digital.psk_4()
+        qpsk = digital.constellation_calcdist(points, coding, 4, 1, NO_NORM)
+        npwr = 2
+        qpsk.set_npwr(npwr)
         prec = 8
+        qpsk.gen_soft_dec_lut(prec)
+        # use lut indices to test exact sample points
+        re = [0, 30, 60, 0, 150, 255, 180, 255]
+        im = [0, 45, 145, 255, 190, 255, 12, 0]
+        PADDING = 2
+        max_axis = digital.min_max_axes(qpsk.points())
+        axis_limit = PADDING * max_axis
+        src_data = self.lut_index_to_complex(re, im, prec, axis_limit)
+        Es = max(np.abs(qpsk.points())) ** 2
+        expected = self.flatten([self.llr_qpsk(s, npwr, Es) for s in src_data])
+        self.run_test(qpsk, src_data, expected, 5)
+
+    def test_qpsk_lut_external_sd(self):
+        points, coding = digital.psk_4()
+        qpsk = digital.constellation_calcdist(points, coding, 4, 1, NO_NORM)
+        prec = 8
+        axlimit = 2
+        lut = soft_dec_table_generator(digital.sd_psk_4, prec, axlimit)
+        qpsk.set_soft_dec_lut(lut, prec, axlimit)
         src_data = (-1.0 - 1.0j, 1.0 - 1.0j, -1.0 + 1.0j, 1.0 + 1.0j,
                     -2.0 - 2.0j, 2.0 - 2.0j, -2.0 + 2.0j, 2.0 + 2.0j,
                     -0.2 - 0.2j, 0.2 - 0.2j, -0.2 + 0.2j, 0.2 + 0.2j,
                     0.3 + 0.4j, 0.1 - 1.2j, -0.8 - 0.1j, -0.4 + 0.8j,
                     0.8 + 1.0j, -0.5 + 0.1j, 0.1 + 1.2j, -1.7 - 0.9j)
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.psk_4_0x0_0_1,
-            digital.sd_psk_4_0x0_0_1)
+        expected = self.flatten([digital.sd_psk_4(s) for s in src_data])
+        self.run_test(qpsk, src_data, expected, 1)
 
-    def test_constellation_soft_decoder_cf_qpsk_8_rand(self):
+    def llr_qam(self, samp, npwr):
+        """ Log-likelihood ratio for constellation in digital.qam_16 """
+        def gexp(x, mean, pwr):
+            """calculate exponent portion of gaussian pdf"""
+            return np.exp(-0.5 / pwr * (x - mean) ** 2)
+
+        npwr_i = npwr_q = npwr / 2
+        # the qam gray coding allows the first two bits to
+        # depend only on the real part
+        IP = 1 / 3  # QAM inner points
+        OP = 1.0  # QAM outer points
+        nom3 = gexp(samp.real, IP, npwr_i) + gexp(samp.real, OP, npwr_i)
+        den3 = gexp(samp.real, -IP, npwr_i) + gexp(samp.real, -OP, npwr_i)
+        llrbit3 = np.log(nom3 / den3)
+        nom2 = gexp(samp.real, -IP, npwr_i) + gexp(samp.real, IP, npwr_i)
+        den2 = gexp(samp.real, -OP, npwr_i) + gexp(samp.real, OP, npwr_i)
+        llrbit2 = np.log(nom2 / den2)
+        # similarly, the last two bits only depend on the imag part
+        nom1 = gexp(samp.imag, IP, npwr_q) + gexp(samp.imag, OP, npwr_q)
+        den1 = gexp(samp.imag, -IP, npwr_q) + gexp(samp.imag, -OP, npwr_q)
+        llrbit1 = np.log(nom1 / den1)
+        nom0 = gexp(samp.imag, IP, npwr_q) + gexp(samp.imag, -IP, npwr_q)
+        den0 = gexp(samp.imag, OP, npwr_q) + gexp(samp.imag, -OP, npwr_q)
+        llrbit0 = np.log(nom0 / den0)
+        return [llrbit3, llrbit2, llrbit1, llrbit0]
+
+    def test_qam_no_lut(self):
+        points, coding = digital.qam_16()
+        qam = digital.constellation_calcdist(points, coding, 4, 1, NO_NORM)
+        npwr = 1.25
+        qam.set_npwr(npwr)
+        src_data = [-3 - 3j, -2 + 1j, -1.25 + 0.8j, 0.3 - 0.1j, 4 + 3j]
+        expected = self.flatten([self.llr_qam(s, npwr) for s in src_data])
+        self.run_test(qam, src_data, expected, 5)
+
+    def test_qam_lut(self):
+        points, coding = digital.qam_16()
+        qam = digital.constellation_calcdist(points, coding, 4, 1, NO_NORM)
+        npwr = 2.2
+        qam.set_npwr(npwr)
         prec = 8
-        src_data = vectorize(complex)(
-            2 * random.randn(100), 2 * random.randn(100))
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.psk_4_0x0_0_1,
-            digital.sd_psk_4_0x0_0_1,
-            3)
+        qam.gen_soft_dec_lut(prec)
+        # use lut indices to test exact sample points in lut
+        re = [0, 30, 60, 0, 150, 255, 180, 255]
+        im = [0, 45, 145, 255, 190, 255, 12, 0]
+        max_axis = digital.min_max_axes(qam.points())
+        PADDING = 2
+        axis_limit = PADDING * max_axis
+        src_data = self.lut_index_to_complex(re, im, prec, axis_limit)
+        expected = self.flatten([self.llr_qam(s, npwr) for s in src_data])
+        self.run_test(qam, src_data, expected, 5)
 
-    def test_constellation_soft_decoder_cf_qpsk_8_rand2(self):
+    def test_qam16_lut_external_sd(self):
+        points, coding = digital.qam_16()
+        qam = digital.constellation_calcdist(points, coding, 4, 1)
+        axlimit = 2
         prec = 8
-        src_data = vectorize(complex)(
-            2 * random.randn(100), 2 * random.randn(100))
-        self.helper_no_lut(
-            prec,
-            src_data,
-            digital.psk_4_0x0_0_1,
-            digital.sd_psk_4_0x0_0_1)
+        lut = soft_dec_table_generator(digital.sd_qam_16, prec, axlimit)
+        qam.set_soft_dec_lut(lut, prec, axlimit)
 
-    def test_constellation_soft_decoder_cf_qam16_3(self):
-        prec = 3
         src_data = (-1.0 - 1.0j, 1.0 - 1.0j, -1.0 + 1.0j, 1.0 + 1.0j,
                     -2.0 - 2.0j, 2.0 - 2.0j, -2.0 + 2.0j, 2.0 + 2.0j,
                     -0.2 - 0.2j, 0.2 - 0.2j, -0.2 + 0.2j, 0.2 + 0.2j,
                     0.3 + 0.4j, 0.1 - 1.2j, -0.8 - 0.1j, -0.4 + 0.8j,
                     0.8 + 1.0j, -0.5 + 0.1j, 0.1 + 1.2j, -1.7 - 0.9j)
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.qam_16_0x0_0_1_2_3,
-            digital.sd_qam_16_0x0_0_1_2_3)
 
-    def test_constellation_soft_decoder_cf_qam16_8(self):
-        prec = 8
-        src_data = (-1.0 - 1.0j, 1.0 - 1.0j, -1.0 + 1.0j, 1.0 + 1.0j,
-                    -2.0 - 2.0j, 2.0 - 2.0j, -2.0 + 2.0j, 2.0 + 2.0j,
-                    -0.2 - 0.2j, 0.2 - 0.2j, -0.2 + 0.2j, 0.2 + 0.2j,
-                    0.3 + 0.4j, 0.1 - 1.2j, -0.8 - 0.1j, -0.4 + 0.8j,
-                    0.8 + 1.0j, -0.5 + 0.1j, 0.1 + 1.2j, -1.7 - 0.9j)
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.qam_16_0x0_0_1_2_3,
-            digital.sd_qam_16_0x0_0_1_2_3)
-
-    def test_constellation_soft_decoder_cf_qam16_8_rand(self):
-        prec = 8
-        src_data = vectorize(complex)(
-            2 * random.randn(100), 2 * random.randn(100))
-        self.helper_with_lut(
-            prec,
-            src_data,
-            digital.qam_16_0x0_0_1_2_3,
-            digital.sd_qam_16_0x0_0_1_2_3,
-            3)
-
-    def test_constellation_soft_decoder_cf_qam16_8_rand2(self):
-        prec = 8
-        #src_data = vectorize(complex)(2*random.randn(100), 2*random.randn(100))
-        src_data = vectorize(complex)(2 * random.randn(2), 2 * random.randn(2))
-        self.helper_no_lut(
-            prec,
-            src_data,
-            digital.qam_16_0x0_0_1_2_3,
-            digital.sd_qam_16_0x0_0_1_2_3)
+        expected = self.flatten([digital.sd_qam_16(s) for s in src_data])
+        self.run_test(qam, src_data, expected, 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     gr_unittest.run(test_constellation_soft_decoder)
+    #points, syms = digital.psk_2()
+    #sd = digital.sd_psk_2
+    #breakpoint()

--- a/gr-digital/python/digital/qam_constellations.py
+++ b/gr-digital/python/digital/qam_constellations.py
@@ -8,10 +8,10 @@
 #
 #
 
-import numpy
 from .constellation_map_generator import constellation_map_generator
+from .utils.mod_codes import invert_code
 
-'''
+"""
 Note on the naming scheme. Each constellation is named using a prefix
 for the type of constellation, the order of the constellation, and a
 distinguishing feature, which comes in three modes:
@@ -83,11 +83,11 @@ For 16QAM:
         3, 1, 2, 0
         3, 2, 0, 1
         3, 2, 1, 0
-'''
+"""
 
 
 def qam_16_0x0_0_1_2_3():
-    '''
+    """
     | 0010  0110 | 1110  1010
     |
     | 0011  0111 | 1111  1011
@@ -95,15 +95,45 @@ def qam_16_0x0_0_1_2_3():
     | 0001  0101 | 1101  1001
     |
     | 0000  0100 | 1100  1000
-    '''
-    const_points = [-3 - 3j, -1 - 3j, 1 - 3j, 3 - 3j,
-                    -3 - 1j, -1 - 1j, 1 - 1j, 3 - 1j,
-                    -3 + 1j, -1 + 1j, 1 + 1j, 3 + 1j,
-                    -3 + 3j, -1 + 3j, 1 + 3j, 3 + 3j]
-    symbols = [0x0, 0x4, 0xC, 0x8,
-               0x1, 0x5, 0xD, 0x9,
-               0x3, 0x7, 0xF, 0xB,
-               0x2, 0x6, 0xE, 0xA]
+    """
+    const_points = [
+        -3 - 3j,
+        -1 - 3j,
+        1 - 3j,
+        3 - 3j,
+        -3 - 1j,
+        -1 - 1j,
+        1 - 1j,
+        3 - 1j,
+        -3 + 1j,
+        -1 + 1j,
+        1 + 1j,
+        3 + 1j,
+        -3 + 3j,
+        -1 + 3j,
+        1 + 3j,
+        3 + 3j,
+    ]
+    # Soft decision functions assume corners are (+/-1, +/-1). Scale for consistency
+    const_points = [c / 3.0 for c in const_points]
+    symbols = [
+        0x0,
+        0x4,
+        0xC,
+        0x8,
+        0x1,
+        0x5,
+        0xD,
+        0x9,
+        0x3,
+        0x7,
+        0xF,
+        0xB,
+        0x2,
+        0x6,
+        0xE,
+        0xA,
+    ]
     return (const_points, symbols)
 
 
@@ -112,7 +142,7 @@ qam_16_0 = qam_16
 
 
 def qam_16_0x1_0_1_2_3():
-    '''
+    """
     | 0011  0111 | 1111  1011
     |
     | 0010  0110 | 1110  1010
@@ -120,17 +150,18 @@ def qam_16_0x1_0_1_2_3():
     | 0000  0100 | 1100  1000
     |
     | 0001  0101 | 1101  1001
-    '''
+    """
     k = 0x1
     pi = [0, 1, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_1 = qam_16_0x1_0_1_2_3
 
 
 def qam_16_0x2_0_1_2_3():
-    '''
+    """
     | 0000  0100 | 1100  1000
     |
     | 0001  0101 | 1101  1001
@@ -138,17 +169,18 @@ def qam_16_0x2_0_1_2_3():
     | 0011  0111 | 1111  1011
     |
     | 0010  0110 | 1110  1010
-    '''
+    """
     k = 0x2
     pi = [0, 1, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_2 = qam_16_0x2_0_1_2_3
 
 
 def qam_16_0x3_0_1_2_3():
-    '''
+    """
     | 0001  0101 | 1101  1001
     |
     | 0000  0100 | 1100  1000
@@ -156,17 +188,18 @@ def qam_16_0x3_0_1_2_3():
     | 0010  0110 | 1110  1010
     |
     | 0011  0111 | 1111  1011
-    '''
+    """
     k = 0x3
     pi = [0, 1, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_3 = qam_16_0x3_0_1_2_3
 
 
 def qam_16_0x0_1_0_2_3():
-    '''
+    """
     | 0001  0101 | 1101  1001
     |
     | 0011  0111 | 1111  1011
@@ -174,17 +207,18 @@ def qam_16_0x0_1_0_2_3():
     | 0010  0110 | 1110  1010
     |
     | 0000  0100 | 1100  1000
-    '''
+    """
     k = 0x0
     pi = [1, 0, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_4 = qam_16_0x0_1_0_2_3
 
 
 def qam_16_0x1_1_0_2_3():
-    '''
+    """
     | 0000  0100 | 1100  1000
     |
     | 0010  0110 | 1110  1010
@@ -192,17 +226,18 @@ def qam_16_0x1_1_0_2_3():
     | 0011  0111 | 1111  1011
     |
     | 0001  0101 | 1101  1001
-    '''
+    """
     k = 0x1
     pi = [1, 0, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_5 = qam_16_0x1_1_0_2_3
 
 
 def qam_16_0x2_1_0_2_3():
-    '''
+    """
     | 0011  0111 | 1111  1011
     |
     | 0001  0101 | 1101  1001
@@ -210,17 +245,18 @@ def qam_16_0x2_1_0_2_3():
     | 0000  0100 | 1100  1000
     |
     | 0010  0110 | 1110  1010
-    '''
+    """
     k = 0x2
     pi = [1, 0, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_6 = qam_16_0x2_1_0_2_3
 
 
 def qam_16_0x3_1_0_2_3():
-    '''
+    """
     | 0010  0110 | 1110  1010
     |
     | 0000  0100 | 1100  1000
@@ -228,10 +264,11 @@ def qam_16_0x3_1_0_2_3():
     | 0001  0101 | 1101  1001
     |
     | 0011  0111 | 1111  1011
-    '''
+    """
     k = 0x3
     pi = [1, 0, 2, 3]
-    return constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    points, decoded_bits = constellation_map_generator(qam_16()[0], qam_16()[1], k, pi)
+    return points, invert_code(decoded_bits)
 
 
 qam_16_7 = qam_16_0x3_1_0_2_3
@@ -239,8 +276,9 @@ qam_16_7 = qam_16_0x3_1_0_2_3
 
 # Soft bit LUT generators
 
-def sd_qam_16_0x0_0_1_2_3(x, Es=1):
-    '''
+
+def sd_qam_16_0x0_0_1_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0010  0110 | 1110  1010
@@ -250,19 +288,14 @@ def sd_qam_16_0x0_0_1_2_3(x, Es=1):
     | 0001  0101 | 1101  1001
     |
     | 0000  0100 | 1100  1000
-    '''
+    """
 
-    dist = Es * numpy.sqrt(2)
-    boundary = dist / 3.0
-    dist0 = dist / 6.0
-#    print "Sample:    ", x
-#    print "Es:        ", Es
-#    print "Distance:  ", dist
-#    print "Boundary:  ", boundary
-#    print "1st Bound: ", dist0
-
-    x_re = x.real
-    x_im = x.imag
+    # Function no longer depends on Es, therefore make this sd_qam
+    # consistent with other sd_qam functions
+    boundary = 2
+    dist0 = 1
+    x_re = 3 * x.real
+    x_im = 3 * x.imag
 
     if x_re < -boundary:
         b3 = boundary * (x_re + dist0)
@@ -281,15 +314,15 @@ def sd_qam_16_0x0_0_1_2_3(x, Es=1):
     b2 = -abs(x_re) + boundary
     b0 = -abs(x_im) + boundary
 
-    return [(Es / 2.0) * b3, (Es / 2.0) * b2, (Es / 2.0) * b1, (Es / 2.0) * b0]
+    return [b3, b2, b1, b0]
 
 
 sd_qam_16 = sd_qam_16_0x0_0_1_2_3
 sd_qam_16_0 = sd_qam_16
 
 
-def sd_qam_16_0x1_0_1_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x1_0_1_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0011  0111 | 1111  1011
@@ -299,7 +332,7 @@ def sd_qam_16_0x1_0_1_2_3(x, Es=1):
     | 0000  0100 | 1100  1000
     |
     | 0001  0101 | 1101  1001
-    '''
+    """
     x_re = 3 * x.real
     x_im = 3 * x.imag
 
@@ -326,8 +359,8 @@ def sd_qam_16_0x1_0_1_2_3(x, Es=1):
 sd_qam_16_1 = sd_qam_16_0x1_0_1_2_3
 
 
-def sd_qam_16_0x2_0_1_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x2_0_1_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0000  0100 | 1100  1000
@@ -337,7 +370,7 @@ def sd_qam_16_0x2_0_1_2_3(x, Es=1):
     | 0011  0111 | 1111  1011
     |
     | 0010  0110 | 1110  1010
-    '''
+    """
 
     x_re = 3 * x.real
     x_im = 3 * x.imag
@@ -365,8 +398,8 @@ def sd_qam_16_0x2_0_1_2_3(x, Es=1):
 sd_qam_16_2 = sd_qam_16_0x2_0_1_2_3
 
 
-def sd_qam_16_0x3_0_1_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x3_0_1_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0001  0101 | 1101  1001
@@ -376,7 +409,7 @@ def sd_qam_16_0x3_0_1_2_3(x, Es=1):
     | 0010  0110 | 1110  1010
     |
     | 0011  0111 | 1111  1011
-    '''
+    """
     x_re = 3 * x.real
     x_im = 3 * x.imag
 
@@ -403,8 +436,8 @@ def sd_qam_16_0x3_0_1_2_3(x, Es=1):
 sd_qam_16_3 = sd_qam_16_0x3_0_1_2_3
 
 
-def sd_qam_16_0x0_1_0_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x0_1_0_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0001  0101 | 1101  1001
@@ -414,7 +447,7 @@ def sd_qam_16_0x0_1_0_2_3(x, Es=1):
     | 0010  0110 | 1110  1010
     |
     | 0000  0100 | 1100  1000
-    '''
+    """
     x_re = 3 * x.real
     x_im = 3 * x.imag
 
@@ -441,8 +474,8 @@ def sd_qam_16_0x0_1_0_2_3(x, Es=1):
 sd_qam_16_4 = sd_qam_16_0x0_1_0_2_3
 
 
-def sd_qam_16_0x1_1_0_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x1_1_0_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0000  0100 | 1100  1000
@@ -452,7 +485,7 @@ def sd_qam_16_0x1_1_0_2_3(x, Es=1):
     | 0011  0111 | 1111  1011
     |
     | 0001  0101 | 1101  1001
-    '''
+    """
     x_re = 3 * x.real
     x_im = 3 * x.imag
 
@@ -479,8 +512,8 @@ def sd_qam_16_0x1_1_0_2_3(x, Es=1):
 sd_qam_16_5 = sd_qam_16_0x1_1_0_2_3
 
 
-def sd_qam_16_0x2_1_0_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x2_1_0_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0011  0111 | 1111  1011
@@ -490,7 +523,7 @@ def sd_qam_16_0x2_1_0_2_3(x, Es=1):
     | 0000  0100 | 1100  1000
     |
     | 0010  0110 | 1110  1010
-    '''
+    """
     x_re = 3 * x.real
     x_im = 3 * x.imag
 
@@ -517,8 +550,8 @@ def sd_qam_16_0x2_1_0_2_3(x, Es=1):
 sd_qam_16_6 = sd_qam_16_0x2_1_0_2_3
 
 
-def sd_qam_16_0x3_1_0_2_3(x, Es=1):
-    '''
+def sd_qam_16_0x3_1_0_2_3(x):
+    """
     | Soft bit LUT generator for constellation:
     |
     | 0010  0110 | 1110  1010
@@ -528,7 +561,7 @@ def sd_qam_16_0x3_1_0_2_3(x, Es=1):
     | 0001  0101 | 1101  1001
     |
     | 0011  0111 | 1111  1011
-    '''
+    """
     x_re = 3 * x.real
     x_im = 3 * x.imag
 


### PR DESCRIPTION
Updated the generation and access of soft decision lookup tables to be consistent, for soft decisions calculated internally or from an external function. Previously, function digital.soft_dec_table_generator created a table with coordinates that differed from digital.soft_dec_table and the equivalent c++ code in constellation::gen_soft_dec_lut. This issue led to soft decoder problems found when using an external lookup table. Fixes #7487

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Previously, the coordinates for the lookup table as created in function digital.soft_dec_table_generator were inconsistent with the table generation from digital.soft_dec_table. The lookup table has reverted to using a linear coordinate system based on linspace. The example file constellation_soft_decoder.grc was updated and tested for all possible constellations. With these changes, all constellations performed soft decoding correctly.

Issues discovered during the bug fix:

1. The generation of the coordinates from soft_dec_table_generator were different than other functions or methods. That function still used linspace, while other tables did not. This led to the error seen in issue 7487.

2. The soft_dec_table_generator's axis limits were based on the energy per symbol, but other table generation functions were based on min_max_axes. Unfortunately, the energy per symbol cannot uniquely identify the min_max_axes because it depends on the constellation. 

3. Most of the QA test code only showed that the python lookup table functions worked the same as the constellation's c++ function. They don't show that the lookup operation were correct. 

4. Attempts were made to test additional constellations in psk_constellations.py and qam_constellations.py. They failed due to a misunderstanding of symbol mappings.

5. Script test_soft_decisions.py no longer produced correct results.

Modifications made for fixes:

1. The lookup table has reverted to linspace for all table generation functions. This table is much easier to understand for writing and reading.

2. For external lookup tables, an explicit parameter axis_limit is added. This must be done as attempts to automatically calculate the axis limit proved too difficult. For internal lookup tables, however, the same logic has been kept. For the case of internal lookup tables, the axis limit can be calculated.

3. The external soft decision functions in qam_constellations.py and psk_constellations.py has the Es parameter removed because it did not provide accurate results.

4. The constellation generation functions in qam_constellations.py and psk_constellations.py were fixed as they did not provide the correct symbol mapping.

5. Soft decision functions were also fixed due to misunderstanding of symbol mapping.

6. More rigorous QA code was added to ensure correct soft decisions. They include comparing soft decisions to simplified LLR equations for BPSK, QPSK, and QAM. Constellations with non-involutions symbol mappings were also added.

7. Script test_soft_decisions.py was fixed to print results from the many ways to calculate soft decisisions.

### API Change

1. The most significant API change was the addition of the axis_limit parameter.
```
constellation::set_soft_dec_lut(
    const std::vector<std::vector<float>>& soft_dec_lut, 
    int precision, 
    float axis_limit)
soft_dec_table_generator(soft_dec_gen, prec, axis_limit)
calc_soft_dec_from_table(sample, table, prec, axis_limit)
```
2. External python functions of the form similar to sd_psk_4_0x0_0_1 no longer has Es parameter.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7487 

For reference PR #6748 shows the most recent changes to the soft decision lookup table.  

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
This PR affects the calculation of soft decisions within the constellation object. Therefore, it primarily affects the constellation object and the constellation soft decoder block.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

QA testing was performed with qa_constellation_soft_decoder_cf.py. The tests in this file were updated. Previously, these tests only showed that the python code worked the same as the c++ code. New tests were added to verify correct calculation of the soft decisions. For internally generated soft decisions, these results were compared with established log-likelihood ratio formulas for bpsk, qpsk and qam constellations. For external soft decisions functions like digital.sd_qam_16, the soft decoder output was compared directly with the external function. Test cases also contained various noise power and constellation amplitude to show robustness. In addition, two test cases were kept to show that the python code matches the c++ code.

With these fixes, example file constellation_soft_decoder.grc was run, proving that all constellation decoded correctly.
<img width="1024" height="752" alt="constellation_soft_decoder" src="https://github.com/user-attachments/assets/1ce11df9-07b3-4849-9411-ae432659b1a5" />
<img width="1111" height="647" alt="Screenshot 2025-11-20 at 2 44 51 PM" src="https://github.com/user-attachments/assets/701c2807-0c1c-4040-95a3-fad5788273f1" />

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
