### PR TITLE
CI: try running gh worker with 4 cores

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -111,7 +111,7 @@ jobs:
       image: ${{ matrix.containerid }}
       volumes:
         - build_data:/build
-      options: --cpus 2 ${{ matrix.containeroptions }}
+      options: --cpus 4 ${{ matrix.containeroptions }}
     steps:
     - uses: actions/checkout@v1
       name: Checkout Project
@@ -135,7 +135,7 @@ jobs:
         path: /build/compile_commands.json
         if-no-files-found: ignore
     - name: Make
-      run: cmake --build /build --parallel 2
+      run: cmake --build /build --parallel 4
     - name: Make Test
       env:
         QT_QPA_PLATFORM: offscreen


### PR DESCRIPTION
I see that tools that count their own cores run with 4 threads. Let's try the same – CI has been **awfully** slow the last couple of days (where I could routinely get 40 min PR builds, I'm now happy when everything is done 1h 30min later).

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
