### PR TITLE
grc: warn when opening flowgraphs saved with different GRC versions

### DIFF
--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -401,6 +401,7 @@ class Platform(Element):
                 )
 
         return data
+
     def save_flow_graph(self, filename, flow_graph):
         data = flow_graph.export_data()
 


### PR DESCRIPTION
## Description

This PR adds a non-blocking warning when opening a `.grc` file that was last saved
with a significantly different GNU Radio Companion (GRC) version.

GRC files already store the version they were saved with in their metadata.
This change compares the major/minor version from `metadata.grc_version` with
the currently running GRC version and emits a warning when they differ, as such
differences may lead to unexpected behavior.

Patch-level version differences do not trigger a warning.

## Related Issue

Fixes #5561.

## Which blocks/areas does this affect?

- GNU Radio Companion (GRC)
- Flowgraph loading path
- Platform.parse_flow_graph()

This change only affects user-facing warnings during flowgraph load and does not
modify runtime DSP behavior or block execution.

## Testing Done

- Opened existing '.grc' files with matching GRC versions to confirm no warning
  is emitted.
- Modified the 'metadata.grc_version' field in a '.grc' file to an older major/minor
  version and verified that a warning is shown in the GRC message output pane.
- Confirmed normal flowgraph loading behavior is unaffected.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have squashed my commits to have one significant change per commit.
- [x] I have signed my commits before making this PR.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.