### PR TITLE
Add GNU Radio Companion Flatpak

### DIFF
--- a/flatpak/org.gnuradio.grc.yaml
+++ b/flatpak/org.gnuradio.grc.yaml
@@ -1,0 +1,420 @@
+id: org.gnuradio.grc
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: gnuradio-companion
+rename-icon: gnuradio-grc
+rename-desktop-file: gnuradio-grc.desktop
+finish-args:
+  - --device=all
+  - --share=network
+  - --share=ipc
+  - --socket=pulseaudio
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=home
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/doc
+  - /share/man
+  - /man
+  - "*.a"
+  - "*.la"
+
+modules:
+  - name: fftw3f
+    config-opts:
+      - --enable-threads
+      - --enable-shared
+      - --disable-static
+      - --enable-float
+    build-options:
+      arch:
+        x86_64:
+          config-opts:
+            - --enable-sse2
+            - --enable-avx
+            - --enable-avx-128-fma
+        aarch64:
+          config-opts:
+            - --enable-neon
+    sources:
+      - type: archive
+        url: https://www.fftw.org/fftw-3.3.10.tar.gz
+        sha256: 56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
+
+  - name: hidapi
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/libusb/hidapi.git
+        tag: hidapi-0.15.0
+        commit: d6b2a974608dec3b76fb1e36c189f22b9cf3650c
+
+  - name: airspy
+    buildsystem: cmake-ninja
+    build-options:
+      cflags: -std=gnu17
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/airspy/airspyone_host.git
+        tag: v1.0.10
+        commit: 229d5a5045b890621cd9cc200a19b1541c6021ae
+
+  - name: airspyhf
+    buildsystem: cmake-ninja
+    build-options:
+      cflags: -std=gnu17
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DINSTALL_UDEV_RULES=OFF
+    sources:
+      - type: git
+        url: https://github.com/airspy/airspyhf.git
+        tag: 1.6.8
+        commit: 8891387edddcd185e2949e9814e9ef35f46f0722
+
+  - name: bladerf
+    buildsystem: cmake-ninja
+    build-options:
+      cflags: -Wno-calloc-transposed-args
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/Nuand/bladeRF.git
+        tag: '2025.10'
+        commit: fcf9423325ae49f5fdd2e5b52ab68bfc2576ad47
+
+  - name: hackrf
+    buildsystem: cmake-ninja
+    subdir: host
+    config-opts:
+      - -DINSTALL_UDEV_RULE=OFF
+    sources:
+      - type: git
+        url: https://github.com/greatscottgadgets/hackrf.git
+        tag: v2026.01.2
+        commit: 85160ee735a1c9ffee1d2674f7495f16471527a6
+
+  - name: libaio
+    no-autogen: true
+    make-install-args:
+      - prefix=${FLATPAK_DEST}
+    sources:
+      - type: archive
+        url: https://pagure.io/libaio/archive/libaio-0.3.113/libaio-libaio-0.3.113.tar.gz
+        sha256: 716c7059703247344eb066b54ecbc3ca2134f0103307192e6c2b7dab5f9528ab
+
+  - name: plutosdr
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DINSTALL_UDEV_RULE=OFF
+      - -DHAVE_DNS_SD=OFF
+    sources:
+      - type: git
+        url: https://github.com/analogdevicesinc/libiio.git
+        tag: v0.26
+        commit: a0eca0d2bf10326506fb762f0eec14255b27bef5
+
+  - name: limesdr
+    buildsystem: cmake-ninja
+    build-options:
+      cflags: -std=gnu17
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DENABLE_QUICKTEST=OFF
+      - -DENABLE_GUI=OFF
+      - -DENABLE_SOAPY_LMS7=OFF
+      - -DENABLE_EXAMPLES=OFF
+      - -DENABLE_UTILITIES=OFF
+      - -DENABLE_HEADERS=ON
+    sources:
+      - type: git
+        url: https://github.com/myriadrf/LimeSuite.git
+        tag: v23.11.0
+        commit: c2d9e87754586304577beff4dc5b16fb9b72c826
+
+  - name: mirisdr
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/ericek111/libmirisdr-5.git
+        # there are no new tags
+        commit: 78a874b30a4c3161251b8e12ffb6443f29005eb3
+
+  - name: rtlsdr
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DDETACH_KERNEL_DRIVER=ON
+    sources:
+      - type: git
+        url: https://github.com/steve-m/librtlsdr.git
+        # latest master for 2.0.2 versioning fix
+        commit: ae0dd6d4f09088d13500a854091b45ad281ca4f0
+
+  - name: volk
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/gnuradio/volk.git
+        tag: v3.2.0
+        commit: 308948abf8384bb4bf6467e14b585df708789782
+
+  - name: boost
+    buildsystem: simple
+    sources:
+      - type: archive
+        # 1.88.0 brings breaking changes for uhd
+        url: https://sourceforge.net/projects/boost/files/boost/1.87.0/boost_1_87_0.tar.bz2
+        sha256: af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
+    build-commands:
+      - ./bootstrap.sh --prefix=/app --with-libraries=system,chrono,date_time,filesystem,program_options,serialization,thread,test,regex
+      - ./b2 -j $FLATPAK_BUILDER_N_JOBS install
+
+  - name: uhd
+    buildsystem: cmake-ninja
+    subdir: host
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DENABLE_DOXYGEN=OFF
+      - -DENABLE_MANUAL=OFF
+      - -DENABLE_MAN_PAGES=OFF
+      - -DENABLE_PYTHON_API=OFF
+      - -DENABLE_TESTS=OFF
+      - -DINSTALL_UDEV_RULES=OFF
+    sources:
+      - type: git
+        url: https://github.com/EttusResearch/uhd.git
+        # 4.9.0.0 has possible breaking API changes
+        tag: v4.8.0.0
+        commit: 308126a479ca19dfaebfe4784b375e608788d763
+      - type: patch
+        paths:
+          - patches/uhd-add-missing-cstdint-includes.patch
+          - patches/uhd-disable-ascii-art-dft.patch
+          - patches/uhd-disable-latency-utils.patch
+
+  - name: spdlog
+    buildsystem: cmake-ninja
+    build-options:
+      cflags: -fPIC
+      cxxflags: -fPIC
+    sources:
+      - type: git
+        url: https://github.com/gabime/spdlog.git
+        tag: v1.15.3
+        commit: 6fa36017cfd5731d617e1a934f0e5ea9c4445b13
+
+  - name: pybind11
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DPYBIND11_INSTALL=ON
+      - -DPYBIND11_TEST=OFF
+    sources:
+      - type: git
+        url: https://github.com/pybind/pybind11.git
+        tag: v3.0.1
+        commit: f5fbe867d2d26e4a0a9177a51f6e568868ad3dc8
+      - type: patch
+        path: patches/pybind11-fix-python-inc-path.patch
+
+  - name: cli11
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_TESTING=OFF
+    sources:
+      - type: git
+        url: https://github.com/CLIUtils/CLI11.git
+        tag: v2.5.0
+        commit: 4160d259d961cd393fd8d67590a8c7d210207348
+
+  - name: refl-cpp
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/veselink1/refl-cpp.git
+        tag: v0.12.4
+        commit: 27fbd7d2e6d86bc135b87beef6b5f7ce53afd4fc
+
+  - name: meson-python
+    buildsystem: simple
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/28/58/66db620a8a7ccb32633de9f403fe49f1b63c68ca94e5c340ec5cceeb9821/meson_python-0.18.0-py3-none-any.whl
+        sha256: 3b0fe051551cc238f5febb873247c0949cd60ded556efa130aa57021804868e2
+      - type: file
+        url: https://files.pythonhosted.org/packages/7e/b1/8e63033b259e0a4e40dd1ec4a9fee17718016845048b43a36ec67d62e6fe/pyproject_metadata-0.9.1-py3-none-any.whl
+        sha256: ee5efde548c3ed9b75a354fc319d5afd25e9585fa918a34f62f904cc731973ad
+    build-commands:
+      - pip3 install --no-index --find-links=file://${PWD} --prefix=${FLATPAK_DEST} "meson-python" --no-build-isolation
+
+  - name: python-numpy
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
+        sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
+    build-commands:
+      - pip3 install --no-index --find-links=file://${PWD} --prefix=${FLATPAK_DEST} --no-build-isolation .
+
+  - name: python-pyyaml
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz
+        sha256: d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f
+    build-commands:
+      - pip3 install --no-index --find-links=file://${PWD} --prefix=${FLATPAK_DEST} --no-build-isolation .
+
+  - name: python-six
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz
+        sha256: ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+    build-commands:
+      - pip3 install --no-index --find-links=file://${PWD} --prefix=${FLATPAK_DEST} --no-build-isolation .
+
+  - name: pmt
+    buildsystem: meson
+    config-opts:
+      - -Denable_testing=false
+    sources:
+      - type: git
+        url: https://github.com/gnuradio/pmt.git
+        # there are no tags
+        commit: 5960738cd35827acceb5a4de9e1c4005d2d02305
+      - type: patch
+        path: patches/pmt-refl-cpp.patch
+
+  - name: soapy
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapySDR.git
+        tag: soapy-sdr-0.8.1
+        commit: 1cf5a539a21414ff509ff7d0eedfc5fa8edb90c6
+
+  - name: soapy_airspy
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyAirspy.git
+        # latest master for multiple fixes
+        commit: 99f0ac5a9cab96d24f86288c32168abe534c1da3
+
+  - name: soapy_airspyhf
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyAirspyHF.git
+        # latest master for multiple fixes
+        commit: 7457d6972d97ea6808a2774a9439501308e4c688
+
+  - name: soapy_hackrf
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyHackRF.git
+        # latest master for multiple fixes
+        commit: 143ff5e7e0f786e341df8846c04e8273c5183c26
+
+  - name: libad9361-iio
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/analogdevicesinc/libad9361-iio.git
+        tag: v0.3
+        commit: 7cc4cdbf575571d3b8581b183bea4591861e99fb
+
+  - name: soapy_plutosdr
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyPlutoSDR.git
+        # latest master for multiple fixes
+        commit: cdce23959aca536d5436e0cc689d069a8239f487
+
+  - name: soapy_rtlsdr
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyRTLSDR.git
+        # latest master for multiple fixes
+        commit: b1f568d1b57cc973a1d2ee49be68d0d748d164e4
+
+  - name: soapy_uhd
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyUHD.git
+        # latest master for multiple fixes
+        commit: 2a5d381f68fd05d5b3c0e7db56c36892ea99b4ae
+
+  - name: soapy_remote
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyRemote.git
+        # latest master for multiple fixes
+        commit: 40c3ef9053b63885b7444ce7e9ef00d2c7964c9d
+
+  - name: portaudio
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/PortAudio/portaudio.git
+        tag: v19.7.0
+        commit: 147dd722548358763a8b649b3e4b41dfffbcfbb6
+
+  - name: gnuradio
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_DEFAULT=ON
+      - -DENABLE_GRC=ON
+      - -DENABLE_SYSTEM_DESKTOP=ON
+      - -DENABLE_TESTING=OFF
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/gnuradio/gnuradio.git
+        tag: v3.10.12.0
+        commit: ec7a3239645162ffea1925e6f1e6e62bf1349d03
+#      - type: dir
+#        path: ..
+      - type: patch
+        path: patches/gnuradio-direct-freedesktop-install.patch
+
+  - name: gr-iqbal
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_DOXYGEN=OFF
+    sources:
+      - type: git
+        url: https://gitea.osmocom.org/sdr/gr-iqbal.git
+        tag: v0.38.3
+        commit: 6782a1f934bc6c3bd293d34ab7453a85b00f4fab
+
+  - name: gr-osmosdr
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://gitea.osmocom.org/sdr/gr-osmosdr.git
+        tag: v0.2.6
+        commit: a6afeaa3a1038e64751616d769537cd22ace015d

--- a/flatpak/patches/gnuradio-direct-freedesktop-install.patch
+++ b/flatpak/patches/gnuradio-direct-freedesktop-install.patch
@@ -1,0 +1,43 @@
+From: "A. Maitland Bottoms" <bottoms@debian.org>
+Subject: direct freedesktop install
+
+Have CMake install desktop files - Debian tooling will handle them.
+
+--- a/grc/scripts/freedesktop/CMakeLists.txt
++++ b/grc/scripts/freedesktop/CMakeLists.txt
+@@ -6,6 +6,25 @@
+ #
+ 
+ ########################################################################
++if(ENABLE_SYSTEM_DESKTOP)
++# Install desktop
++install(FILES gnuradio-grc.desktop DESTINATION share/applications)
++
++# Install mime
++install(FILES gnuradio-grc.xml DESTINATION share/mime/packages)
++
++# Install appstream / metainfo file
++install(FILES org.gnuradio.grc.metainfo.xml DESTINATION share/metainfo)
++
++# Install icons
++install(FILES grc-icon-256.png DESTINATION share/icons/hicolor/256x256/apps RENAME gnuradio-grc.png)
++install(FILES grc-icon-128.png DESTINATION share/icons/hicolor/128x128/apps RENAME gnuradio-grc.png)
++install(FILES grc-icon-64.png DESTINATION share/icons/hicolor/64x64/apps RENAME gnuradio-grc.png)
++install(FILES grc-icon-48.png DESTINATION share/icons/hicolor/48x48/apps RENAME gnuradio-grc.png)
++install(FILES grc-icon-32.png DESTINATION share/icons/hicolor/32x32/apps RENAME gnuradio-grc.png)
++install(FILES grc-icon-24.png DESTINATION share/icons/hicolor/24x24/apps RENAME gnuradio-grc.png)
++install(FILES grc-icon-16.png DESTINATION share/icons/hicolor/16x16/apps RENAME gnuradio-grc.png)
++endif(ENABLE_SYSTEM_DESKTOP)
+ 
+ find_program(HAVE_XDG_UTILS xdg-desktop-menu)
+ 
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -425,6 +425,7 @@
+ # install, but for source builds, that's actually more convenient.
+ ########################################################################
+ gr_register_component("post-install" ENABLE_POSTINSTALL)
++option(ENABLE_SYSTEM_DESKTOP "Enable direct installation of desktop files to system paths" OFF)
+ 
+ ########################################################################
+ # Add subdirectories (in order of deps)

--- a/flatpak/patches/pmt-refl-cpp.patch
+++ b/flatpak/patches/pmt-refl-cpp.patch
@@ -1,0 +1,17 @@
+diff --git a/meson.build b/meson.build
+index 1dfae18..cb3b5be 100644
+--- a/meson.build
++++ b/meson.build
+@@ -102,11 +102,7 @@ fmt_dep = dependency('fmt', version:'>=10.0.0')
+ 
+ cmake = import('cmake')
+ 
+-# Configure the CMake project
+-refl_cpp = cmake.subproject('refl-cpp')
+-
+-# Fetch the dependency object
+-refl_cpp_dep = refl_cpp.dependency('refl-cpp')
++refl_cpp_dep = dependency('refl-cpp')
+ 
+ incdir = include_directories('include')
+ pmt_dep = declare_dependency(include_directories : incdir, dependencies : refl_cpp_dep)

--- a/flatpak/patches/pybind11-fix-python-inc-path.patch
+++ b/flatpak/patches/pybind11-fix-python-inc-path.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/FindPythonLibsNew.cmake b/tools/FindPythonLibsNew.cmake
+index 7351bcaa..43a39be0 100644
+--- a/tools/FindPythonLibsNew.cmake
++++ b/tools/FindPythonLibsNew.cmake
+@@ -302,7 +302,7 @@ mark_as_advanced(PYTHON_LIBRARY PYTHON_INCLUDE_DIR)
+ # cache entries because they are meant to specify the location of a single
+ # library. We now set the variables listed by the documentation for this
+ # module.
+-set(PYTHON_INCLUDE_DIRS "${PYTHON_INCLUDE_DIR}")
++set(PYTHON_INCLUDE_DIRS "/usr/include/python3.13")
+ set(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
+ if(NOT PYTHON_DEBUG_LIBRARY)
+   set(PYTHON_DEBUG_LIBRARY "")

--- a/flatpak/patches/uhd-add-missing-cstdint-includes.patch
+++ b/flatpak/patches/uhd-add-missing-cstdint-includes.patch
@@ -1,0 +1,36 @@
+From 14337e23e4e073be5377dbcefc96ed04515ac51a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Thu, 13 Mar 2025 18:44:13 +0100
+Subject: [PATCH] uhd: Add some missing cstdint includes
+
+This aids with making UHD gcc-15 compatible (more fixes are required for
+full compatibility).
+---
+ host/include/uhd/features/ref_clk_calibration_iface.hpp   | 1 +
+ host/lib/include/uhdlib/usrp/dboard/fbx/fbx_constants.hpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/host/include/uhd/features/ref_clk_calibration_iface.hpp b/host/include/uhd/features/ref_clk_calibration_iface.hpp
+index 86a20053c..7aa80628e 100644
+--- a/host/include/uhd/features/ref_clk_calibration_iface.hpp
++++ b/host/include/uhd/features/ref_clk_calibration_iface.hpp
+@@ -8,6 +8,7 @@
+ 
+ #include <uhd/config.hpp>
+ #include <uhd/features/discoverable_feature.hpp>
++#include <cstdint>
+ #include <memory>
+ 
+ namespace uhd { namespace features {
+diff --git a/host/lib/include/uhdlib/usrp/dboard/fbx/fbx_constants.hpp b/host/lib/include/uhdlib/usrp/dboard/fbx/fbx_constants.hpp
+index fd23fb8ef..8f1fc4e91 100644
+--- a/host/lib/include/uhdlib/usrp/dboard/fbx/fbx_constants.hpp
++++ b/host/lib/include/uhdlib/usrp/dboard/fbx/fbx_constants.hpp
+@@ -10,6 +10,7 @@
+ #include <unordered_map>
+ #include <array>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstring>
+ #include <list>
+ #include <map>

--- a/flatpak/patches/uhd-disable-ascii-art-dft.patch
+++ b/flatpak/patches/uhd-disable-ascii-art-dft.patch
@@ -1,0 +1,35 @@
+diff --git a/host/examples/CMakeLists.txt b/host/examples/CMakeLists.txt
+index 69e84f95d..26b2306b4 100644
+--- a/host/examples/CMakeLists.txt
++++ b/host/examples/CMakeLists.txt
+@@ -51,19 +51,19 @@ endforeach(example_source)
+ ########################################################################
+ # ASCII Art DFT - requires curses, so this part is optional
+ ########################################################################
+-set(CURSES_NEED_NCURSES 1)
+-find_package(Curses)
++#set(CURSES_NEED_NCURSES 1)
++#find_package(Curses)
+ 
+-if(CURSES_FOUND)
+-    include_directories(${CURSES_INCLUDE_DIR})
+-    add_executable(rx_ascii_art_dft rx_ascii_art_dft.cpp)
+-    target_link_libraries(rx_ascii_art_dft uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
+-    UHD_INSTALL(TARGETS rx_ascii_art_dft RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
++#if(CURSES_FOUND)
++#    include_directories(${CURSES_INCLUDE_DIR})
++#    add_executable(rx_ascii_art_dft rx_ascii_art_dft.cpp)
++#    target_link_libraries(rx_ascii_art_dft uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
++#    UHD_INSTALL(TARGETS rx_ascii_art_dft RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
+ 
+-    add_executable(twinrx_freq_hopping twinrx_freq_hopping.cpp)
+-    target_link_libraries(twinrx_freq_hopping uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
+-    UHD_INSTALL(TARGETS twinrx_freq_hopping RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
+-endif(CURSES_FOUND)
++#    add_executable(twinrx_freq_hopping twinrx_freq_hopping.cpp)
++#    target_link_libraries(twinrx_freq_hopping uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
++#    UHD_INSTALL(TARGETS twinrx_freq_hopping RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
++#endif(CURSES_FOUND)
+ 
+ ########################################################################
+ # Examples using C API

--- a/flatpak/patches/uhd-disable-latency-utils.patch
+++ b/flatpak/patches/uhd-disable-latency-utils.patch
@@ -1,0 +1,62 @@
+diff --git a/host/utils/latency/CMakeLists.txt b/host/utils/latency/CMakeLists.txt
+index e4cd4d171..e806d8da0 100644
+--- a/host/utils/latency/CMakeLists.txt
++++ b/host/utils/latency/CMakeLists.txt
+@@ -5,33 +5,33 @@
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #
+ 
+-set(CURSES_NEED_NCURSES 1)
+-find_package(Curses)
++#set(CURSES_NEED_NCURSES 1)
++#find_package(Curses)
+ 
+-if(CURSES_FOUND)
+-    include_directories(${CURSES_INCLUDE_DIR})
+-    set(latency_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
+-    include_directories(${latency_include_dir})
+-    set(latency_lib_path ${CMAKE_CURRENT_SOURCE_DIR}/lib/Responder.cpp)
++#if(CURSES_FOUND)
++#    include_directories(${CURSES_INCLUDE_DIR})
++#    set(latency_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
++#    include_directories(${latency_include_dir})
++#    set(latency_lib_path ${CMAKE_CURRENT_SOURCE_DIR}/lib/Responder.cpp)
+ 
+-    set(sources
+-        responder.cpp
+-    )
++#    set(sources
++#        responder.cpp
++#    )
+ 
+-    set(latency_comp_name utilities)
+-    set(latency_comp_dest ${PKG_LIB_DIR}/utils/latency)
++#    set(latency_comp_name utilities)
++#    set(latency_comp_dest ${PKG_LIB_DIR}/utils/latency)
+ 
+     #for each source: build an executable and install
+-    foreach(source ${sources})
+-        get_filename_component(name ${source} NAME_WE)
+-        add_executable(${name} ${source} ${latency_lib_path})
+-    	LIBUHD_APPEND_SOURCES(${name})
+-        target_link_libraries(${name} uhd ${Boost_LIBRARIES} ${CURSES_LIBRARIES})
+-    	UHD_INSTALL(TARGETS ${name} RUNTIME DESTINATION ${latency_comp_dest} COMPONENT ${latency_comp_name})
+-    endforeach(source)
++#    foreach(source ${sources})
++#        get_filename_component(name ${source} NAME_WE)
++#        add_executable(${name} ${source} ${latency_lib_path})
++#    	LIBUHD_APPEND_SOURCES(${name})
++#        target_link_libraries(${name} uhd ${Boost_LIBRARIES} ${CURSES_LIBRARIES})
++#    	UHD_INSTALL(TARGETS ${name} RUNTIME DESTINATION ${latency_comp_dest} COMPONENT ${latency_comp_name})
++#    endforeach(source)
+ 
+-    UHD_INSTALL(PROGRAMS run_tests.py graph.py
+-                DESTINATION ${latency_comp_dest}
+-                COMPONENT ${latency_comp_name}
+-    )
+-endif(CURSES_FOUND)
++#    UHD_INSTALL(PROGRAMS run_tests.py graph.py
++#                DESTINATION ${latency_comp_dest}
++#                COMPONENT ${latency_comp_name}
++#    )
++#endif(CURSES_FOUND)


### PR DESCRIPTION
<img width="1481" height="989" alt="screenshot" src="https://github.com/user-attachments/assets/95531a68-99bd-4a57-aacf-82af7ba047c1" />

**Proof of concept, do not merge.** See #5923 for more context and limitations.

There is no gr-qtgui support (as that would require full Qt and additional modules) and some other libraries and hardware drivers may be missing, but GRC runs and basic RTL-SDR projects seem to work correctly.

There is also no support enabled for the following components:
- JSON/YAML config blocks
- gr_modtool
- gr-video-sdl
- gr-wavelet
- gr-zeromq

By the way, it is possible to open an interactive shell in the Flatpak container and use standard GNU Radio (and other) tools from there:

```
$ flatpak run --command=sh org.gnuradio.grc
```

It is also possible to use these tools directly from the current shell:

```
$ flatpak run --command=foo org.gnuradio.grc
```

(Replace `foo` with the actual command.)

Tested with GNU Radio 3.10.12.0. Fails to build with latest Git main on:
`FAILED: [code=1] gr-uhd/lib/CMakeFiles/gnuradio-uhd.dir/rfnoc_fft_impl.cc.o`

Based on my [Gqrx Flatpak](https://github.com/flathub/dk.gqrx.gqrx), feel free to re-use for your projects.