### PR TITLE
grc: Accept failures in message sending

### DIFF
--- a/grc/core/Messages.py
+++ b/grc/core/Messages.py
@@ -5,8 +5,9 @@
 #
 
 
-import traceback
+import logging
 import sys
+import traceback
 
 #  A list of functions that can receive a message.
 MESSENGERS_LIST = list()
@@ -40,7 +41,11 @@ def send(message):
         message: a message string
     """
     for messenger in MESSENGERS_LIST:
-        messenger(_indent + message)
+        try:
+            messenger(_indent + message)
+        except:
+            logging.getLogger(__name__).error(
+                "Error in messenger: %s (message: %s)", messenger, message)
 
 
 # register stdout by default


### PR DESCRIPTION
This fixes a rare corner case seen in unit tests, where multiple tests interfere with one another.

During the execution of unit tests for the pluggable workflow PR, this sometimes happened. I couldn't quite track it down, but when you run multiple GRC-related tasks in quick succession in a unit test, the output messenger would fail to open-and-close the file descriptor.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
