### PR TITLE
grc: Make generate aware of execution

### DIFF
--- a/grc/core/generator/cpp_hier_block.py
+++ b/grc/core/generator/cpp_hier_block.py
@@ -30,7 +30,7 @@ class CppHierBlockGenerator(CppTopBlockGenerator):
         self._mode = Constants.HIER_BLOCK_FILE_MODE
         self.file_path_yml = self.file_path + '.block.yml'
 
-    def write(self):
+    def write(self, _=None):
         """generate output and write it to files"""
         CppTopBlockGenerator.write(self)
 

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -70,7 +70,7 @@ class CppTopBlockGenerator(object):
         for key in deprecated_block_keys:
             Messages.send_warning("The block {!r} is deprecated.".format(key))
 
-    def write(self):
+    def write(self, _=None):
         """create directory, generate output and write it to files"""
         self._warnings()
 

--- a/grc/core/generator/hier_block.py
+++ b/grc/core/generator/hier_block.py
@@ -29,7 +29,7 @@ class HierBlockGenerator(TopBlockGenerator):
         self._mode = Constants.HIER_BLOCK_FILE_MODE
         self.file_path_yml = self.file_path[:-3] + '.block.yml'
 
-    def write(self):
+    def write(self, _=None):
         """generate output and write it to files"""
         TopBlockGenerator.write(self)
 

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -64,7 +64,7 @@ class TopBlockGenerator(object):
         for key in deprecated_block_keys:
             Messages.send_warning("The block {!r} is deprecated.".format(key))
 
-    def write(self):
+    def write(self, _=None):
         """generate output and write it to files"""
         self._warnings()
 

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -69,6 +69,9 @@ class Application(Gtk.Application):
         self.init_file_paths = [os.path.abspath(
             file_path) for file_path in file_paths]
         self.init = False
+        # exec_called tracks if "generate" is implied by "execute", or called
+        # directly. If true, then "execute" was called previously.
+        self.exec_called = False
 
     def do_startup(self):
         Gtk.Application.do_startup(self)
@@ -760,14 +763,16 @@ class Application(Gtk.Application):
                     generator = page.get_generator()
                     try:
                         Messages.send_start_gen(generator.file_path)
-                        generator.write()
+                        generator.write(self.exec_called)
                         self.generator = generator
                     except Exception as e:
                         Messages.send_fail_gen(e)
 
         elif action == Actions.FLOW_GRAPH_EXEC:
-            if not page.process:
+            if not page.process:  # Don't execute if already running
+                self.exec_called = True
                 Actions.FLOW_GRAPH_GEN()
+                self.exec_called = False
                 if self.generator:
                     xterm = self.platform.config.xterm_executable
                     if self.config.xterm_missing() != xterm:

--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -1397,7 +1397,7 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
     def block_dec_type_triggered(self):
         log.debug("block_dec_type")
 
-    def generate_triggered(self):
+    def generate_triggered(self, called_from_exec=False):
         log.debug("generate")
         if not self.currentFlowgraphScene.saved:
             self.save_triggered()
@@ -1410,14 +1410,14 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         generator = self.platform.Generator(
             self.currentFlowgraph, os.path.dirname(filename)
         )
-        generator.write()
+        generator.write(called_from_exec)
         self.currentView.generator = generator
         log.info(f"Generated {generator.file_path}")
 
     def execute_triggered(self):
         log.debug("execute")
         if self.currentView.process_is_done():
-            self.generate_triggered()
+            self.generate_triggered(called_from_exec=True)
             if self.currentView.generator:
                 xterm = self.app.qsettings.value("grc/xterm_executable", "")
                 '''if self.config.xterm_missing() != xterm:


### PR DESCRIPTION
When generating a flow graph, we make the generator aware if it's being called directly, or implied by "execute". This can be useful for future workflows.

## Related Issue

In the RFNoC workflow that I built, the "generate" step is pretty expensive. Because calling "execute" always implies calling "generate", it's good to know where that came from. You can see more info by looking at the RFNoC workflow in #7548.

## Which blocks/areas does this affect?

This change by itself doesn't actually change anything, it just lays down groundwork.

## Testing Done

The RFNoC workflow is a good test case, but the other tests and GRC functions still work with this as before.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
