### PR TITLE
doc(digital): explain √2 normalization in constellation_soft_decoder_cf

### DIFF
--- a/gr-digital/lib/constellation_soft_decoder_cf_impl.h
+++ b/gr-digital/lib/constellation_soft_decoder_cf_impl.h
@@ -33,6 +33,15 @@ public:
                                        float npwr = 1.0);
     ~constellation_soft_decoder_cf_impl() override;
 
+    /**
+     * Set the noise power (used for LLR normalization).
+     *
+     * For standard QPSK with points at (±1±j)/√2, the average symbol energy is 1.
+     * The soft-decision LLRs are automatically scaled by 1/√2 so that the
+     * effective noise variance remains consistent with N0 when passed to
+     * downstream FEC decoders (Viterbi, LDPC, etc.).
+     * Default = 1.0 (unit average energy).
+     */
     void set_npwr(float npwr) override;
     void set_constellation(constellation_sptr constellation) override;
 


### PR DESCRIPTION
### What
Add missing Doxygen comment for `set_npwr()` explaining why QPSK soft-decision LLRs are automatically scaled by 1/√2.

### Why
This is a frequently asked question by new contributors and communication engineers. The normalization ensures unit average symbol energy and consistent noise variance (N0) for downstream FEC decoders (Viterbi, LDPC, etc.).
