### PR TITLE
pmt: Add python_to_pair function for convenient PDU/pair creation

### DIFF
--- a/gnuradio-runtime/python/pmt/__init__.py
+++ b/gnuradio-runtime/python/pmt/__init__.py
@@ -46,3 +46,4 @@ PMT_EOF = get_PMT_EOF()
 
 from .pmt_to_python import pmt_to_python as to_python
 from .pmt_to_python import python_to_pmt as to_pmt
+from .pmt_to_python import python_to_pair as to_pair

--- a/gnuradio-runtime/python/pmt/pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/pmt_to_python.py
@@ -142,3 +142,8 @@ def python_to_pmt(p):
         elif isinstance(p, python_type):
             return from_python(p)
     raise ValueError("can't convert %s type to pmt (%s)" % (type(p), p))
+
+
+def python_to_pair(first, second):
+    """ Constructs PMT pair from two python elements """
+    return pmt.cons(python_to_pmt(first), python_to_pmt(second))

--- a/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
@@ -12,6 +12,7 @@
 import unittest
 import pmt
 from pmt import pmt_to_python as pmt2py
+import numpy as np
 
 
 class test_pmt_to_python(unittest.TestCase):
@@ -20,9 +21,9 @@ class test_pmt_to_python(unittest.TestCase):
         b = pmt.from_double(123765)
         self.assertEqual(pmt.to_python(b), 123765)
         t = pmt.to_pmt(list(range(5)))
+        self.assertTrue(pmt.is_vector(t))
 
     def test_numpy_to_uvector_and_reverse(self):
-        import numpy as np
         N = 100
         narr = np.ndarray(N, dtype=np.cdouble)
         narr.real[:] = np.random.uniform(size=N)
@@ -31,6 +32,18 @@ class test_pmt_to_python(unittest.TestCase):
         nparr = pmt2py.uvector_to_numpy(uvector)
         self.assertEqual(nparr.dtype, narr.dtype)
         self.assertTrue(np.all(nparr == narr))
+
+    def test_python_to_pair(self):
+        pdu = pmt.to_pair({"key": 42}, np.arange(64, dtype=np.uint8))
+        self.assertTrue(pmt.is_pdu(pdu))
+        self.assertTrue(pmt.is_pair(pdu))
+        metadict = pmt.car(pdu)
+        self.assertTrue(pmt.is_dict(metadict))
+        val = pmt.dict_ref(metadict, pmt.intern("key"), not_found=pmt.from_long(0))
+        self.assertEqual(42, pmt.to_long(val))
+        uvec = pmt.cdr(pdu)
+        self.assertTrue(pmt.is_u8vector(uvec))
+        self.assertListEqual(list(range(64)), pmt.u8vector_elements(uvec))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds a new convenience function to form a pmt pair from two python objects. Although function pmt.to_pmt() allows conversion of several python types to pmt, there is no easy way to do the same for a pmt pair. This new function is especially useful for making PDUs in python.

An example of using the new function pmt.to_pair():
```
pdu1 = pmt.to_pair(None, np.ones(128, "uint8"))
pdu2 = pmt.to_pair({"key": 42}, np.arange(64, "uint8"))
```
Examples of the current method:
```
pdu1 = pmt.cons(pmt.PMT_NIL, pmt.make_u8vector(128, 1))
pdu2 = pmt.cons(pmt.to_pmt({"key": 42}), pmt.to_pmt(np.arange(64, "uint8")))
```

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
closes #7952

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
module pmt_to_python

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Added a QA test and passed.
Performed regression testing via "make test" and all tests passed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
