### PR TITLE
remove duplicately installed files

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -167,7 +167,9 @@ jobs:
         if-no-files-found: warn
         # these things are kinda large, keep them around for 7 days: we can recreate them if we want
         retention-days: 7
-
+    - name: Check for installation duplicates
+      if: ${{ ! matrix.skip_upload }}
+      run: tools/check_installation_duplicates.bash /build/install_manifest.txt
   mingw64:
     timeout-minutes: 80
   # All of these shall depend on the formatting check (needs: check-formatting)

--- a/gr-uhd/grc/CMakeLists.txt
+++ b/gr-uhd/grc/CMakeLists.txt
@@ -77,12 +77,9 @@ if(ENABLE_UHD_RFNOC)
         uhd_fpga_ctrl.domain.yml
         uhd_fpga_data.domain.yml
         uhd_fpga_io_axi4_mm.domain.yml
-        uhd_fpga_io_axi4_mm.domain.yml
-        uhd_fpga_io_ctrl_port.domain.yml
         uhd_fpga_io_ctrl_port.domain.yml
         uhd_fpga_io_gpio.domain.yml
         uhd_fpga_io_radio.domain.yml
-        uhd_fpga_io_time_keeper.domain.yml
         uhd_fpga_io_time_keeper.domain.yml
         uhd_fpga_io_xport.domain.yml
         DESTINATION ${GRC_BLOCKS_DIR})

--- a/tools/check_installation_duplicates.bash
+++ b/tools/check_installation_duplicates.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Checks whether any files got installed twice
+# Argument: path of install_manifest.txt from a cmake build
+infile="$1" 
+sort "${infile}" > /tmp/sorted \
+  && sort -u "${infile}" > /tmp/sorted_unique \
+  && differences="$(comm -3 /tmp/sorted /tmp/sorted_unique)" \
+  || exit 12
+
+if [[ -n "${differences}" ]]; then
+  printf '%s\n' "${differences}" | while read -r line ; do
+    printf '::error file=%s"::duplicately installed file "%s"\n' "${line}" "${line}"
+  done
+exit 42
+fi


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

three files appeard twice in gr-uhd/grc/CMakeLists.txt and hence got "doubly installed".

Which is not a problem until you make uninstall or such.

Generally, recommendation should probably be to sort file lists and check for duplicates, but this just honestly seems to have slipped through the cracks. Happens!

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

installation

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

added a github check. not something a human should need to think about too much.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
