### PR TITLE
uhd: Add FIR filter block support to RFNoC image builder

### DIFF
--- a/gr-uhd/grc/CMakeLists.txt
+++ b/gr-uhd/grc/CMakeLists.txt
@@ -63,6 +63,7 @@ if(ENABLE_UHD_RFNOC)
         uhd_fpga_duc.block.yml
         uhd_fpga_eth_ta.block.yml
         uhd_fpga_fft.block.yml
+        uhd_fpga_fir_filter.block.yml
         uhd_fpga_fosphor.block.yml
         uhd_fpga_keep_one_in_n.block.yml
         uhd_fpga_null_src_sink.block.yml

--- a/gr-uhd/grc/uhd.tree.yml
+++ b/gr-uhd/grc/uhd.tree.yml
@@ -25,11 +25,13 @@
       - uhd_fpga_null_src_sink
       - uhd_fpga_replay
       - uhd_fpga_addsub
-      - uhd_fpga_fosphor
+      - uhd_fpga_f15
       - uhd_fpga_keep_one_in_n
       - uhd_fpga_siggen
       - uhd_fpga_split_stream
       - uhd_fpga_switchboard
+      - uhd_fpga_vector_iir
+      - uhd_fpga_fir_filter
     - Core:
       - uhd_fpga_sep
       - uhd_fpga_device_bsp

--- a/gr-uhd/grc/uhd_fpga_fir_filter.block.yml
+++ b/gr-uhd/grc/uhd_fpga_fir_filter.block.yml
@@ -1,0 +1,47 @@
+id: uhd_fpga_fir_filter
+label: RFNoC FIR Filter
+
+parameters:
+-   id: type
+    label: RFNoC Block Type
+    dtype: enum
+    default: 'block'
+    options: ['block', 'sep', 'device']
+    hide: all
+-   id: desc
+    label: Block Descriptor
+    dtype: string
+    default: 'fir_filter.yml'
+    hide: all
+-   id: NUM_PORTS
+    label: Number of Ports
+    dtype: int
+    default: 1
+    hide: part
+
+inputs:
+-   domain: rfnoc.clk
+    id: ce_clk
+    dtype: message
+-   domain: rfnoc.data
+    id: in_
+    dtype: fc32
+    multiplicity: ${ NUM_PORTS }
+
+outputs:
+-   domain: rfnoc.data
+    id: out_
+    dtype: fc32
+    multiplicity: ${ NUM_PORTS }
+
+doc_url: UHD_FPGA_FIR
+
+documentation: |-
+  RFNoC FIR Filter(FPGA Implementation).
+  Instantiates a FIR Filter block in the FPGA bitfile.
+  This block calculates a running average (using FIR filters) for every element
+  of a vector. This is useful to average the output of an FFT block.
+
+
+file_format: 1
+


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Adds the FIR Filter to the RFNoC Image Builder

## Which blocks/areas does this affect?
This only affects the FIR Filter RFNoC block on the RFNoC Image Builder side. 

## Testing Done
Added the block to the Image and Build it with without getting an Error.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.

![grafik](https://github.com/user-attachments/assets/3cbba460-12ab-4ff9-a645-e70e7e5f83ff)
