### PR TITLE
grc-qt: fix crash when loading invalid  `.grc` files

### DIFF
--- a/grc/gui_qt/components/window.py
+++ b/grc/gui_qt/components/window.py
@@ -184,9 +184,8 @@ class MainWindow(QtWidgets.QMainWindow, base.Component):
                         self.open_triggered(file)
                         grc_file_found = True
                     except Exception as e:
-                        import traceback
                         log.error(f"failed to load flowgraph file {file} with exception {e}")
-                        log.debug(f"file {file}: {traceback.format_exception(value=e, tb=e.__traceback__)}")
+                        log.debug(f"file {file}:", exc_info=True)
         if not grc_file_found:
             self.new_triggered()
 


### PR DESCRIPTION

## Description
This PR fixes a crash in GNU Radio Companion when opening invalid or corrupted
`.grc` files.

On  newer Python version , the exception handling code attempted to call
`traceback.format_exception()` with an invalid call, which caused a
secondary exception and crashed GRC instead of handling the original error

This change replaces manual traceback formatting with standard logging using
`exc_info=True`, preserving the full traceback while preventing the crash.

## Related Issue

Fixes #7993

## Which blocks/areas does this affect?
- GNU Radio Companion (GRC)
- Qt GUI file-loading path
- Error handling for `.grc` files

## Testing Done
- Reproduced the crash using `gnuradio-companion --qt` with invalid `.grc` files.
- Rebuilt GNU Radio from source after applying this change.
- Verified that the application no longer crashes and handles the error .

## Checklist


- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
