### PR TITLE
blocks/annotator_raw: QA sporadically fails on overtasked mac QA (maint-3.10)

### DIFF
--- a/gr-blocks/python/blocks/qa_annotator_raw.py
+++ b/gr-blocks/python/blocks/qa_annotator_raw.py
@@ -59,7 +59,7 @@ class test_annotator_raw(gr_unittest.TestCase):
 
     def test_003_late_insertion(self):
         N = 1000
-        total_time = 0.5
+        total_time = 1.0
         tags_in = [
             (n * N, pmt.mp(f"key_{n}"), pmt.from_long(n * 10)) for n in range(N // 2, N)
         ]


### PR DESCRIPTION
Backport of the relevant part of #7853 

----

Increase overall processing time to increase tolerances

Puh, this is really not a tight race to win, and the macOS builder still
manages to lose it.
