### PR TITLE
grc-qt: fix properties dialog dropdown type mismatch crash

### DIFF
--- a/grc/gui_qt/components/dialogs.py
+++ b/grc/gui_qt/components/dialogs.py
@@ -149,10 +149,15 @@ class PropsDialog(QDialog):
                         dropdown.currentIndexChanged.connect(self.gui_update)
                     else:
                         dropdown.setEditable(True)
-                        dropdown.setCurrentIndex(
-                            dropdown.param_values.index(param.get_value())
-                        )
+
+                        values = [str(v) for v in dropdown.param_values]
+                        value = str(param.get_value())
+
+                        if value in values:
+                            dropdown.setCurrentIndex(values.index(value))
+
                         dropdown.currentIndexChanged.connect(self.gui_update)
+
                 elif param.dtype in ("file_open", "file_save"):
                     dtype_label = QPushButton("...")
                     dtype_label.setFlat(True)


### PR DESCRIPTION
### Description

This PR fixes a crash in the GRC Qt Properties dialog that occurs when opening
blocks with dropdown parameters whose stored value type does not match the
dropdown option type (e.g., string vs float or int).

The issue is commonly triggered by blocks such as UHD USRP Sink/Source and
Osmocom Source, where parameters like `start_time` may be stored as numeric
values while the dropdown options are strings. This causes a `ValueError`
during index lookup and crashes GRC.

The fix normalizes both the dropdown option values and the parameter value
to strings before indexing, preventing the type-mismatch crash while
preserving existing UI behavior.

### Related Issue

Fixes #7826

### Which blocks/areas does this affect?

- GRC Qt Properties dialog
- Blocks using dropdown parameters with numeric defaults
  (e.g., UHD USRP Sink/Source, Osmocom Source)

### Testing Done

- Opened GRC Qt on Linux
- Added UHD USRP Sink and Osmocom Source blocks
- Opened the Properties dialog
- Verified the dialog opens without crashing
- Confirmed enum parameters and editable dropdown behavior remain unchanged

### Checklist
☑️ I have read the CONTRIBUTING document.
☑️ I have squashed my commits to have one significant change per commit.
☑️ I have signed my commits before making this PR.
☑️ My code follows the code style of this project. See GREP1.md.
⬜ I have updated the documentation where necessary.
⬜ I have added tests to cover my changes, and all previous tests pass.