### PR TITLE
gr_filter: Add missing mmse_fir_interpolator.h to filter include directory on install

### DIFF
--- a/gr-filter/include/gnuradio/filter/CMakeLists.txt
+++ b/gr-filter/include/gnuradio/filter/CMakeLists.txt
@@ -19,6 +19,7 @@ install(
           iir_filter.h
           interpolator_taps.h
           interp_fir_filter.h
+          mmse_fir_interpolator.h
           mmse_fir_interpolator_cc.h
           mmse_fir_interpolator_ff.h
           mmse_interp_differentiator_cc.h


### PR DESCRIPTION
## Description
This PR adds back the missing mmse_fir_interpolator header file being used by mmse_fir_interpolator_ff and mmse_fir_interpolator_cc header files.

## Related Issue
Trying to compile oot modules using mmse_fir_interpolator keep failing due to missing mmse_fir_interpolator.h file in gnuradio/filter folder.

Example:

```
In file included from /home/bjk/gnuradio/src/modules/gr-bluetooth/lib/../include/bluetooth/multi_block.h:30,
                 from /home/bjk/gnuradio/src/modules/gr-bluetooth/lib/multi_block.cc:31:
/home/bjk/gnuradio/include/gnuradio/filter/mmse_fir_interpolator_ff.h:16:10: fatal error: gnuradio/filter/mmse_fir_interpolator.h: File or directory not found
   16 | #include <gnuradio/filter/mmse_fir_interpolator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

## Which blocks/areas does this affect?
Several oot projects using mmse_fir_interpolator_ff or mmse_fir_interpolator_cc

## Testing Done
Recompiled gnuradio with changes and tested oot projects to compile

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
