### PR TITLE
grc:  Using the Escape key in PropsDialog is buggy

### DIFF
--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -304,6 +304,9 @@ class PropsDialog(Gtk.Dialog):
             insert('\n\n# External Code ({}.py)\n'.format(block.name), src)
 
     def _handle_key_press(self, widget, event):
+        if event.keyval == Gdk.KEY_Escape:
+            self.response(Gtk.ResponseType.REJECT)
+            return True  # Map Escape key to reject button
         close_dialog = (
             event.keyval == Gdk.KEY_Return and
             event.get_state() & Gdk.ModifierType.CONTROL_MASK == 0 and


### PR DESCRIPTION




<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
See #7877

But the problem is more general and affects blocks with ports. Changing the port number (input or output ) in a block and pressing Esc removes the block area and only the ports can be seen in the flowgraph.

.
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Pressing Esc in the PropsDialog for blocks without ports the key is mapped to accept, but I think the common use should be 'Abort Editing'

So this pr maps Esc to reject
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7877

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested like described in #7877
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
