### PR TITLE
TCP- Server: Fix a crash on a connection reset package

### DIFF
--- a/gr-network/lib/tcp_connection.cc
+++ b/gr-network/lib/tcp_connection.cc
@@ -31,6 +31,7 @@ tcp_connection::tcp_connection(asio::io_context& io_context,
                                bool no_delay /*=false*/)
     : d_socket(io_context), d_buf(MTU), d_block(NULL), d_no_delay(no_delay)
 {
+    configure_default_loggers(d_logger, d_debug_logger, "tcp_connection");
     try {
         d_socket.set_option(asio::ip::tcp::no_delay(no_delay));
     } catch (...) {
@@ -91,7 +92,12 @@ void tcp_connection::handle_read(const asio::error_code& error, size_t bytes_tra
                 handle_read(error, bytes_transferred);
             });
     } else {
-        d_socket.shutdown(asio::ip::tcp::socket::shutdown_both);
+        asio::error_code ec;
+        d_socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+        if (ec) {
+            d_logger->info(error.message());
+            d_logger->info(ec.message());
+        }
         d_socket.close();
     }
 }

--- a/gr-network/lib/tcp_connection.h
+++ b/gr-network/lib/tcp_connection.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_TCP_CONNECTION_H
 #define INCLUDED_TCP_CONNECTION_H
 
+#include <gnuradio/logger.h>
 #include <asio.hpp>
 #include <pmt/pmt.h>
 #include <memory>
@@ -32,6 +33,10 @@ private:
     tcp_connection(asio::io_context& io_context, int MTU = 10000, bool no_delay = false);
 
     void handle_read(const asio::error_code& error, size_t bytes_transferred);
+
+protected:
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
 public:
     typedef std::shared_ptr<tcp_connection> sptr;


### PR DESCRIPTION
.



<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
See issue 7930

To fix this issue, it's necessary to handle the error in d.socket_shutdown.

I think, it's helpfull for the user to report an info in this case.

So I added a funcion get_logger in basic_block, to get access to the block's logger.
The example in 7930 now results in
socket_pdu :info: Connection reset by peer
socket_pdu :info: Transport endpoint is not connected when receiving a reset and the process keeps running
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7930
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
basic_block add a function to get the block's logger
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run the exmple in #7930 
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
