### PR TITLE
buffer_single_mapped: locking needs a named object

### DIFF
--- a/gnuradio-runtime/lib/buffer_single_mapped.cc
+++ b/gnuradio-runtime/lib/buffer_single_mapped.cc
@@ -126,7 +126,7 @@ bool buffer_single_mapped::allocate_buffer(int nitems)
 bool buffer_single_mapped::input_blkd_cb_ready(int items_required,
                                                unsigned int read_index)
 {
-    gr::thread::scoped_lock(*this->mutex());
+    gr::thread::scoped_lock lock(*this->mutex());
 
     return (((d_bufsize - read_index) < (uint32_t)items_required) &&
             (d_write_index < read_index));
@@ -136,7 +136,7 @@ bool buffer_single_mapped::output_blkd_cb_ready(int output_multiple)
 {
     uint32_t space_avail = 0;
     {
-        gr::thread::scoped_lock(*this->mutex());
+        gr::thread::scoped_lock lock(*this->mutex());
         space_avail = space_available();
     }
     return (((space_avail > 0) || (space_avail == 0 && d_has_history)) &&


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

In `buffer_single_mapped`, we make a small mistake where we create a scoped lock as a temporary object.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
#7760

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Hopefully, none? Realistically, it fixes a bug.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Tests continue to pass. I just wonder know whether *acquiring* the lock was what was sufficient, not holding it. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
