### PR TITLE
filter, grc: modify RRC blocks to contain better default parameters

### DIFF
--- a/gr-filter/grc/filter_fft_root_raised_cosine_filter.block.yml
+++ b/gr-filter/grc/filter_fft_root_raised_cosine_filter.block.yml
@@ -29,7 +29,7 @@ parameters:
 -   id: sym_rate
     label: Symbol Rate
     dtype: real
-    default: '1.0'
+    default: samp_rate/sps
 -   id: alpha
     label: Alpha
     dtype: real
@@ -37,7 +37,7 @@ parameters:
 -   id: ntaps
     label: Num Taps
     dtype: int
-    default: 11*samp_rate
+    default: 11*sps
 -   id: nthreads
     label: Num. Threads
     dtype: int

--- a/gr-filter/grc/filter_root_raised_cosine_filter.block.yml
+++ b/gr-filter/grc/filter_root_raised_cosine_filter.block.yml
@@ -34,7 +34,7 @@ parameters:
 -   id: sym_rate
     label: Symbol Rate
     dtype: real
-    default: '1.0'
+    default: samp_rate/sps
 -   id: alpha
     label: Alpha
     dtype: real
@@ -42,7 +42,7 @@ parameters:
 -   id: ntaps
     label: Num Taps
     dtype: int
-    default: 11*samp_rate
+    default: 11*sps
 
 inputs:
 -   domain: stream

--- a/gr-filter/grc/variable_rrc_filter_taps.block.yml
+++ b/gr-filter/grc/variable_rrc_filter_taps.block.yml
@@ -14,6 +14,7 @@ parameters:
 -   id: sym_rate
     label: Symbol Rate (Hz)
     dtype: float
+    default: samp_rate/sps
 -   id: alpha
     label: Excess BW
     dtype: float


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Previously, the default parameters for several root raised cosine blocks were incorrect. These were the most commonly used default parameters:

Sample Rate: samp_rate
Symbol Rate: 1.0
Number of Taps: 11 * samp_rate

Because samp_rate defaults to 32000, the default number of taps is then 352,000. There is rarely a need for this many taps, and in many cases, would create unnecessary computation on the computer. The Symbol Rate is also incorrect with respect to the default symbol rate. Most likely, there was confusion between the sample rate and the samples per symbol aka sps. The default parameters are changed to the following to make it more accurate:

Sample Rate: samp_rate
Symbol Rate: samp_rate/sps
Number of Taps: 11 * sps

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
The GRC blocks Root Raised Cosine Filter, FFT Root Raised Cosine Filter, and RRC Filter Taps.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

No QA testing needed as this is just a change in default parameters for GRC. The modified code was built and installed. The modified GRC blocks were opened and visually inspected to verify correct defaults. For system testing, a simple flowgraph with variable sps = 4 and blocks random source, constellation modulator, RRC filter, and time sink was created, run, and verified it worked as expected.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ X ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ X ] I have squashed my commits to have one significant change per commit. 
- [ X ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ X ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ X ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ X ] I have added tests to cover my changes, and all previous tests pass.
