### PR TITLE
bp 7656 2

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -173,19 +173,6 @@ macro(GR_PYBIND_MAKE_CHECK_HASH name updir filter files)
         PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
                 ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include)
 
-    # Precompile the pybind11 header
-    # This should speed up building of the python bindings at least in larger modules
-    # This functionality is only available in CMake >= 3.16
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
-        target_precompile_headers(
-            ${name}_python
-            PRIVATE
-            ${pybind11_INCLUDE_DIR}/pybind11/pybind11.h
-            ${pybind11_INCLUDE_DIR}/pybind11/complex.h
-            ${pybind11_INCLUDE_DIR}/pybind11/operators.h
-            ${pybind11_INCLUDE_DIR}/pybind11/stl.h)
-    endif()
-
     target_link_libraries(
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})

--- a/gnuradio-runtime/CMakeLists.txt
+++ b/gnuradio-runtime/CMakeLists.txt
@@ -38,39 +38,6 @@ gr_register_component(
     Volk_FOUND)
 
 get_filename_component(GNURADIO_RUNTIME_PYTHONPATH ${PROJECT_SOURCE_DIR}/python ABSOLUTE)
-########################################################################
-# Setup precompiled header pseudo-component
-########################################################################
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
-    set(GR_CMAKE_HAS_PCH ${CMAKE_VERSION})
-endif()
-
-gr_register_component("common-precompiled-headers" ENABLE_COMMON_PCH
-                      ENABLE_GNURADIO_RUNTIME GR_CMAKE_HAS_PCH)
-
-if(ENABLE_COMMON_PCH)
-    add_library(common-precompiled-headers STATIC
-                ${CMAKE_CURRENT_SOURCE_DIR}/lib/dummy.cc)
-    target_include_directories(
-        common-precompiled-headers
-        PUBLIC $<INSTALL_INTERFACE:include>
-               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-               $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
-
-    if(MSVC)
-        target_compile_definitions(
-            common-precompiled-headers
-            PUBLIC # disables stupidity and enables std::min and std::max
-                   -DNOMINMAX)
-    endif(MSVC)
-
-    target_precompile_headers(
-        common-precompiled-headers
-        PUBLIC
-        $<$<COMPILE_LANGUAGE:CXX>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio/top_block.h>>
-    )
-    target_link_libraries(common-precompiled-headers PUBLIC spdlog::spdlog)
-endif()
 
 ########################################################################
 # Register controlport component

--- a/gnuradio-runtime/include/gnuradio/high_res_timer.h
+++ b/gnuradio-runtime/include/gnuradio/high_res_timer.h
@@ -11,10 +11,6 @@
 #ifndef INCLUDED_GNURADIO_HIGH_RES_TIMER_H
 #define INCLUDED_GNURADIO_HIGH_RES_TIMER_H
 
-#include <gnuradio/api.h>
-#include <chrono>
-#include <ratio>
-
 ////////////////////////////////////////////////////////////////////////
 // Use architecture defines to determine the implementation
 ////////////////////////////////////////////////////////////////////////
@@ -22,16 +18,21 @@
 #define GNURADIO_HRT_USE_CLOCK_GETTIME
 #include <ctime>
 #elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#include <windows.h>
 #define GNURADIO_HRT_USE_QUERY_PERFORMANCE_COUNTER
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+#include <mach/mach_time.h>
 #define GNURADIO_HRT_USE_MACH_ABSOLUTE_TIME
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define GNURADIO_HRT_USE_CLOCK_GETTIME
 #include <ctime>
 #else
+#include <ratio>
 #define GNURADIO_HRT_USE_GENERIC_CLOCK
 #endif
 
+#include <gnuradio/api.h>
+#include <chrono>
 
 ////////////////////////////////////////////////////////////////////////
 namespace gr {
@@ -79,7 +80,6 @@ inline gr::high_res_timer_type gr::high_res_timer_tps(void) { return 1000000000U
 
 ////////////////////////////////////////////////////////////////////////
 #ifdef GNURADIO_HRT_USE_MACH_ABSOLUTE_TIME
-#include <mach/mach_time.h>
 
 inline gr::high_res_timer_type gr::high_res_timer_now(void)
 {
@@ -101,7 +101,6 @@ inline gr::high_res_timer_type gr::high_res_timer_tps(void)
 
 ////////////////////////////////////////////////////////////////////////
 #ifdef GNURADIO_HRT_USE_QUERY_PERFORMANCE_COUNTER
-#include <windows.h>
 
 inline gr::high_res_timer_type gr::high_res_timer_now(void)
 {

--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -11,6 +11,13 @@
 #ifndef INCLUDED_THREAD_H
 #define INCLUDED_THREAD_H
 
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
 #include <gnuradio/api.h>
 #include <boost/thread/barrier.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -19,16 +26,6 @@
 #include <boost/thread/thread.hpp>
 #include <memory>
 #include <vector>
-
-#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-
-#include <windows.h>
-
-#endif
 
 namespace gr {
 namespace thread {

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -152,12 +152,6 @@ target_compile_definitions(gnuradio-runtime PUBLIC ${MPLIB_DEFINITIONS})
 # constants.cc includes boost::dll headers, force them to use std::filesystem
 target_compile_definitions(gnuradio-runtime PRIVATE BOOST_DLL_USE_STD_FS)
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
-    target_precompile_headers(
-        gnuradio-runtime PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../include/gnuradio/sync_block.h)
-endif()
-
 ########################################################################
 # Add controlport stuff to gnuradio-runtime
 ########################################################################

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -13,14 +13,20 @@
 #include "config.h"
 #endif
 
+#if defined(_WIN32)
+// always include <windows.h> first
+#include <windows.h>
+
+// Sysinfoapi.h MUST NOT BE included before windows.h
+#include <Sysinfoapi.h>
+#endif
+
 #include "pagesize.h"
 #include <gnuradio/logger.h>
 
 namespace gr {
 
 #if defined(_WIN32)
-
-#include <Sysinfoapi.h>
 
 int native_pagesize(const gr::logger_ptr logger)
 {

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -12,6 +12,10 @@
 #include <config.h>
 #endif
 
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#include <windows.h>
+#endif
+
 #include "realtime_impl.h"
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
@@ -55,9 +59,6 @@ static int rescale_virtual_pri(int virtual_pri, int min_real_pri, int max_real_p
 
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-
-#include <windows.h>
-
 namespace gr {
 namespace realtime {
 

--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -8,11 +8,6 @@
  *
  */
 
-#include <gnuradio/logger.h>
-#include <gnuradio/thread/thread.h>
-#include <spdlog/fmt/fmt.h>
-#include <stdexcept>
-
 /* Platform detection & Platform-specific includes */
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 #define __GR_TARGET_WIN__
@@ -32,6 +27,12 @@
 #include <regex>
 #endif
 
+/* Platform-independent includes */
+
+#include <gnuradio/logger.h>
+#include <gnuradio/thread/thread.h>
+#include <spdlog/fmt/fmt.h>
+#include <stdexcept>
 
 namespace gr {
 namespace thread {

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -12,12 +12,15 @@
 #include <config.h>
 #endif
 
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#include <windows.h>
+#endif
+
 #include "tpb_thread_body.h"
 #include <gnuradio/pmt_fmt.h>
 #include <gnuradio/prefs.h>
 #include <pmt/pmt.h>
 #include <boost/thread.hpp>
-#include <iostream>
 
 namespace gr {
 
@@ -26,10 +29,7 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
                                  int max_noutput_items)
     : d_exec(block, max_noutput_items)
 {
-    // std::cerr << "tpb_thread_body: " << block << std::endl;
-
 #if defined(_MSC_VER) || defined(__MINGW32__)
-#include <windows.h>
     thread::set_thread_name(GetCurrentThread(),
                             block->name() + std::to_string(block->unique_id()));
 #else

--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.h
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.h
@@ -11,12 +11,13 @@
 #ifndef GR_VMCIRCBUF_CREATEFILEMAPPING_H
 #define GR_VMCIRCBUF_CREATEFILEMAPPING_H
 
-#include "vmcircbuf.h"
-#include <gnuradio/api.h>
-
 #ifdef HAVE_CREATEFILEMAPPING
 #include <windows.h>
 #endif
+
+#include "vmcircbuf.h"
+#include <gnuradio/api.h>
+
 
 namespace gr {
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/high_res_timer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/high_res_timer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(high_res_timer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3992258b56f41917eef9df090ef2d185)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c1d38d208896a952ff0dcfb57e96d812)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/lib/CMakeLists.txt
+++ b/gr-analog/lib/CMakeLists.txt
@@ -47,10 +47,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime gnuradio-blocks
     PRIVATE gnuradio-filter)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-analog PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-analog PUBLIC $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-audio/lib/CMakeLists.txt
+++ b/gr-audio/lib/CMakeLists.txt
@@ -139,9 +139,5 @@ if(WIN32)
     endif()
 endif(WIN32)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-audio PRIVATE common-precompiled-headers)
-endif()
-
 gr_library_foo(gnuradio-audio)
 install(FILES ${gr_audio_confs} DESTINATION ${GR_PREFSDIR})

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -179,10 +179,6 @@ if(SNDFILE_FOUND)
     target_link_libraries(gnuradio-blocks PRIVATE sndfile::sndfile)
 endif()
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-blocks PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-blocks PUBLIC $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-channels/lib/CMakeLists.txt
+++ b/gr-channels/lib/CMakeLists.txt
@@ -25,10 +25,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime
     PRIVATE gnuradio-filter gnuradio-analog gnuradio-blocks)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-channels PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-channels PUBLIC $<INSTALL_INTERFACE:include>
                              $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-digital/lib/CMakeLists.txt
+++ b/gr-digital/lib/CMakeLists.txt
@@ -95,10 +95,6 @@ target_link_libraries(
     gnuradio-digital PUBLIC gnuradio-runtime gnuradio-filter gnuradio-blocks
                             gnuradio-analog Boost::boost Volk::volk)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-digital PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-digital
     PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-dtv/lib/CMakeLists.txt
+++ b/gr-dtv/lib/CMakeLists.txt
@@ -74,10 +74,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime
     PRIVATE gnuradio-analog gnuradio-filter gnuradio-fec Volk::volk)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-dtv PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-dtv PUBLIC $<INSTALL_INTERFACE:include>
                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-fec/lib/CMakeLists.txt
+++ b/gr-fec/lib/CMakeLists.txt
@@ -77,10 +77,6 @@ endif(MSVC)
 
 target_link_libraries(gnuradio-fec PUBLIC gnuradio-runtime gnuradio-blocks)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-fec PRIVATE common-precompiled-headers)
-endif()
-
 # Address linker issues with std::filesystem on Centos 8 and Debian
 target_link_libraries(
     gnuradio-fec

--- a/gr-fft/lib/CMakeLists.txt
+++ b/gr-fft/lib/CMakeLists.txt
@@ -15,10 +15,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime Volk::volk
     PRIVATE fftw3f::fftw3f)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-fft PRIVATE common-precompiled-headers)
-endif()
-
 # Address linker issues with std::filesystem on Centos 8 and Debian
 target_link_libraries(
     gnuradio-fft

--- a/gr-filter/lib/CMakeLists.txt
+++ b/gr-filter/lib/CMakeLists.txt
@@ -58,10 +58,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime gnuradio-fft Volk::volk
     PRIVATE gnuradio-blocks)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-filter PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-filter PUBLIC $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-iio/lib/CMakeLists.txt
+++ b/gr-iio/lib/CMakeLists.txt
@@ -34,10 +34,6 @@ if(libad9361_SUFFICIENT)
     target_compile_definitions(gnuradio-iio PUBLIC -DGR_IIO_LIBAD9361)
 endif(libad9361_SUFFICIENT)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-iio PRIVATE common-precompiled-headers)
-endif()
-
 #Add Windows DLL resource file if using MSVC
 if(MSVC)
     include(${PROJECT_SOURCE_DIR}/cmake/Modules/GrVersion.cmake)

--- a/gr-network/lib/CMakeLists.txt
+++ b/gr-network/lib/CMakeLists.txt
@@ -28,10 +28,6 @@ add_library(
 
 target_link_libraries(gnuradio-network PUBLIC gnuradio-runtime)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-network PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-network
     PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-pdu/lib/CMakeLists.txt
+++ b/gr-pdu/lib/CMakeLists.txt
@@ -35,10 +35,6 @@ endif(MSVC)
 
 target_link_libraries(gnuradio-pdu PUBLIC gnuradio-runtime)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-pdu PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-pdu
     PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -70,11 +70,6 @@ set(QTGUI_LIBS
     Qt5::Widgets
 )
 
-if(ENABLE_COMMON_PCH)
-    set(PRIVATE_LIBS common-precompiled-headers)
-endif()
-
-
 add_library(
     gnuradio-qtgui
     ${QTGUI_SOURCES}

--- a/gr-soapy/lib/CMakeLists.txt
+++ b/gr-soapy/lib/CMakeLists.txt
@@ -15,10 +15,6 @@ target_compile_features(gnuradio-soapy PRIVATE ${GR_CXX_VERSION_FEATURE})
 
 target_link_libraries(gnuradio-soapy PUBLIC gnuradio-runtime ${SoapySDR_LIBRARIES})
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-soapy PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-soapy PUBLIC $<INSTALL_INTERFACE:include>
                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-trellis/lib/CMakeLists.txt
+++ b/gr-trellis/lib/CMakeLists.txt
@@ -32,10 +32,6 @@ add_library(
 
 target_link_libraries(gnuradio-trellis PUBLIC gnuradio-runtime gnuradio-digital)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-trellis PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-trellis PUBLIC $<INSTALL_INTERFACE:include>
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)

--- a/gr-video-sdl/lib/CMakeLists.txt
+++ b/gr-video-sdl/lib/CMakeLists.txt
@@ -15,10 +15,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime
     PRIVATE ${SDL_LIBRARY})
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-video-sdl PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-video-sdl
     PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-vocoder/lib/CMakeLists.txt
+++ b/gr-vocoder/lib/CMakeLists.txt
@@ -28,10 +28,6 @@ target_include_directories(
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 target_link_libraries(gnuradio-vocoder PUBLIC gnuradio-runtime)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-vocoder PRIVATE common-precompiled-headers)
-endif()
-
 if(LIBCODEC2_FOUND)
     target_sources(gnuradio-vocoder PRIVATE codec2.cc codec2_decode_ps_impl.cc
                                             codec2_encode_sp_impl.cc)

--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -26,10 +26,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime
     PRIVATE GSL::gsl)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-wavelet PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-wavelet
     PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-zeromq/lib/CMakeLists.txt
+++ b/gr-zeromq/lib/CMakeLists.txt
@@ -30,10 +30,6 @@ target_link_libraries(
     PUBLIC gnuradio-runtime
     PRIVATE ZeroMQ::ZeroMQ)
 
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-zeromq PRIVATE common-precompiled-headers)
-endif()
-
 target_include_directories(
     gnuradio-zeromq PUBLIC $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)


### PR DESCRIPTION
#7656

- **Windows: include ordering matters; windows.h before other sys headers**
- **CMake&runtime: remove precompiled header infrastructure**
