### PR TITLE
uhd: Fix rfnoc_fosphor.grc by setting radio block args

### DIFF
--- a/gr-uhd/examples/grc/rfnoc_fosphor.grc
+++ b/gr-uhd/examples/grc/rfnoc_fosphor.grc
@@ -327,7 +327,7 @@ blocks:
     alias: ''
     antenna: RX2
     bandwidth: '0'
-    block_args: ''
+    block_args: f"spp={fft_size}"
     comment: ''
     dc_offset: 'False'
     device_select: '-1'


### PR DESCRIPTION
The example is changed to set the spp value of the radio block to the desired FFT size, so that FFT blocks of all generations can handle the data.

Otherwise, 'rfnoc rx streamer: warning : Received fractional vector! Expect signal fagmentation.' would occur.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->


## Related Issue

Supersedes https://github.com/gnuradio/gnuradio/pull/7885

<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
One example in gr-uhd.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
