### PR TITLE
Add runtime-changeable min/max frequency support for DigitalNumberControl

### DIFF
--- a/gr-qtgui/python/qtgui/digitalnumbercontrol.py
+++ b/gr-qtgui/python/qtgui/digitalnumbercontrol.py
@@ -145,6 +145,25 @@ class DigitalNumberControl(QFrame):
     def setReadOnly(self, b_read_only):
         self.read_only = b_read_only
 
+    
+    def setMinFrequency(self, min_freq_hz):
+        """Set minimum frequency at runtime"""
+        self.min_freq = int(min_freq_hz)
+        if self.cur_freq < self.min_freq:
+            self.setFrequencyNow(self.min_freq)
+
+    def setMaxFrequency(self, max_freq_hz):
+        """Set maximum frequency at runtime"""
+        self.max_freq = int(max_freq_hz)
+        if self.cur_freq > self.max_freq:
+            self.setFrequencyNow(self.max_freq)
+
+    def setFrequencyRange(self, min_freq_hz, max_freq_hz):
+        """Set both min and max frequencies at runtime"""
+        self.setMinFrequency(min_freq_hz)
+        self.setMaxFrequency(max_freq_hz)
+
+
     def mousePressEvent(self, event):
         super(DigitalNumberControl, self).mousePressEvent(event)
         self.offset = event.pos()


### PR DESCRIPTION
This PR adds runtime-changeable minimum and maximum frequency support to the DigitalNumberControl and LabeledDigitalNumberControl classes in GNU Radio’s Qt GUI module.

Details:

Introduced new methods:

setMinFrequency(min_freq_hz) – sets the minimum allowed frequency at runtime.

setMaxFrequency(max_freq_hz) – sets the maximum allowed frequency at runtime.

setFrequencyRange(min_freq_hz, max_freq_hz) – sets both min and max frequencies simultaneously.

Updated the LabeledDigitalNumberControl to pass these methods through to the inner DigitalNumberControl.

Current frequency is automatically clamped to the new range when updated.

Enables dynamic range adjustment, making the control suitable for multi-band radios.