### PR TITLE
grc: xml converter: Supply default output_language

### DIFF
--- a/grc/converter/flow_graph.py
+++ b/grc/converter/flow_graph.py
@@ -23,6 +23,10 @@ def from_xml(filename):
         file_format = _guess_file_format_1(data)
 
     data['metadata'] = {'file_format': file_format}
+    # Old XML-based flow graphs only supported Python, but didn't always declare
+    # that in the options. We'll default to Python if it's not set.
+    if 'output_language' not in data['options']:
+        data['options']['output_language'] = 'python'
 
     return data
 


### PR DESCRIPTION
Old XML-based GRC files don't necessarily provide output_language, but they only supported Python anyway, so we auto-populate that field.

For example, `grc/tests/resources/test_compiler.grc ` does not specify a language, only the `generate_options`. I had an intermediate state of the GRC pluggable workflow where knowing the language was required, but I do think this is a safe change regardless.

## Related Issue

I was seeing some failures in GRC unit tests related to this. They don't occur on master, but this change is sensible and useful by itself.

## Which blocks/areas does this affect?

Only XML import of old flow graphs.

## Testing Done

I've run GRC tests more than I care while working on the pluggable workflows.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
