### PR TITLE
GH CI/conda: migrate rerender action to setup-micromamba

### DIFF
--- a/.github/workflows/conda-rerender-ci.yml
+++ b/.github/workflows/conda-rerender-ci.yml
@@ -42,7 +42,7 @@ jobs:
             dependencies:
               - conda-smithy
       - name: Install conda-smithy
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: rerender-env.yml
       - name: Re-render


### PR DESCRIPTION
I don't want to constantly juggle conda environments for rerendering (which I'd use for nothing else, sorry!)

Thus, the rerender action is valuable. Sadly, it seems github uses the action from main, not from the current branch, so there seems to be no way of updating it but through merging this to main first. sigh.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
