### PR TITLE
modtool: Add support for rfnoc_block

### DIFF
--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -152,7 +152,7 @@ def get_arglist(self):
             fg='cyan'),
             prompt_suffix='',
             default='',
-            show_default=False)
+            show_default=False) if not self.info['yes'] else ''
 
 
 def get_py_qa(self):
@@ -160,7 +160,7 @@ def get_py_qa(self):
     if self.add_py_qa is None:
         if not (self.info['blocktype'] in ('noblock') or self.skip_subdirs['python']):
             self.add_py_qa = ask_yes_no(click.style(
-                'Add Python QA code?', fg='cyan'), True)
+                'Add Python QA code?', fg='cyan'), True) if not self.info['yes'] else True
         else:
             self.add_py_qa = False
 
@@ -170,6 +170,6 @@ def get_cpp_qa(self):
     if self.add_cc_qa is None:
         if self.info['lang'] == 'cpp':
             self.add_cc_qa = ask_yes_no(click.style('Add C++ QA code?', fg='cyan'),
-                                        not self.add_py_qa)
+                                        not self.add_py_qa) if not self.info['yes'] else not self.add_py_qa
         else:
             self.add_cc_qa = False

--- a/gr-utils/modtool/tools/code_generator.py
+++ b/gr-utils/modtool/tools/code_generator.py
@@ -26,7 +26,8 @@ GRTYPELIST = {
     'general': 'block',
     'tagged_stream': 'tagged_stream_block',
     'hier': 'hier_block2',
-    'noblock': ''
+    'noblock': '',
+    'rfnoc_block': 'uhd::rfnoc_block',
 }
 
 


### PR DESCRIPTION
This extends gr_modtool to also generate C++ block controllers for RFNoC blocks:

    gr_modtool add -t rfnoc_block

...will create such a block controller. C++ RFNoC blocks allow control of RFNoC blocks from GNU Radio, even though GNU Radio does not control the streaming through such blocks.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done

I tested this on `gr-rfnoc_gain`, and tried to recreate the same code that was manually created (and is heavily vetted).


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
