### PR TITLE
bp #7747

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -47,8 +47,10 @@ macro(GR_PYBIND_MAKE name updir filter files)
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${name}_python PRIVATE -Wno-unused-variable
-        )# disable warnings for docstring templates
+        target_compile_options(${name}_python PRIVATE
+            -Wno-unused-variable
+            -Wno-error=deprecated-declarations
+        ) # disable warnings for docstring templates
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_dependencies(${name}_python ${name}_docstrings)
 
@@ -190,8 +192,10 @@ macro(GR_PYBIND_MAKE_CHECK_HASH name updir filter files)
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${name}_python PRIVATE -Wno-unused-variable
-        )# disable warnings for docstring templates
+        target_compile_options(${name}_python PRIVATE
+            -Wno-unused-variable
+            -Wno-error=deprecated-declarations
+        ) # disable warnings for docstring templates
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(NOT SNDFILE_FOUND AND ${name} STREQUAL blocks)
         target_compile_options(${name}_python PRIVATE -DNO_WAVFILE)
@@ -336,8 +340,10 @@ macro(GR_PYBIND_MAKE_OOT name updir filter files)
         ${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module
                                Python::NumPy gnuradio-${MODULE_NAME})
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${name}_python PRIVATE -Wno-unused-variable
-        )# disable warnings for docstring templates
+        target_compile_options(${name}_python PRIVATE
+            -Wno-unused-variable
+            -Wno-error=deprecated-declarations
+        ) # disable warnings for docstring templates
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_dependencies(${name}_python ${name}_docstrings ${regen_targets})
 

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -802,8 +802,8 @@ struct rpcbasic_register_set : public rpcbasic_base {
      * \param display_     The display mask
      */
     rpcbasic_register_set(const std::string& block_alias,
-                          const char* functionbase,
-                          void (T::*function)(Tto),
+                          [[maybe_unused]] const char* functionbase,
+                          [[maybe_unused]] void (T::*function)(Tto),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -862,10 +862,10 @@ struct rpcbasic_register_set : public rpcbasic_base {
      * \param minpriv_     The required minimum privilege level
      * \param display_     The display mask
      */
-    rpcbasic_register_set(const std::string& name,
-                          const char* functionbase,
+    rpcbasic_register_set([[maybe_unused]] const std::string& name,
+                          [[maybe_unused]] const char* functionbase,
                           T* obj,
-                          void (T::*function)(Tto),
+                          [[maybe_unused]] void (T::*function)(Tto),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -982,8 +982,8 @@ struct rpcbasic_register_trigger : public rpcbasic_base {
      * \param minpriv_     The required minimum privilege level
      */
     rpcbasic_register_trigger(const std::string& block_alias,
-                              const char* functionbase,
-                              void (T::*function)(),
+                              [[maybe_unused]] const char* functionbase,
+                              [[maybe_unused]] void (T::*function)(),
                               const char* desc_ = "",
                               priv_lvl_t minpriv_ = RPC_PRIVLVL_MIN)
     {
@@ -1022,10 +1022,10 @@ struct rpcbasic_register_trigger : public rpcbasic_base {
      * \param desc_        A string to describing the variable.
      * \param minpriv_     The required minimum privilege level
      */
-    rpcbasic_register_trigger(const std::string& name,
-                              const char* functionbase,
+    rpcbasic_register_trigger([[maybe_unused]] const std::string& name,
+                              [[maybe_unused]] const char* functionbase,
                               T* obj,
-                              void (T::*function)(),
+                              [[maybe_unused]] void (T::*function)(),
                               const char* desc_ = "",
                               priv_lvl_t minpriv_ = RPC_PRIVLVL_MIN)
     {
@@ -1133,8 +1133,8 @@ public:
      * \param display_     The display mask
      */
     rpcbasic_register_get(const std::string& block_alias,
-                          const char* functionbase,
-                          Tfrom (T::*function)(),
+                          [[maybe_unused]] const char* functionbase,
+                          [[maybe_unused]] Tfrom (T::*function)(),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1176,8 +1176,8 @@ public:
      * '[variable]() const' getter functions.
      */
     rpcbasic_register_get(const std::string& block_alias,
-                          const char* functionbase,
-                          Tfrom (T::*function)() const,
+                          [[maybe_unused]] const char* functionbase,
+                          [[maybe_unused]] Tfrom (T::*function)() const,
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1238,10 +1238,10 @@ public:
      * \param minpriv_     The required minimum privilege level
      * \param display_     The display mask
      */
-    rpcbasic_register_get(const std::string& name,
-                          const char* functionbase,
+    rpcbasic_register_get([[maybe_unused]] const std::string& name,
+                          [[maybe_unused]] const char* functionbase,
                           T* obj,
-                          Tfrom (T::*function)(),
+                          [[maybe_unused]] Tfrom (T::*function)(),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1281,10 +1281,10 @@ public:
      * \brief Same as above that allows using '[variable]() const'
      * getter functions.
      */
-    rpcbasic_register_get(const std::string& name,
-                          const char* functionbase,
+    rpcbasic_register_get([[maybe_unused]] const std::string& name,
+                          [[maybe_unused]] const char* functionbase,
                           T* obj,
-                          Tfrom (T::*function)() const,
+                          [[maybe_unused]] Tfrom (T::*function)() const,
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1612,7 +1612,7 @@ public:
      * \param display_     The display mask
      */
     rpcbasic_register_handler(const std::string& block_alias,
-                              const char* handler,
+                              [[maybe_unused]] const char* handler,
                               const char* units_ = "",
                               const char* desc_ = "",
                               priv_lvl_t minpriv_ = RPC_PRIVLVL_MIN,

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/rpcregisterhelpers_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/rpcregisterhelpers_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rpcregisterhelpers.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0e7fa8e10f2385eff09832a4476c1fff)                     */
+/* BINDTOOL_HEADER_FILE_HASH(655cba56c80e645375b1cc15510d87d3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Backport #7747 

By definition, pybind has to bind even deprecated functions (until we
actually remove them).

So, erroring out when we do that is not an option.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
