### PR TITLE
Drive-by: improve patterned interleaver

### DIFF
--- a/gr-blocks/lib/patterned_interleaver_impl.cc
+++ b/gr-blocks/lib/patterned_interleaver_impl.cc
@@ -11,6 +11,7 @@
 
 #include "patterned_interleaver_impl.h"
 #include <gnuradio/io_signature.h>
+#include <algorithm>
 
 namespace gr {
 namespace blocks {
@@ -21,19 +22,49 @@ patterned_interleaver::sptr patterned_interleaver::make(size_t itemsize,
     return gnuradio::make_block_sptr<patterned_interleaver_impl>(itemsize, pattern);
 }
 
+namespace {
+template <typename T>
+constexpr typename T::value_type pattern_max(const T& pattern)
+{
+    if (pattern.empty()) {
+        return -1;
+    }
+    return *std::max_element(pattern.cbegin(), pattern.cend());
+}
+
+template <typename T>
+auto pattern_to_iosig(const T& pattern, size_t itemsize)
+{
+    if (pattern.empty()) {
+        return gr::io_signature::make(0, 0, itemsize);
+    }
+    auto size = pattern_max(pattern) + 1;
+    return gr::io_signature::make(size, gr::io_signature::IO_INFINITE, itemsize);
+}
+
+template <typename T>
+constexpr std::vector<typename T::value_type> pattern_to_count(const T& pattern)
+{
+    if (pattern.empty()) {
+        return {};
+    }
+    T counts(pattern_max(pattern) + 1);
+    for (const auto& idx : pattern) {
+        counts[idx]++;
+    }
+    return counts;
+}
+} // namespace
+
 patterned_interleaver_impl::patterned_interleaver_impl(size_t itemsize,
                                                        std::vector<int> pattern)
     : block("patterned_interleaver",
-            io_signature::make(
-                pattern_max(pattern) + 1, pattern_max(pattern) + 1, itemsize),
+            pattern_to_iosig(pattern, itemsize),
             io_signature::make(1, 1, itemsize)),
       d_pattern(pattern),
-      d_counts(pattern_max(pattern) + 1, 0),
+      d_counts(pattern_to_count(pattern)),
       d_itemsize(itemsize)
 {
-    for (const auto& i : d_pattern) {
-        d_counts[i]++;
-    }
     set_output_multiple(d_pattern.size());
 }
 
@@ -42,9 +73,11 @@ int patterned_interleaver_impl::general_work(int noutput_items,
                                              gr_vector_const_void_star& input_items,
                                              gr_vector_void_star& output_items)
 {
-    const size_t nblks = noutput_items / d_pattern.size();
+    int items_left;
+    unsigned int nblks;
 
-    for (size_t i = 0; i < nblks; i++) {
+    for (items_left = noutput_items, nblks = 0; items_left > 0;
+         items_left -= d_pattern.size(), nblks++) {
         for (const auto input_idx : d_pattern) {
             memcpy(output_items[0], input_items[input_idx], d_itemsize);
             reinterpret_cast<const char*&>(input_items[input_idx]) += d_itemsize;
@@ -65,6 +98,16 @@ void patterned_interleaver_impl::forecast(int noutput_items,
     for (size_t i = 0; i < ninput_items_required.size(); i++) {
         ninput_items_required[i] = d_counts[i] * nblks;
     }
+}
+
+bool patterned_interleaver_impl::check_topology(int ninput, int noutput)
+{
+    if (noutput != 1) {
+        return false;
+    }
+    /* it's not OK to have fewer inputs connected than our maximum input index, but more
+     * might be OK */
+    return static_cast<size_t>(ninput) >= d_counts.size();
 }
 
 } /* namespace blocks */

--- a/gr-blocks/lib/patterned_interleaver_impl.h
+++ b/gr-blocks/lib/patterned_interleaver_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012 Free Software Foundation, Inc.
+ * Copyright 2025 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -12,7 +13,6 @@
 #define INCLUDED_PATTERNED_INTERLEAVER_IMPL_H
 
 #include <gnuradio/blocks/patterned_interleaver.h>
-#include <algorithm>
 
 namespace gr {
 namespace blocks {
@@ -27,19 +27,13 @@ public:
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
 
-    static int pattern_max(std::vector<int> pattern)
-    {
-        if (pattern.empty()) {
-            return 0;
-        }
-        return *std::max_element(pattern.begin(), pattern.end());
-    }
-
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    bool check_topology(int ninput, int noutputs) override;
 
-    std::vector<int> d_pattern;
-    std::vector<int> d_counts;
-    size_t d_itemsize;
+private:
+    const std::vector<int> d_pattern;
+    const std::vector<int> d_counts;
+    const size_t d_itemsize;
 };
 
 } /* namespace blocks */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

We were doing a lot of unnecessary copies, and that with avoidable reallocations, every call to work. Fixed that.

In the second commit, also moved thread-unsafe members out of public view, and implementation detail to _impl.cc

(first commit can be backported, second can't)

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

blocks / patterned interleaver

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
no new tests

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
