### PR TITLE
cmake: fix build with Boost 1.89.0

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -13,7 +13,7 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
 find_dependency(spdlog)
 find_dependency(MPLIB)
 
-set(BOOST_REQUIRED_COMPONENTS date_time program_options system regex thread)
+set(BOOST_REQUIRED_COMPONENTS date_time program_options regex thread)
 
 if(NOT ENABLE_TESTING)
     set(ENABLE_TESTING

--- a/cmake/Modules/GrBoost.cmake
+++ b/cmake/Modules/GrBoost.cmake
@@ -14,7 +14,7 @@ set(__INCLUDED_GR_BOOST_CMAKE TRUE)
 # Setup Boost and handle some system specific things
 ########################################################################
 
-set(BOOST_REQUIRED_COMPONENTS date_time program_options system regex thread)
+set(BOOST_REQUIRED_COMPONENTS date_time program_options regex thread)
 
 if(UNIX
    AND NOT BOOST_ROOT


### PR DESCRIPTION
## Description
When testing upcoming Boost 1.89.0 in Homebrew (https://github.com/Homebrew/homebrew-core/pull/233031), GNU Radio build failed due to Boost.System changes.

Boost.System has been header-only since Boost 1.69 and will be dropping the compatibility stub library in Boost 1.89 (boostorg/system@7a495bb). Since GNU Radio uses Boost >= 1.69, the easy fix is to drop `system`
from the `COMPONENTS` as recommended by upstream: `https://github.com/boostorg/system/issues/132#issuecomment-3146378680`

https://github.com/gnuradio/gnuradio/blob/721e477cdb4ed22214ed886d6063cff2dac7d0b5/cmake/Modules/GrMinReq.cmake#L13

## Related Issue
N/A

## Which blocks/areas does this affect?
CMake / build

## Testing Done
Checked successful local compilation with Boost 1.89.0.beta1. Built on macOS 15 arm64 in Homebrew environment.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
