### PR TITLE
grc: Fix GRC-Qt file open dialog on PyQt5

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -890,10 +890,11 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
         else:
             dirname = os.getcwd()
         Open = QtWidgets.QFileDialog.getOpenFileName
+        # Despite qtpy, PyQt5 and PySide2 have different signatures for getOpenFileName
         filename, filtr = Open(
-            self,
-            self.actions["open"].statusTip(),
-            dir=dirname,
+            self,  # parent
+            self.actions["open"].statusTip(),  # caption
+            dirname,  # dir
             filter="Flow Graph Files (*.grc);;All files (*.*)",
         )
         return filename


### PR DESCRIPTION
Despite using qtpy, the signature for opening files on PyQt5 and PySide2 is different. Luckily, the order of arguments is the same, so by not using keyword arguments, we can make this call cross-compatible.

On PyQt5, the third argument is called 'directory', and on PySide2, it's called 'dir'.

## Related Issue

I didn't open a bug for this, but if you have PyQt5 and not PySide2 (which apparently is the default on Ubuntu 22.04), then you will see this when trying to open a file with the Qt version:


```
  File "[...]/python3.10/site-packages/gnuradio/grc/gui_qt/components/window.py", line 982, in open_triggered
    filename = self.open()
  File "[...]/python3.10/site-packages/gnuradio/grc/gui_qt/components/window.py", line 893, in open            filename, filtr = Open(
TypeError: getOpenFileName(parent: QWidget = None, caption: str = '', directory: str = '', filter: str = '', initialFilter: str = '', options: Union[QFileDialog.Options, QFileDialog.Option] = 0): 'dir' is not a valid keyword argument                               
```


## Which blocks/areas does this affect?

GRC-Qt

## Testing Done

Opened a file

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
