### PR TITLE
audio: unify priorities between sink and source architectures

### DIFF
--- a/gr-audio/docs/audio.dox
+++ b/gr-audio/docs/audio.dox
@@ -94,23 +94,7 @@ registration list in gr-audio/lib/audio_registry.cc and
 audio_registry.h files. Select the appropriate registry priority, HIGH
 if you want this to be the default when using 'auto'. For Linux audio
 systems, we generally want to default to ALSA, fall back on OSS, but
-have other machine interfaces defined as MED priority. For example, in
-the .cc file for ALSA, OSS, and PortAudio:
-
-\code
-    #ifdef ALSA_FOUND
-            s_registry.push_back(register_source(REG_PRIO_HIGH, "alsa", alsa_source_fcn));
-    #endif /* ALSA_FOUND */
-
-    #ifdef OSS_FOUND
-            s_registry.push_back(register_source(REG_PRIO_LOW, "oss", oss_source_fcn));
-    #endif /* OSS_FOUND */
-
-    #ifdef PORTAUDIO_FOUND
-            s_registry.push_back(register_source(REG_PRIO_MED, "portaudio", portaudio_source_fcn));
-    #endif /* PORTAUDIO_FOUND */
-\endcode
-
+have other machine interfaces defined as MED priority.
 
 5. Follow the examples in the gr-audio/lib/CMakeLists.txt file for the
 different machine types to add the new one, including the

--- a/gr-audio/lib/audio_registry.h
+++ b/gr-audio/lib/audio_registry.h
@@ -34,11 +34,6 @@ struct sink_entry_t {
     sink_factory_t sink;
 };
 
-source_entry_t
-register_source(reg_prio_type prio, const std::string& arch, source_factory_t source);
-sink_entry_t
-register_sink(reg_prio_type prio, const std::string& arch, sink_factory_t sink);
-
 #ifdef ALSA_FOUND
 source::sptr
 alsa_source_fcn(int sampling_rate, const std::string& device_name, bool ok_to_block);


### PR DESCRIPTION
## Description
I made a mistake 4 years ago that gave the "windows" sink a different
priority than the source. That led to great user confusion.

Make sure that doesn't happen again. Instead, keep priorities in a
central map.

Remove the internal and unused registry functions that just create a struct manually instead of using the aggregate initialization method / default constructor.

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #7784

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

inner workings of gr-audio. Should un-shamble windows.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

works on my machine. We don't have CI coverage, that's another bug (#2539)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
