### PR TITLE
pybind/building: don't error on deprecated symbols

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -47,8 +47,10 @@ macro(GR_PYBIND_MAKE name updir filter files)
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${name}_python PRIVATE -Wno-unused-variable
-        )# disable warnings for docstring templates
+        target_compile_options(${name}_python PRIVATE
+            -Wno-unused-variable
+            -Wno-error=deprecated-declarations
+        ) # disable warnings for docstring templates
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_dependencies(${name}_python ${name}_docstrings)
 
@@ -190,8 +192,10 @@ macro(GR_PYBIND_MAKE_CHECK_HASH name updir filter files)
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${name}_python PRIVATE -Wno-unused-variable
-        )# disable warnings for docstring templates
+        target_compile_options(${name}_python PRIVATE
+            -Wno-unused-variable
+            -Wno-error=deprecated-declarations
+        ) # disable warnings for docstring templates
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(NOT SNDFILE_FOUND AND ${name} STREQUAL blocks)
         target_compile_options(${name}_python PRIVATE -DNO_WAVFILE)
@@ -336,8 +340,10 @@ macro(GR_PYBIND_MAKE_OOT name updir filter files)
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${name}_python PRIVATE -Wno-unused-variable
-        )# disable warnings for docstring templates
+        target_compile_options(${name}_python PRIVATE
+            -Wno-unused-variable
+            -Wno-error=deprecated-declarations
+        ) # disable warnings for docstring templates
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_dependencies(${name}_python ${name}_docstrings ${regen_targets})
 


### PR DESCRIPTION
By definition, pybind has to bind even deprecated functions (until we
actually remove them).

So, erroring out when we do that is not an option.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

CI on maint-3.10 fails on F41/clang, because that notices how we're binding deprecated trellis/interleaver.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
