### PR TITLE
qtgui: deprecate QT GUI Push Button in favor of QT GUI Msg Push Button

### DIFF
--- a/gr-qtgui/grc/qtgui_msgpushbutton.block.yml
+++ b/gr-qtgui/grc/qtgui_msgpushbutton.block.yml
@@ -69,4 +69,6 @@ documentation: |-
 
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.
 
+    This block replaces the deprecated “QT GUI Push Button” and provides a message-based interface for button events.
+    
 file_format: 1

--- a/gr-qtgui/grc/qtgui_push_button.block.yml
+++ b/gr-qtgui/grc/qtgui_push_button.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_push_button
 label: QT GUI Push Button
-flags: [ show_id, python ]
+flags: [show_id, python, deprecated]
 
 parameters:
 -   id: label


### PR DESCRIPTION
<!--- qtgui: deprecate QT GUI Push Button in favor of QT GUI Msg Push Button. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Deprecates the legacy QT GUI Push Button block and updates documentation to direct users toward the QT GUI Msg Push Button as its modern, message-based replacement.

Changes include:

Marked `qtgui_push_button.block.yml` as deprecated.

Added `deprecation_note` referencing the new block.

Updated `qtgui_msg_push_button.block.yml` documentation to note it replaces the old block.

## Related Issue
Fixes #7958

## Which blocks/areas does this affect?
Blocks: QT GUI Push Button, QT GUI Msg Push Button

Area: `gr-qtgui` / GRC block definitions

Impact: Metadata and documentation only — no runtime logic changes.

## Testing Done
Verified that GRC marks QT GUI Push Button as deprecated and shows the note.

Opened existing flowgraphs containing the deprecated block — loaded fine and showed the warning.

Confirmed QT GUI Msg Push Button operates correctly (emits messages on click).

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x ] I have squashed my commits to have one significant change per commit. 
- [x ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x ] All previous tests pass.
