### PR TITLE
clang-tidy: update .clang-tidy file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert,readability-container-size-empty,modernize-use-override,modernize-make-unique,modernize-deprecated-headers,misc-unused-using-decls,misc-redundant-expression'
+Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert,readability-container-size-empty,modernize-use-override,modernize-make-unique,modernize-deprecated-headers,misc-unused-using-decls,misc-redundant-expression,bugprone-redundant-branch-condition,bugprone-shared-ptr-array-mismatch,bugprone-string-constructor,bugprone-string-integer-assignment,bugprone-unused-raii'
 # Not in here: modernize-use-emplace, since that basically broke all things it touched
 WarningsAsErrors: ''
 HeaderFilterRegex: '\.(cc|c|cpp|h|hpp)$'


### PR DESCRIPTION
New checks! Actually found bugs with the RAII checker.


## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Clang-tidy evolves, and there's new checks. Added a few helpful ones. #7759, for example, is something that was raised this way.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
