### PR TITLE
gr-network: add QA tests for tcp_sink

### DIFF
--- a/gr-network/python/network/qa_tcp_sink.py
+++ b/gr-network/python/network/qa_tcp_sink.py
@@ -13,46 +13,137 @@ import threading
 import time
 
 
-class qa_tcp_sink (gr_unittest.TestCase):
-    def tcp_receive(self, serversocket):
-        for _ in range(2):
-            clientsocket, address = serversocket.accept()
-            while True:
-                data = clientsocket.recv(4096)
-                if not data:
-                    break
-            clientsocket.close()
-
-    def setUp(self):
-        self.tb = gr.top_block()
-
-    def tearDown(self):
-        self.tb = None
-
-    def test_restart(self):
-        serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        serversocket.settimeout(30.0)
-        serversocket.bind(('localhost', 2000))
-        serversocket.listen()
-
-        thread = threading.Thread(target=self.tcp_receive, args=(serversocket,))
-        thread.start()
-
-        null_source = blocks.null_source(gr.sizeof_gr_complex)
-        throttle = blocks.throttle(gr.sizeof_gr_complex, 320000, True)
-        tcp_sink = network.tcp_sink(gr.sizeof_gr_complex, 1, '127.0.0.1', 2000, 1)
-        self.tb.connect(null_source, throttle, tcp_sink)
-        self.tb.start()
-        time.sleep(0.1)
-        self.tb.stop()
-        time.sleep(0.1)
-        self.tb.start()
-        time.sleep(0.1)
-        self.tb.stop()
-
-        thread.join()
-        serversocket.close()
+def _recv_exact(conn, nbytes):
+    """Receive exactly nbytes from a connected socket."""
+    data = b""
+    while len(data) < nbytes:
+        chunk = conn.recv(nbytes - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return data
 
 
-if __name__ == '__main__':
+def _alloc_port():
+    """Allocate a TCP port safely."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.listen(1)
+    s.close()
+    return port
+
+
+class qa_tcp_sink(gr_unittest.TestCase):
+
+    def test_001_server_false(self):
+        """server=False: tcp_sink connects to external socket."""
+        payload = bytes(range(50))
+        port = _alloc_port()
+
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", port))
+        srv.listen(1)
+
+        received = {}
+
+        def server_thread():
+            conn, _ = srv.accept()
+            received["data"] = _recv_exact(conn, len(payload))
+            conn.close()
+            srv.close()
+
+        t = threading.Thread(target=server_thread, daemon=True)
+        t.start()
+
+        tb = gr.top_block()
+        src = blocks.vector_source_b(list(payload), False)
+        sink = network.tcp_sink(gr.sizeof_char, 1, "127.0.0.1", port, False)
+        tb.connect(src, sink)
+        tb.run()
+
+        t.join(timeout=5.0)
+        self.assertEqual(payload, received.get("data", b""))
+
+    def test_002_server_true(self):
+        """server=True: tcp_sink listens, client connects."""
+        payload = bytes(range(60))
+        port = _alloc_port()
+        received = {}
+
+        def client_thread():
+            deadline = time.time() + 5.0
+            while time.time() < deadline:
+                try:
+                    c = socket.create_connection(("127.0.0.1", port), timeout=2.0)
+                    received["data"] = _recv_exact(c, len(payload))
+                    c.close()
+                    return
+                except OSError:
+                    time.sleep(0.05)
+
+        t = threading.Thread(target=client_thread, daemon=True)
+        t.start()
+
+        tb = gr.top_block()
+        src = blocks.vector_source_b(list(payload), False)
+        sink = network.tcp_sink(gr.sizeof_char, 1, "127.0.0.1", port, True)
+        tb.connect(src, sink)
+        tb.run()
+
+        t.join(timeout=5.0)
+        self.assertEqual(payload, received.get("data", b""))
+
+    def test_003_end_to_end_sink_server(self):
+        """End-to-end: tcp_sink is server, tcp_source connects."""
+        payload = bytes(range(40))
+        port = _alloc_port()
+
+        tb_sink = gr.top_block()
+        src_sink = blocks.vector_source_b(list(payload), False)
+        sink = network.tcp_sink(gr.sizeof_char, 1, "127.0.0.1", port, True)
+        tb_sink.connect(src_sink, sink)
+
+        tb_src = gr.top_block()
+        source = network.tcp_source(gr.sizeof_char, 1, "127.0.0.1", port, False)
+        vsink = blocks.vector_sink_b()
+        tb_src.connect(source, vsink)
+
+        tb_sink.start()
+        tb_src.start()
+
+        tb_sink.wait()
+        tb_src.stop()
+        tb_src.wait()
+
+        self.assertEqual(list(payload), vsink.data())
+
+    def test_004_end_to_end_source_server(self):
+        """End-to-end: tcp_source is server, tcp_sink connects."""
+        payload = bytes(range(45))
+        port = _alloc_port()
+
+        tb_src = gr.top_block()
+        source = network.tcp_source(gr.sizeof_char, 1, "127.0.0.1", port, True)
+        vsink = blocks.vector_sink_b()
+        tb_src.connect(source, vsink)
+
+        tb_sink = gr.top_block()
+        src_sink = blocks.vector_source_b(list(payload), False)
+        sink = network.tcp_sink(gr.sizeof_char, 1, "127.0.0.1", port, False)
+        tb_sink.connect(src_sink, sink)
+
+        tb_src.start()
+        tb_sink.start()
+
+        tb_sink.wait()
+        tb_src.stop()
+        tb_src.wait()
+
+        self.assertEqual(list(payload), vsink.data())
+
+
+if __name__ == "__main__":
     gr_unittest.run(qa_tcp_sink)


### PR DESCRIPTION
## Description
This PR adds missing QA coverage for `gnuradio.network.tcp_sink`, following the scenarios described in issue #7697.  
The added tests validate correct byte transfer in both server/client modes and in end-to-end configurations with `tcp_source`.

## Related Issue
Fixes #7697

## Which blocks/areas does this affect?
- `gr-network`
- `gnuradio.network.tcp_sink`
- QA tests under `gr-network/python/network`

## Testing Done
- GitHub Actions CI (PR checks)

> Local build from source on Windows was not feasible due to missing dependency packages (Boost, etc.). CI is expected to be the source of truth for test execution.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit.
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed) *(will add sign-off before merge)*
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated documentation where necessary. *(not required for this change)*
- [x] I have added tests to cover my changes, and all previous tests pass.