### PR TITLE
whole-tree: consistently use 'override'

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer_reader_sm.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader_sm.h
@@ -21,25 +21,25 @@ namespace gr {
 class GR_RUNTIME_API buffer_reader_sm : public buffer_reader
 {
 public:
-    ~buffer_reader_sm();
+    ~buffer_reader_sm() override;
 
     /*!
      * \brief Return number of items available for reading.
      */
-    virtual int items_available() const;
+    int items_available() const override;
 
     /*!
      * \brief Return true if thread is ready to call input_blocked_callback,
      * false otherwise; delegate calls to buffer class's input_blkd_cb_ready()
      */
-    virtual bool input_blkd_cb_ready(int items_required) const;
+    bool input_blkd_cb_ready(int items_required) const override;
 
     /*!
      * \brief Callback function that the scheduler will call when it determines
      * that the input is blocked; delegate calls to buffer class's
      * input_blocked_callback()
      */
-    virtual bool input_blocked_callback(int items_required, int items_avail);
+    bool input_blocked_callback(int items_required, int items_avail) override;
 
 private:
     friend class buffer;

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.h
@@ -35,7 +35,7 @@ public:
                            const std::string& desc,
                            int len,
                            unsigned int disp_mask);
-    ~ctrlport_probe2_b_impl();
+    ~ctrlport_probe2_b_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.h
@@ -35,7 +35,7 @@ public:
                            const std::string& desc,
                            int len,
                            unsigned int disp_mask);
-    ~ctrlport_probe2_c_impl();
+    ~ctrlport_probe2_c_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.h
@@ -35,7 +35,7 @@ public:
                            const std::string& desc,
                            int len,
                            unsigned int disp_mask);
-    ~ctrlport_probe2_f_impl();
+    ~ctrlport_probe2_f_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.h
@@ -35,7 +35,7 @@ public:
                            const std::string& desc,
                            int len,
                            unsigned int disp_mask);
-    ~ctrlport_probe2_i_impl();
+    ~ctrlport_probe2_i_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.h
@@ -35,7 +35,7 @@ public:
                            const std::string& desc,
                            int len,
                            unsigned int disp_mask);
-    ~ctrlport_probe2_s_impl();
+    ~ctrlport_probe2_s_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-blocks/lib/ctrlport_probe_c_impl.h
+++ b/gr-blocks/lib/ctrlport_probe_c_impl.h
@@ -30,7 +30,7 @@ private:
 
 public:
     ctrlport_probe_c_impl(const std::string& id, const std::string& desc);
-    ~ctrlport_probe_c_impl();
+    ~ctrlport_probe_c_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-digital/lib/crc_append_impl.h
+++ b/gr-digital/lib/crc_append_impl.h
@@ -34,14 +34,14 @@ public:
                     bool result_reflected,
                     bool swap_endianness,
                     unsigned skip_header_bytes);
-    ~crc_append_impl();
+    ~crc_append_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
-                     gr_vector_void_star& output_items);
+                     gr_vector_void_star& output_items) override;
     void msg_handler(pmt::pmt_t pmt_msg);
 };
 

--- a/gr-digital/lib/crc_check_impl.h
+++ b/gr-digital/lib/crc_check_impl.h
@@ -36,14 +36,14 @@ public:
                    bool swap_endianness,
                    bool discard_crc,
                    unsigned skip_header_bytes);
-    ~crc_check_impl();
+    ~crc_check_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
-                     gr_vector_void_star& output_items);
+                     gr_vector_void_star& output_items) override;
     void msg_handler(const pmt::pmt_t& pmt_msg);
 };
 

--- a/gr-digital/lib/descrambler_bb_impl.h
+++ b/gr-digital/lib/descrambler_bb_impl.h
@@ -24,7 +24,7 @@ private:
 
 public:
     descrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len);
-    ~descrambler_bb_impl();
+    ~descrambler_bb_impl() override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr_source_b_impl.h
+++ b/gr-digital/lib/glfsr_source_b_impl.h
@@ -31,7 +31,7 @@ public:
                         bool repeat = true,
                         uint64_t mask = 0,
                         uint64_t seed = 0x1);
-    ~glfsr_source_b_impl();
+    ~glfsr_source_b_impl() override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr_source_f_impl.h
+++ b/gr-digital/lib/glfsr_source_f_impl.h
@@ -31,7 +31,7 @@ public:
                         bool repeat = true,
                         uint64_t mask = 0,
                         uint64_t seed = 0x1);
-    ~glfsr_source_f_impl();
+    ~glfsr_source_f_impl() override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/scrambler_bb_impl.h
+++ b/gr-digital/lib/scrambler_bb_impl.h
@@ -25,7 +25,7 @@ private:
 
 public:
     scrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len);
-    ~scrambler_bb_impl();
+    ~scrambler_bb_impl() override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-fft/lib/ctrlport_probe_psd_impl.h
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.h
@@ -35,7 +35,7 @@ private:
 
 public:
     ctrlport_probe_psd_impl(const std::string& id, const std::string& desc, int len);
-    ~ctrlport_probe_psd_impl();
+    ~ctrlport_probe_psd_impl() override;
 
     void setup_rpc() override;
 

--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -30,7 +30,7 @@ public:
     virtual QwtRasterData* copy() const;
 
 #if QWT_VERSION >= 0x060200
-    virtual QwtInterval interval(Qt::Axis) const override;
+    QwtInterval interval(Qt::Axis) const override;
     void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -31,7 +31,7 @@ public:
     virtual QwtRasterData* copy() const;
 
 #if QWT_VERSION >= 0x060200
-    virtual QwtInterval interval(Qt::Axis) const override;
+    QwtInterval interval(Qt::Axis) const override;
     void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 

--- a/gr-qtgui/lib/matrix_display.h
+++ b/gr-qtgui/lib/matrix_display.h
@@ -87,7 +87,7 @@ public:
                             const std::string& y_axis_label,
                             const std::string& z_axis_label,
                             QWidget* parent = nullptr);
-    ~matrix_display();
+    ~matrix_display() override;
 
     void set_contour(bool contour);
     void set_color_map(const std::string& color_map);

--- a/gr-qtgui/lib/matrix_display_signal.h
+++ b/gr-qtgui/lib/matrix_display_signal.h
@@ -19,7 +19,7 @@ class matrix_display_signal : public QObject
 
 public:
     matrix_display_signal() {}
-    ~matrix_display_signal() {}
+    ~matrix_display_signal() override {}
 
 signals:
     void data_ready(QVector<double> data);

--- a/gr-qtgui/lib/matrix_sink_impl.h
+++ b/gr-qtgui/lib/matrix_sink_impl.h
@@ -41,7 +41,7 @@ public:
                      const std::string& color_map,
                      const std::string& interpolation,
                      QWidget* parent = nullptr);
-    ~matrix_sink_impl();
+    ~matrix_sink_impl() override;
 
     void exec_() override;
     QApplication* d_qApplication;

--- a/gr-soapy/lib/block_impl.h
+++ b/gr-soapy/lib/block_impl.h
@@ -65,7 +65,7 @@ protected:
     block_impl(block_impl&&) = delete;
     block_impl& operator=(const block_impl&) = delete;
     block_impl& operator=(block_impl&&) = delete;
-    virtual ~block_impl();
+    ~block_impl() override;
 
     size_t d_nchan;
     std::mutex d_device_mutex;
@@ -192,15 +192,14 @@ public:
     std::vector<unsigned>
     read_registers(const std::string& name, unsigned addr, size_t length) const override;
 
-    virtual arginfo_list_t get_setting_info() const override;
-    virtual void write_setting(const std::string& key, const std::string& value) override;
-    virtual std::string read_setting(const std::string& key) const override;
-    virtual arginfo_list_t get_setting_info(size_t channel) const override;
-    virtual void write_setting(size_t channel,
-                               const std::string& key,
-                               const std::string& value) override;
-    virtual std::string read_setting(size_t channel,
-                                     const std::string& key) const override;
+    arginfo_list_t get_setting_info() const override;
+    void write_setting(const std::string& key, const std::string& value) override;
+    std::string read_setting(const std::string& key) const override;
+    arginfo_list_t get_setting_info(size_t channel) const override;
+    void write_setting(size_t channel,
+                       const std::string& key,
+                       const std::string& value) override;
+    std::string read_setting(size_t channel, const std::string& key) const override;
 
     std::vector<std::string> list_gpio_banks() const override;
     void write_gpio(const std::string& bank, unsigned value) override;


### PR DESCRIPTION
as found through applying clang-tidy (see #7760),

```shell
clang-tidy -p /path/to/build --fix \
    $( grep modernize-use-override /path/to/clang-tidy.log | sed 's/^\([^:]*\):.*/\1/' | sort -u)
```

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Code quality / style consistency

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

still compiles, tests still pass. This should not be a functional change

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
