### PR TITLE
blocks/annotator_raw: use set instead of vector to avoid sorting

### DIFF
--- a/gr-blocks/python/blocks/qa_annotator_raw.py
+++ b/gr-blocks/python/blocks/qa_annotator_raw.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Copyright 2025 Marcus Müller
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest
+from gnuradio.blocks import vector_sink_b, vector_source_b, annotator_raw, throttle
+from time import sleep
+import pmt
+
+
+class test_annotator_raw(gr_unittest.TestCase):
+
+    def compare_tag_iterables(self, tags_out: list, tags_in: list, name: str):
+        for tag, ref in zip(tags_out, tags_in):
+            self.assertTupleEqual(
+                (tag.offset, tag.key, tag.value),
+                ref,
+                "tag contents differ",
+            )
+            self.assertEqual(pmt.to_python(tag.srcid), name)
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_instantiation(self):
+        blk = annotator_raw(1)
+        self.assertTrue(blk)
+
+    def test_002_preseed(self):
+        N = 1000
+        tags_in = [(n * N, pmt.mp(f"key_{n}"), pmt.from_long(n * 10)) for n in range(N)]
+
+        source = vector_source_b([i % 256 for i in range(N * N)], repeat=False)
+        blk = annotator_raw(gr.sizeof_char)
+        sink = vector_sink_b(reserve_items=N * N)
+        self.tb.connect(source, blk, sink)
+
+        for tag_tuple in tags_in:
+            blk.add_tag(*tag_tuple)
+
+        self.tb.run()
+
+        self.assertEqual(
+            N * N, len(sink.data()), "did not get correct number of samples"
+        )
+
+        tags_out = sink.tags()
+        self.compare_tag_iterables(tags_out, tags_in, blk.name())
+
+    def test_003_late_insertion(self):
+        N = 1000
+        total_time = 0.5
+        tags_in = [
+            (n * N, pmt.mp(f"key_{n}"), pmt.from_long(n * 10)) for n in range(N // 2, N)
+        ]
+
+        source = vector_source_b([i % 256 for i in range(N * N)], repeat=False)
+        slower = throttle(
+            gr.sizeof_char, N * N / total_time, maximum_items_per_chunk=16
+        )
+        blk = annotator_raw(gr.sizeof_char)
+        sink = vector_sink_b(reserve_items=N * N)
+        self.tb.connect(source, slower, blk, sink)
+
+        self.tb.start()
+        sleep(0.4 * total_time)
+        # we should be a fair bit into the input, but not yet halfway through
+        for tag_tuple in tags_in:
+            blk.add_tag(*tag_tuple)
+        self.assertRaises(
+            RuntimeError, lambda: blk.add_tag(0, pmt.PMT_NIL, pmt.PMT_NIL)
+        )
+        self.tb.wait()
+
+        self.assertEqual(
+            N * N, len(sink.data()), "did not get correct number of samples"
+        )
+
+        tags_out = sink.tags()
+        self.compare_tag_iterables(tags_out, tags_in, blk.name())
+
+
+if __name__ == "__main__":
+    gr_unittest.run(test_annotator_raw)


### PR DESCRIPTION
## Description

`annotator_raw` used a vector as queue for randomly inserted tags (i.e., things were re-sorted all the time). Changed that.

Worse, honestly, is that it had no test coverage. Changed that, too.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Closes #7624

I thought #7624 was a good beginner's issue to fix, especially with how much work I put into describing the necessary changes. It seems it wasn't, really. Sigh.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

annotator_raw

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

added new unit test that also covers the temporal aspects
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
