### PR TITLE
qtgui/matrixdisplay: avoid extraneous copy, work with Qt<5.14

### DIFF
--- a/gr-qtgui/lib/matrix_sink_impl.cc
+++ b/gr-qtgui/lib/matrix_sink_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2023 Free Software Foundation, Inc.
+ * Copyright 2025 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -111,9 +112,13 @@ int matrix_sink_impl::work(int noutput_items,
     auto in = static_cast<const input_type*>(input_items[0]);
 
     for (int k = 0; k < noutput_items; k++) {
-        QVector<double> qvec(d_vlen);
-        std::copy(in + k * d_vlen, in + (k + 1) * d_vlen, qvec.begin());
-        emit d_signal->data_ready(qvec);
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+        QVector<double> data(d_vlen);
+        std::copy_n(in + k * d_vlen, d_vlen, data.begin());
+#else
+        QVector<double> data(in + k * d_vlen, in + (k + 1) * d_vlen);
+#endif
+        emit d_signal->data_ready(data);
     }
 
     return noutput_items;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Was backporting #6718, failed, because that didn't include Jeff's fix to work with Qt 5.12.

This is a "best of both worlds" change that avoids the zero-initialization that `QVector(size_t size)` does, but allows for code to work with older versions of Qt.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
