### PR TITLE
fft: Add Configurable FFT Batch Size using FFTW Guru-API

### DIFF
--- a/gr-fft/include/gnuradio/fft/fft.h
+++ b/gr-fft/include/gnuradio/fft/fft.h
@@ -68,15 +68,17 @@ struct fft_outbuf<float, true> {
 template <class T, bool forward>
 class FFT_API fft
 {
+    const int d_fft_size;
     int d_nthreads;
+    const int d_nffts;
     volk::vector<typename fft_inbuf<T, forward>::type> d_inbuf;
     volk::vector<typename fft_outbuf<T, forward>::type> d_outbuf;
     void* d_plan;
     gr::logger d_logger;
-    void initialize_plan(int fft_size);
+    void initialize_plan(int fft_size, int nffts);
 
 public:
-    fft(int fft_size, int nthreads = 1);
+    fft(int fft_size, int nthreads = 1, int nffts = 1);
     // Copy disabled due to d_plan.
     fft(const fft&) = delete;
     fft& operator=(const fft&) = delete;
@@ -87,11 +89,17 @@ public:
      * into which input and output take place. It's done this way in
      * order to ensure optimal alignment for SIMD instructions.
      */
-    typename fft_inbuf<T, forward>::type* get_inbuf() { return d_inbuf.data(); }
-    typename fft_outbuf<T, forward>::type* get_outbuf() { return d_outbuf.data(); }
+    typename fft_inbuf<T, forward>::type* get_inbuf(int fft_idx = 0)
+    {
+        return &(d_inbuf.data()[d_fft_size * fft_idx]);
+    }
+    typename fft_outbuf<T, forward>::type* get_outbuf(int fft_idx = 0)
+    {
+        return &(d_outbuf.data()[d_fft_size * fft_idx]);
+    }
 
-    int inbuf_length() const { return d_inbuf.size(); }
-    int outbuf_length() const { return d_outbuf.size(); }
+    int inbuf_length() const { return d_fft_size; }
+    int outbuf_length() const { return d_fft_size; }
 
     /*!
      *  Set the number of threads to use for calculation.


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Adds API functionality to batch multiple FFTs using the same call to FFTW, useful for blocks needing to do multiple FFTs at once, allowing FFTW to make better optimisations. 

## Related Issue
Closes: #7925 

## Which blocks/areas does this affect?
No user facing block changes, default behaviour is identical to original functionality. 

## Testing Done
FFTed before, FFTed after, no change to original functionality. 
Used FFT API in custom block for multiple FFTs batched. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [N/A] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [N/A] I have added tests to cover my changes, and all previous tests pass.
