### PR TITLE
CI: Fedora 42 builder, cycle Fedora versions

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -89,12 +89,12 @@ jobs:
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
           - distro: 'Ubuntu 24.04'
             containerid: 'gnuradio/ci:ubuntu-24.04-3.10'
-          - distro: 'Fedora 40 (with 0xFE memory initialization, GLIBCXX_ASSERTIONS)'
-            containerid: 'gnuradio/ci:fedora-40-3.10'
+          - distro: 'Fedora 41 (with 0xFE memory initialization, GLIBCXX_ASSERTIONS)'
+            containerid: 'gnuradio/ci:fedora-41-3.10'
             cxxflags: -ftrivial-auto-var-init=pattern -Wp,-D_GLIBCXX_ASSERTIONS
             ldpath: /usr/local/lib64
-          - distro: 'Fedora 41 (clang, ninja)'
-            containerid: 'gnuradio/ci:fedora-41-3.10'
+          - distro: 'Fedora 42 (clang, ninja)'
+            containerid: 'gnuradio/ci:fedora-42-3.10'
             cxxflags: -Wno-unused-command-line-argument
             cmakeflags: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -GNinja
             ldpath: /usr/local/lib64


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

It's that time of year when I get around to updating my CI builder. Same for GNU Radio, I guess.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Helpful understanding esp. #7757 on modern platforms

