### PR TITLE
whole-tree: use container.empty() instead of .length() < 1

### DIFF
--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -474,7 +474,7 @@ void EyeDisplayPlot::setTagBackgroundStyle(Qt::BrushStyle b)
 void EyeDisplayPlot::setYLabel(const std::string& label, const std::string& unit)
 {
     std::string l = label;
-    if (unit.length() > 0)
+    if (!unit.empty())
         l += " (" + unit + ")";
     QwtText yAxisTitle(QString(l.c_str()));
     setAxisTitle(QwtPlot::yLeft, yAxisTitle);

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -481,7 +481,7 @@ void FrequencyDisplayPlot::onPickerPointSelected(const QPointF& p)
 void FrequencyDisplayPlot::setYLabel(const std::string& label, const std::string& unit)
 {
     std::string l = label;
-    if (unit.length() > 0)
+    if (!unit.empty())
         l += " (" + unit + ")";
     setAxisTitle(QwtPlot::yLeft, QString(l.c_str()));
     static_cast<FreqDisplayZoomer*>(d_zoomer)->setYUnit(unit);

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -516,7 +516,7 @@ void TimeDomainDisplayPlot::setTagBackgroundStyle(Qt::BrushStyle b)
 void TimeDomainDisplayPlot::setYLabel(const std::string& label, const std::string& unit)
 {
     std::string l = label;
-    if (unit.length() > 0)
+    if (!unit.empty())
         l += " (" + unit + ")";
     setAxisTitle(QwtPlot::yLeft, QString(l.c_str()));
     ((TimeDomainDisplayZoomer*)d_zoomer)->setYUnitType(unit);

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -440,14 +440,14 @@ void TimeRasterDisplayPlot::reset()
 
     QwtXScaleDraw* xScale = (QwtXScaleDraw*)axisScaleDraw(QwtPlot::xBottom);
     xScale->setSecondsPerLine(sec_per_samp);
-    if (d_x_label.length() > 0) {
+    if (!d_x_label.empty()) {
         setAxisTitle(QwtPlot::xBottom, QString(d_x_label.c_str()));
     } else {
         setAxisTitle(QwtPlot::xBottom, QString("Time (%1)").arg(strunits[iunit].c_str()));
     }
     xScale->initiateUpdate();
 
-    if (d_y_label.length() > 0) {
+    if (!d_y_label.empty()) {
         setAxisTitle(QwtPlot::yLeft, d_y_label.c_str());
     }
 

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -379,7 +379,7 @@ std::string NumberDisplayForm::title() const { return d_title->text().toStdStrin
 void NumberDisplayForm::setTitle(const std::string& title)
 {
     std::string t = title;
-    if (t.length() > 0)
+    if (!t.empty())
         t = "<b><FONT SIZE=4>" + title + "</b>";
     d_title->setText(QString(t.c_str()));
     setGraphType(d_graph_type);


### PR DESCRIPTION
as found through applying clang-tidy (#7760)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
