### PR TITLE
digital: fix binding hash

### DIFF
--- a/gr-digital/python/digital/bindings/ofdm_sync_sc_cfb_python.cc
+++ b/gr-digital/python/digital/bindings/ofdm_sync_sc_cfb_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(ofdm_sync_sc_cfb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8ec48d9c442f1699e3fa727ad27bfca1)                     */
+/* BINDTOOL_HEADER_FILE_HASH(dcf291db4c2b6cde4698acdc2a787a72)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description

We had a bit of an oops (https://github.com/gnuradio/gnuradio/actions/runs/15774247818/job/44464991973) on main. this fixes the hash.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
