### PR TITLE
grc, pdu: fix hidden parameter issue in pdu_lambda block

### DIFF
--- a/gr-pdu/grc/pdu_pdu_lambda.block.yml
+++ b/gr-pdu/grc/pdu_pdu_lambda.block.yml
@@ -19,7 +19,7 @@ parameters:
     label: Key
     dtype: raw
     default: 'pmt.intern("key")'
-    hide: ${ 'none' if metadict.mode == 'META' else 'all' }
+    hide: ${ 'none' if metadict == 'Metadata' else 'all' }
 
 inputs:
 -   id: pdu


### PR DESCRIPTION
Fix issue in PDU Lambda block where Parameter "Key" was always hidden, even when mode "Metadata" was chosen.
fixes #7938

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Previously, the PDU Lambda Block always hid the parameter "Key". This works fine when mode "UVEC" or "RAW" is chosen. However, when "META" is chosen, the parameter "Key" must be shown. Otherwise, there is no way to change that necessary parameter for META mode. This fix allows the parameter to be visisble.

## Related Issue
Fixes #7938 
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
PDU Lambda

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

With new change, the properties dialog shows the "Key" parameter when mode is set to Metadata.

<img width="600" height="523" alt="meta" src="https://github.com/user-attachments/assets/0da39001-a93c-4c3e-bc07-f93e0c92ccc6" />

When mode is set to "Uniform Vector" or "Raw", the "Key" parameter is hidden, as expected.

<img width="600" height="521" alt="uvec" src="https://github.com/user-attachments/assets/e65b7219-ead6-41e9-8763-c230f52e00c5" />

<img width="600" height="520" alt="raw" src="https://github.com/user-attachments/assets/7549ff69-4a39-4851-9da3-3610a9ffd703" />



## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
