### PR TITLE
digital: fix bugs in band-edge filter design

### DIFF
--- a/gr-digital/grc/digital_fll_band_edge_cc.block.yml
+++ b/gr-digital/grc/digital_fll_band_edge_cc.block.yml
@@ -19,7 +19,7 @@ parameters:
     label: Filter Rolloff Factor
     dtype: real
 -   id: filter_size
-    label: Prototype Filter Size
+    label: Filter Size
     dtype: int
 -   id: w
     label: Loop Bandwidth

--- a/gr-digital/lib/fll_band_edge_cc_impl.cc
+++ b/gr-digital/lib/fll_band_edge_cc_impl.cc
@@ -167,7 +167,7 @@ void fll_band_edge_cc_impl::design_filter()
     const float half_sps_inv = 2.0f / d_sps;
     for (size_t i = 0; i < d_filter_size; i++) {
         const float k = -M + i * half_sps_inv;
-        const float position = d_rolloff * k;
+        const float position = 0.5f * d_rolloff * k;
         const float tap = sinc(position - 0.5f) + sinc(position + 0.5f);
         power += tap * tap;
 
@@ -189,7 +189,7 @@ void fll_band_edge_cc_impl::design_filter()
         const float k = (static_cast<signed_type>(i) - N) * inv_twice_sps;
 
         const size_t index = d_filter_size - i - 1;
-        d_taps_lower[index] = tap * gr_expj(-M_TWOPI * (1 + d_rolloff) * k);
+        d_taps_lower[index] = tap * gr_expj(-M_TWOPI * k);
         d_taps_upper[index] = std::conj(d_taps_lower[d_filter_size - i - 1]);
     }
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description

The band-edge filter that is designed in the FLL Band-edge block has two bugs:

- The width of the frequency domain response of the filter is `2 * rolloff`, but it should be `rolloff`.

- The filter is translated in frequency to be centered at `(1 + rolloff) / (2 * sps)`, but it should be centered at `1 / (2 * sps)`.

These problems, and their fixes, are demonstrated in [this Jupyter notebook](https://github.com/daniestevez/jupyter_notebooks/blob/master/Band-edge%20filter.ipynb).

Additionally, this commit changes "Prototype Filter Size" in the GRC YAML to "Filter Size". The band-edge filter is not a Polyphase Filterbank, so using the word "Prototype" here can be misleading.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

No issue.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

FLL Band-Edge block in gr-digital

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

No testing done directly on the changes. The attached [Jupyter notebook](https://github.com/daniestevez/jupyter_notebooks/blob/master/Band-edge%20filter.ipynb) has a Python translation of the filter design code, and the frequency response of the filter is plotted to check that it is correct after making these changes.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. -> No docs changes necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass. -> No new unit tests. Proper unit test is clearly lacking for this block if a wrong filter design was able to go under the radar for many years.
