### PR TITLE
uhd: Bump minimum UHD version to 3.15

### DIFF
--- a/gr-uhd/CMakeLists.txt
+++ b/gr-uhd/CMakeLists.txt
@@ -10,7 +10,7 @@
 ########################################################################
 include(GrBoost)
 
-find_package(UHD "3.9.7")
+find_package(UHD "3.15")
 if("${UHD_VERSION}" VERSION_GREATER_EQUAL "4")
     set(UHD_FOUR_POINT_OH_RFNOC TRUE)
 else()


### PR DESCRIPTION
If we do a GNU Radio 3.11, I want to limit the available UHD versions. Going to UHD 4 would have been nice for me, but I think some people will want to stay on UHD 3 for some reason and there's plenty of gr-uhd that works just fine with that.