### PR TITLE
modtool: Fix swapped sink and source descriptions

### DIFF
--- a/gr-utils/modtool/core/add.py
+++ b/gr-utils/modtool/core/add.py
@@ -41,8 +41,8 @@ class ModToolAdd(ModTool):
     name = 'add'
     description = 'Add new block into a module.'
     block_types = {
-        "sink": "Source block with outputs, but no stream inputs",
-        "source": "Sink block with inputs, but no stream outputs",
+        "sink": "Sink block with inputs, but no stream outputs",
+        "source": "Source block with outputs, but no stream inputs",
         "sync": "Block with synchronous 1:1 input-to-output",
         "decimator": "Block with synchronous N:1 input-to-output",
         "interpolator": "Block with synchronous 1:N input-to-output",


### PR DESCRIPTION
## Description

This PR fixes a swapped description for the source and sink blocks when using `gr_modtool add`.

## Related Issue

None.

## Which blocks/areas does this affect?

Only the output of modtool is affected, no actual code is changed.

## Testing Done

Running `gr_modtool add`.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
