### PR TITLE
uhd: Fix radio clocks for X440 / image builder

### DIFF
--- a/gr-uhd/grc/uhd_fpga_device_bsp.block.yml
+++ b/gr-uhd/grc/uhd_fpga_device_bsp.block.yml
@@ -113,6 +113,18 @@ outputs:
 -   domain: rfnoc.clk
     id: radio_clk
     dtype: message
+    hide: ${ device not in ("x310", "x300", "n300", "n310", "n320", "e31x", "e320", "x410") }
+    optional: ${ device not in ("x310", "x300", "n300", "n310", "n320", "e31x", "e320", "x410") }
+-   domain: rfnoc.clk
+    id: radio0_clk
+    dtype: message
+    hide: ${ device not in ("x440",) }
+    optional: ${ device not in ("x440",) }
+-   domain: rfnoc.clk
+    id: radio1_clk
+    dtype: message
+    hide: ${ device not in ("x440",) }
+    optional: ${ device not in ("x440",) }
 -   domain: rfnoc.clk
     id: ce_clk
     dtype: message


### PR DESCRIPTION
When designing RFNoC bitfiles for X440, the radio clock ports need to be differently named (X440 has clocks `radio0` and `radio1`, X410 only has a `radio` clock).

## Related Issue

No open issue on Github, but if you want to build a bitfile for X440, it should look like this (which is fixed by this PR):

![image](https://github.com/user-attachments/assets/ff804593-0b4d-4e66-8968-cfaa7bff1199)

Instead, it shows the same `radio_clk` port as if it were an X410.

## Which blocks/areas does this affect?

Only people building RFNoC bitfiles through GRC for X440.

## Testing Done

See picture above.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
