### PR TITLE
CI/conda: remove macOS build temporarily

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -26,11 +26,16 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-          - CONFIG: osx_64_numpy1.23python3.11.____cpython
-            SHORT_CONFIG: osx_64_numpy1.23python3.11.____cpython
-            UPLOAD_PACKAGES: True
-            os: macos
-            runs_on: ['macos-13']
+          ## Removed macos, because -13 stopped working, macos-14 fails with
+          ## linker errors in Qt code (very hard to debug without a machine or
+          ## any experience on that platform) and the best guess "just try
+          ## rerendering" fails; log on
+          ## https://github.com/gnuradio/gnuradio/pull/8019
+          # - CONFIG: osx_64_numpy1.23python3.11.____cpython
+          #   SHORT_CONFIG: osx_64_numpy1.23python3.11.____cpython
+          #   UPLOAD_PACKAGES: True
+          #   os: macos
+          #   runs_on: ['macos-13']
           - CONFIG: win_64_numpy1.23python3.11.____cpython
             SHORT_CONFIG: win_64_numpy1.23python3.11.____cpython
             UPLOAD_PACKAGES: True


### PR DESCRIPTION
I can't figure out how to make it work, and even the simple attempt to rerender the conda stuff fails for me, even after investing time into the rerender github action. Realistically, I'll need help from an adult here.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

All our PRs fail because macos-13 is not an available platform anymore.

Updating to macos-14 is not sufficient, because then we get linker errors that I have no idea on how to fix.

Removing the macos build is a harsh regression. But I'm afraid I have to do it.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Failed to fix the underlying issues in #8019

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Our excellent Conda builds :((((


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
