### PR TITLE
Make QA pass qa_annotator_raw and _get_first_tag_in_range again

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -36,7 +36,10 @@ if(ENABLE_TESTING)
                             qa_random.py
                             qa_sys_paths.py
                             qa_tag_utils.py
-                            qa_get_first_tag_in_range.py
+                            # Sadly, this still results in a deadlock due to
+                            # GIL / Buffer locking; see
+                            # https://github.com/gnuradio/gnuradio/issues/7711
+                            # qa_get_first_tag_in_range.py
     )
     # This is a check for whether gr-blocks is enabled
     if(ENABLE_DEFAULT OR ENABLE_GR_BLOCKS)

--- a/gr-blocks/python/blocks/qa_annotator_raw.py
+++ b/gr-blocks/python/blocks/qa_annotator_raw.py
@@ -59,7 +59,7 @@ class test_annotator_raw(gr_unittest.TestCase):
 
     def test_003_late_insertion(self):
         N = 1000
-        total_time = 0.5
+        total_time = 1.0
         tags_in = [
             (n * N, pmt.mp(f"key_{n}"), pmt.from_long(n * 10)) for n in range(N // 2, N)
         ]


### PR DESCRIPTION
- **blocks/annotator_raw: QA sporadically fails on overtasked mac QA**
- **runtime/qa_get_first_tag_in_range: Don't test until underlying deadlock solved**

## Description

The QA has been failing on windows builds and occassionally on Mac builds. This is bad. Let's not run known-to-be-broken QA on main.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Read #7771 for details on deadlocking

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

We now contain the `get_first_tag_in_range` API on main, with no unit test. So, don't use that API until we fix it.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

This PR's CI should run through.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
