### PR TITLE
gr-digital: fix early_late ted computation depth to match actual depth

### DIFF
--- a/gr-digital/lib/timing_error_detector.h
+++ b/gr-digital/lib/timing_error_detector.h
@@ -348,7 +348,7 @@ public:
      * \brief Create a Early-Late timing error detector
      */
     ted_early_late()
-        : timing_error_detector(TED_EARLY_LATE, 2, 2, true, false, constellation_sptr())
+        : timing_error_detector(TED_EARLY_LATE, 2, 3, true, false, constellation_sptr())
     {
     }
     ~ted_early_late() override{};


### PR DESCRIPTION
Fixes #7752

- [ X ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ X ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ X ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ N/A ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ N/A ] I have added tests to cover my changes, and all previous tests pass.
