### PR TITLE
cmake: Omit build path in compiler_flags()

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -143,6 +143,8 @@ STRIP_FROM_PATH        =
 
 STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@/gnuradio-runtime/include \
                          @PROJECT_BINARY_DIR@/gnuradio-runtime/include \
+                         @PROJECT_SOURCE_DIR@/gnuradio-runtime/ \
+                         @PROJECT_BINARY_DIR@/gnuradio-runtime/ \
                          @PROJECT_SOURCE_DIR@/gr-analog/include \
                          @PROJECT_BINARY_DIR@/gr-analog/include \
                          @PROJECT_SOURCE_DIR@/gr-audio/include \

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -20,6 +20,13 @@ message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
 #Generate the constants file, now that we actually know which components will be enabled.
+if(CMAKE_VERSION VERSION_LESS "3.20")
+    set(SAFE_COMPILER_INFO "${COMPILER_INFO}")
+else()
+    cmake_path(GET CMAKE_SOURCE_DIR PARENT_PATH top_build_dir)
+    string(REPLACE "${top_build_dir}" "BUILD_DIR" SAFE_COMPILER_INFO "${COMPILER_INFO}")
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/constants.cc.in
                ${CMAKE_CURRENT_BINARY_DIR}/constants.cc ESCAPE_QUOTES @ONLY)
 

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -68,7 +68,7 @@ const std::string c_compiler() { return "@cmake_c_compiler_version@"; }
 
 const std::string cxx_compiler() { return "@cmake_cxx_compiler_version@"; }
 
-const std::string compiler_flags() { return "@COMPILER_INFO@"; }
+const std::string compiler_flags() { return "@SAFE_COMPILER_INFO@"; }
 
 const std::string build_time_enabled_components() { return "@_gr_enabled_components@"; }
 


### PR DESCRIPTION
Support reproducible builds by replacing reference to the build path.

Copy of https://github.com/gnuradio/gnuradio/pull/6905, with minor mods.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description

See #6905. The only difference is, this change is conditional on the CMake version. Note that 3.20 is fairly old, so this will hopefully help people who build packages for reasonably up-to-date platforms, like @maitbot or @balister.

## Related Issue

Closes #6905.

## Which blocks/areas does this affect?

CMakery only.

## Testing Done

Currently building...

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
