### PR TITLE
uhd: Generate tags when frequency changed from message port.

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -118,7 +118,7 @@ usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direct
         return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     } else {
         _rx_chans_to_tune[chan] = false;
-        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
+        return set_center_freq(_curr_rx_tune_req[chan], chan);
     }
 }
 


### PR DESCRIPTION
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Generally, if the USRP source block's centre frequency is altered, then the output stream is tagged with the current frequency. However, at present if the center frequency is altered via message passing, then these tags are not generated. This PR fixes this functionality by using the `set_center_freq` member function. This performs the same functionality as the original code with the addition of properly setting the `_tag_now` flag.

## Related Issue
Fixes #7725 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
The "USRP Source block". It changes the behaviour **only** around the generation of stream tags when the frequency is retuned via message passing.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I tested the change by building GNU Radio from source using my forked repo, which implemented the fix. I created a basic flowgraph, which allows you to send messages manually and check a tag was generated via the "tag debug" block. With the fix implemented, the stream tags are generated as expected.

I tested the fix in a reproducible development environment using Docker. You can follow the steps below to reproduce my testing.

1. Clone the GitHub repository, and checkout the branch I used for testing:  
```bash
git clone -b usrp-streamtag-fix https://github.com/jcfitzpatrick12/spectre.git
```

2. `cd` to the root directory of the cloned repository and run:  
```bash
docker build --tag spectre-dev-server --target development
```
It can take a while. This builds an image using [this Dockerfile](https://github.com/jcfitzpatrick12/spectre/blob/usrp-streamtag-fix/backend/Dockerfile). As part of the image build, it will build GNU Radio from source using my forked repo which implements the fix in this PR. Once built, you should be able to see it as per the screenshot below: 
![image](https://github.com/user-attachments/assets/1094381c-a06d-4c62-a997-dc3fdc8c7cb8)

3. Run the container using:  
```bash
xhost +
docker run --rm \
           --name spectre-dev-server \
           --volume /dev/shm:/dev/shm \
           --device=/dev/bus/usb \
           --interactive \
           --tty \
           --env DISPLAY=$DISPLAY \
           --volume /tmp/.X11-unix:/tmp/.X11-unix \
           spectre-dev-server \
           /bin/bash
xhost -
```
You can verify it's running, as per the screenshot below: 
![image](https://github.com/user-attachments/assets/3f3d314d-b72f-4d1e-ae80-20cc8c096f8f)


4. Run the following command to ensure the container can see the USRP device:  
```bash
uhd_find_devices
```
You may have to kill the container, and restart it. If you're successful, you should see something like:  
![Screenshot from 2025-02-25 21-51-42](https://github.com/user-attachments/assets/9186c0ba-b80f-432f-b844-c4689070858f)

5. Finally, you can run `gnuradio-companion` from inside the container to launch the GUI. From inside the container, use the following `.grc` file to run a flow graph which can be used to verify the fix ([reproduce_problem.txt](https://github.com/user-attachments/files/18972561/reproduce_problem.txt)- it's stored as raw text so I can upload it). Please refer to the below screenshots for proof of the successful testing:  
![Screenshot from 2025-02-25 21-55-24](https://github.com/user-attachments/assets/db56ce13-1dcd-4508-97e6-ffd89fc8ee07)

You can see a stream tag was generated for the first sample in the stream, and additionally (after the fix) when the frequency was retuned via message passing:  
![Screenshot from 2025-02-25 21-57-09](https://github.com/user-attachments/assets/02233d8e-f62b-4cd2-b2e1-54e19c9c4360)


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
