### PR TITLE
BP 7774

### DIFF
--- a/grc/converter/flow_graph.py
+++ b/grc/converter/flow_graph.py
@@ -23,6 +23,10 @@ def from_xml(filename):
         file_format = _guess_file_format_1(data)
 
     data['metadata'] = {'file_format': file_format}
+    # Old XML-based flow graphs only supported Python, but didn't always declare
+    # that in the options. We'll default to Python if it's not set.
+    if 'output_language' not in data['options']:
+        data['options']['output_language'] = 'python'
 
     return data
 


### PR DESCRIPTION
Backport of #7774 

Old XML-based GRC files don't necessarily provide output_language, but
they only supported Python anyway, so we auto-populate that field.

Signed-off-by: Martin Braun <martin.braun@ettus.com>
