### PR TITLE
OFDM Receiver: add support for even carriers in STF

### DIFF
--- a/gr-digital/python/digital/ofdm_txrx.py
+++ b/gr-digital/python/digital/ofdm_txrx.py
@@ -327,8 +327,9 @@ class ofdm_rx(gr.hier_block2):
 
             even_carriers = any(sync_word1[0::2])
             if even_carriers and any(sync_word1[1::2]):
-                raise ValueError("Alternate carriers in Sync Word 1 "
-                    "must be zero for Schmidl & Cox synchronization")
+                raise ValueError(
+                    "Alternate carriers in Sync Word 1 must be zero for Schmidl & Cox synchronization"
+                )
             self.sync_word1 = sync_word1
 
         self.sync_word2 = ()

--- a/gr-digital/python/digital/ofdm_txrx.py
+++ b/gr-digital/python/digital/ofdm_txrx.py
@@ -319,11 +319,18 @@ class ofdm_rx(gr.hier_block2):
         if sync_word1 is None:
             self.sync_word1 = _make_sync_word1(
                 fft_len, occupied_carriers, pilot_carriers)
+            even_carriers = any(self.sync_word1[0::2])
         else:
             if len(sync_word1) != self.fft_len:
                 raise ValueError(
                     "Length of sync sequence(s) must be FFT length.")
+
+            even_carriers = any(sync_word1[0::2])
+            if even_carriers and any(sync_word1[1::2]):
+                raise ValueError("Alternate carriers in Sync Word 1 "
+                    "must be zero for Schmidl & Cox synchronization")
             self.sync_word1 = sync_word1
+
         self.sync_word2 = ()
         if sync_word2 is None:
             self.sync_word2 = _make_sync_word2(
@@ -340,7 +347,7 @@ class ofdm_rx(gr.hier_block2):
         else:
             self.scramble_seed = 0x00  # We deactivate the scrambler by init'ing it with zeros
         ### Sync ############################################################
-        sync_detect = digital.ofdm_sync_sc_cfb(fft_len, cp_len)
+        sync_detect = digital.ofdm_sync_sc_cfb(fft_len, cp_len, even_carriers)
         delay = blocks.delay(gr.sizeof_gr_complex, fft_len + cp_len)
         oscillator = analog.frequency_modulator_fc(-2.0 / fft_len)
         mixer = blocks.multiply_cc()


### PR DESCRIPTION
## Description
The OFDM Loopback example doesn't work with even carriers in Sync Word 1 (used in the IEEE 802.15.4 SUN PHY), because [OFDM Receiver](https://wiki.gnuradio.org/index.php/OFDM_Receiver) doesn't set the **use_even_carriers** parameter in its call to the Schmidl & Cox synchronizer.

Without this fix OFDM Receiver can't synchronize if **Sync Word 1** (the STF in 802.15.4) uses even carriers. This fix detects whether even or odd carriers are used, complains if both are and sets the **use_even_carriers** parameter in the call to the Schmidl & Cox synchronizer accordingly.

## Related Issue
Corrected version of [7825](https://github.com/gnuradio/gnuradio/pull/7825)

## Which blocks/areas does this affect?
- gr-digital/python/digital/ofdm_txrx.py

## Testing Done
Tested with all IEEE 802.15.4 SUN PHY ODFM Options (1-4).

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
