### PR TITLE
cmake: Force cmake 4.1 search behavior during find_package() for MINGW

### DIFF
--- a/cmake/Modules/GrBoost.cmake
+++ b/cmake/Modules/GrBoost.cmake
@@ -10,6 +10,13 @@ if(DEFINED __INCLUDED_GR_BOOST_CMAKE)
 endif()
 set(__INCLUDED_GR_BOOST_CMAKE TRUE)
 
+# Workaround for behavior change in cmake 4.2, that effects MINGW environments
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
+    if (MINGW)
+        set(CMAKE_FIND_PACKAGE_SORT_DIRECTION "ASC")
+    endif(MINGW)
+endif(CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
+
 ########################################################################
 # Setup Boost and handle some system specific things
 ########################################################################


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Define CMAKE_FIND_PACKAGE_SORT_DIRECTION=ASC building with latest MINGW (release 20251203 or later). This maintains the cmake search order from pre 4.2 cmake during find_package() and is required when searching for boost packages for dynamic linking (GR default). Resolves ci build/test failure observed since MINGW 20251203 released.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
MINGW Windows builds in https://github.com/gnuradio/gnuradio/actions/workflows/make-test.yml broken since beginning of Dev 2025.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
CI regression on Windows (MINGW make-test).

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Manual builds and PR pipeline

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
