### PR TITLE
grc: allow macos editor to be chosen for embedded python blocks

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -7,7 +7,7 @@
 
 import sys
 import textwrap
-from shutil import which as find_executable
+import glob
 
 from gi.repository import Gtk, GLib, Gdk, Gio
 
@@ -408,7 +408,8 @@ def choose_editor(parent, config):
     """
     Give the option to either choose an editor or use the default.
     """
-    content_type = Gio.content_type_from_mime_type("text/x-python")
+    mime = "text/x-python-script" if sys.platform == "darwin" else "text/x-python"
+    content_type = Gio.content_type_from_mime_type(mime)
     if content_type == "*":
         # fallback to plain text on Windows if no useful x-python association
         content_type = Gio.content_type_from_mime_type("text/plain")
@@ -428,6 +429,15 @@ def choose_editor(parent, config):
     response = dialog.run()
     if response == Gtk.ResponseType.OK:
         appinfo = dialog.get_app_info()
-        editor = config.editor = appinfo.get_executable()
+        editor = config.editor = execpath(appinfo.get_executable())
     dialog.destroy()
     return editor
+
+
+def execpath(fname):
+    # for macos, search the Application directory for the fullpath
+    if sys.platform == "darwin":
+        found_paths = glob.glob("/Applications/*/Contents/MacOS/" + fname)
+        if found_paths:
+            return found_paths[0]
+    return fname


### PR DESCRIPTION
Fixes #7115
Signed-off-by: Frank Fu <frankfustuff@gmail.com>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Previously, there was no way to choose an editor for an embedded python block when using GRC on MacOS. The first problem was getting a suitable list of possible editors for python. This is because Apple expects the mime type to be in UTI format such as  "text/x-python-script". This format differs from "text/x-python" which is used in Linux. This change allows the menu of editors to show up.

The second issue is that once the editor is chosen, the executable's name is not sufficient for MacOS apps. Unlike Linux, most Mac apps are not expected to be run from the command line. Therefore, the executable file name (e.g. sublime_text) will not be in the PATH directory. For MacOS, the /Application directory is searched to find the full path of the chosen editor. This fix may not be full-proof for all possible apps, but at least this works for Sublime Text, VS Code, and Emacs. As a workaround, one can enter the full path of the editor in config.conf if this fix doesn't work.

## Related Issue
Fixes #7115
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Embedded Python block and Python Modules which require a selection of an editor.
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested on MacOS 14.7.2
After changes, the Choose Editor button shows list of possible apps on MacOS:

![editor-select](https://github.com/user-attachments/assets/54e0017a-9b4a-4792-9407-2e5909bcb2e0)

Then the Open in Editor button works. I tested for VS Code, Sublime Text and Emacs. Screenshot for VS Code:
![vscode](https://github.com/user-attachments/assets/49d8353a-8c1c-4548-bb55-ba0a0cab3b99)

Also tested on Ubuntu 22.04 to verify Linux compatibility.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
