### PR TITLE
BP 7814 (binding prepend path)

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
@@ -39,7 +39,7 @@ includes = ','.join(args.include)
 name = args.module
 
 namespace = ['gr', name]
-prefix_include_root = name
+prefix_include_root = "gnuradio/" + name
 
 
 with warnings.catch_warnings():


### PR DESCRIPTION
Backport of #7814 

Without this fix, whenever bind_oot_file.py is called (e.g., through
CMake because something changed), a new <modulename>_python.cc file is
generated. During the re-generation, the include path in this file is
corrupted. After running `gr_modtool newmod foo`, and creating a block
(`gr_modtool add bar`), the file gr-foo/python/bindings/bar_python.cc
contains this line:

```cpp
    #include <gnuradio/foo/bar.h>
```

Afterwards, this line is modified to:

```cpp
    #include <foo/bar.h>
```

Signed-off-by: Martin Braun <martin.braun@ettus.com>
