### PR TITLE
network: fix udp_sink for variable veclen

### DIFF
--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -93,7 +93,7 @@ udp_sink_impl::udp_sink_impl(size_t itemsize,
     d_block_size = d_itemsize * d_veclen;
 
     d_precomp_datasize = d_payloadsize - d_header_size;
-    d_precomp_data_overitemsize = d_precomp_datasize / d_itemsize;
+    d_precomp_blocksize = d_precomp_datasize / d_block_size;
 
     int out_multiple = (d_payloadsize - d_header_size) / d_block_size;
 
@@ -257,9 +257,9 @@ int udp_sink_impl::work(int noutput_items,
         d_localqueue_reader->update_read_pointer(d_precomp_datasize);
     }
 
-    int itemsreturned = blocks_available * d_precomp_data_overitemsize;
+    int items_returned = blocks_available * d_precomp_blocksize;
 
-    return itemsreturned;
+    return items_returned;
 }
 
 } /* namespace network */

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -38,7 +38,7 @@ protected:
     bool b_send_eof;
 
     int d_precomp_datasize;
-    int d_precomp_data_overitemsize;
+    int d_precomp_blocksize;
 
     char d_tmpheaderbuff[12]; // Largest header is 10 bytes
 

--- a/gr-network/python/network/qa_udp_sink.py
+++ b/gr-network/python/network/qa_udp_sink.py
@@ -9,18 +9,43 @@
 
 from gnuradio import gr, gr_unittest, blocks, network
 import time
+import socket
+import threading
 
 
-class qa_udp_sink (gr_unittest.TestCase):
+class qa_udp_sink(gr_unittest.TestCase):
     def setUp(self):
         self.tb = gr.top_block()
+        self.thread_stopped = False
+        self.receive_ready = False
 
     def tearDown(self):
         self.tb = None
 
+    def run_socket_receiver_thread(self, skt):
+        self.packets = []
+        while not self.thread_stopped:
+            try:
+                pkt, _ = skt.recvfrom(9000)
+                # Keep receiving packets until timeout
+                while pkt:
+                    self.packets.append(pkt)
+                    pkt, _ = skt.recvfrom(9000)
+
+            except socket.timeout:
+                # Set flag after first timeout to avoid race condition
+                self.receive_ready = True
+        skt.close()
+
+    def make_socket(self, addr, port):
+        skt = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        skt.bind((addr, port))
+        skt.settimeout(0.1)
+        return skt
+
     def test_restart(self):
         null_source = blocks.null_source(gr.sizeof_gr_complex)
-        throttle = blocks.throttle(gr.sizeof_gr_complex, 320000, True)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, 320000)
         udp_sink = network.udp_sink(gr.sizeof_gr_complex, 1, '127.0.0.1', 2000,
                                     0, 1472, False)
         self.tb.connect(null_source, throttle, udp_sink)
@@ -31,6 +56,49 @@ class qa_udp_sink (gr_unittest.TestCase):
         self.tb.start()
         time.sleep(0.1)
         self.tb.stop()
+
+    def test_ten_packets(self):
+        skt = self.make_socket("127.0.0.1", 12345)
+        rxthread = threading.Thread(target=self.run_socket_receiver_thread, args=(skt,))
+        rxthread.start()
+        NUM_PKTS = 10
+        PAYLOAD_SZ = 1472
+        input_src = [1] * PAYLOAD_SZ * NUM_PKTS
+        src = blocks.vector_source_b(input_src)
+        snk = network.udp_sink(
+            gr.sizeof_char, 1, "127.0.0.1", 12345, 0, PAYLOAD_SZ, True
+        )
+        self.tb.connect(src, snk)
+        while not self.receive_ready:
+            time.sleep(0.001)
+        self.tb.run()
+        self.thread_stopped = True
+        rxthread.join()
+        bytes_received = [i for pkt in self.packets for i in pkt]
+        self.assertListEqual(input_src, bytes_received)
+
+    def test_veclen(self):
+        skt = self.make_socket("127.0.0.1", 12346)
+        rxthread = threading.Thread(target=self.run_socket_receiver_thread, args=(skt,))
+        rxthread.start()
+        VECLEN = 8
+        NUMPKTS = 100
+        PAYLOAD_SZ = 1472
+        input_src = [2] * NUMPKTS * PAYLOAD_SZ
+        src = blocks.vector_source_b(input_src, vlen=VECLEN)
+        snk = network.udp_sink(
+            gr.sizeof_char, VECLEN, "127.0.0.1", 12346, 0, PAYLOAD_SZ, True
+        )
+
+        self.tb.connect(src, snk)
+        while not self.receive_ready:
+            time.sleep(0.001)
+        self.tb.run()
+        self.thread_stopped = True
+        rxthread.join()
+        self.assertEqual(NUMPKTS, len(self.packets))
+        bytes_received = [i for pkt in self.packets for i in pkt]
+        self.assertListEqual(input_src, bytes_received)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Previously, the UDP Sink block would freeze when using a vector length larger than 1. This change fixes the issue.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #7007 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
UDP Sink block

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Added QA tests for udp sink with different vector lengths. The previous code would fail, but now with the changes it passes. Also tested with the simplified flowgraph in issue #7007 to confirm system testing. For regression testing, performed make test and verified all other tests passed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
