### PR TITLE
gr-analog: Fix PSD computation errors: cast noverlap to int

### DIFF
--- a/gr-analog/examples/fmtest.py
+++ b/gr-analog/examples/fmtest.py
@@ -142,7 +142,7 @@ def main():
         d = fm.snk_tx.data()[Ns:Ns + Ne]
         sp1_f = fig1.add_subplot(2, 1, 1)
 
-        X, freq = sp1_f.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
+        X, freq = sp1_f.psd(d, NFFT=fftlen, noverlap= int(fftlen / 4), Fs=fs,
                             window=lambda d: d * winfunc(fftlen),
                             visible=False)
         X_in = 10.0 * numpy.log10(abs(numpy.fft.fftshift(X)))
@@ -181,7 +181,7 @@ def main():
             d = fm.snks[i].data()[Ns:Ne]
 
             sp2_f = fig2.add_subplot(Nrows, Ncols, 1 + i)
-            X, freq = sp2_f.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs_o,
+            X, freq = sp2_f.psd(d, NFFT=fftlen, noverlap= int(fftlen / 4), Fs=fs_o,
                                 window=lambda d: d * winfunc(fftlen),
                                 visible=False)
             #X_o = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This change fixes a TypeError encountered during PSD calculation in fmtest.py.
The issues were:

The noverlap parameter was passed as a float (fftlen / 4), which caused slicing operations to fail.

We ensured noverlap is cast to an integer.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
N/A

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Affects gr-analog/examples/fmtest.py

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
- Manually ran fmtest.py after applying the fixes.

- Confirmed that the PSD computation runs without TypeError.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.