### PR TITLE
feat:Trim single line param values before evaluation

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -127,13 +127,28 @@ class Param(Element):
         return value
 
     def set_value(self, value):
-        # Must be a string
-        self.value = str(value)
+        """
+        Store the user provided value.
+
+        Strips leading and trailing whitespace for all parameter types except
+        multiline fields where whitespace can be significant.
+        """
+        value = str(value)
+        if self._should_trim_value():
+            value = value.strip()
+        self.value = value
 
     def set_default(self, value):
         if self.default == self.value:
             self.set_value(value)
         self.default = str(value)
+
+    def _should_trim_value(self) -> bool:
+        """
+        Determine if leading/trailing whitespace should be trimmed when saving
+        parameter values.
+        """
+        return self.dtype not in ('_multiline', '_multiline_python_external')
 
     def rewrite(self):
         Element.rewrite(self)

--- a/grc/tests/test_param_trim.py
+++ b/grc/tests/test_param_trim.py
@@ -1,0 +1,30 @@
+from grc.core.params.param import Param
+
+
+class _DummyParent:
+    """Minimal parent placeholder for Param."""
+
+
+def _make_param(dtype: str) -> Param:
+    return Param(parent=_DummyParent(), id='test', dtype=dtype, default='')
+
+
+def test_set_value_trims_whitespace_for_strings():
+    param = _make_param('string')
+    param.set_value('  tcp  ')
+    assert param.get_value() == 'tcp'
+
+
+def test_set_value_trims_mixed_whitespace_variants():
+    param = _make_param('string')
+    for raw in (' tcp', 'tcp ', '  tcp', 'tcp  '):
+        param.set_value(raw)
+        assert param.get_value() == 'tcp'
+
+
+def test_set_value_preserves_multiline_whitespace():
+    param = _make_param('_multiline')
+    text = '  line 1\n  line 2  '
+    param.set_value(text)
+    assert param.get_value() == text
+


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This change adds automatic trimming of leading and trailing whitespace to single-line parameter values before they are saved or evaluated.
This prevents bugs caused by accidental whitespace

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7972

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Affects parameter handling within the runtime configuration system.
file edited : gnuradio-runtime/python/gnuradio/param.py

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Added regression tests verifying trimming behavior for single-line parameters.(' tcp', 'tcp ', '  tcp', 'tcp  ')
Added tests ensuring multiline parameters are preserved untouched.('  line 1\n  line 2  ')
test file : test_param_trim.py

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
