### PR TITLE
grcqt: Separate block comments into their own QGraphicsTextItems

### DIFF
--- a/grc/gui_qt/components/canvas/flowgraph.py
+++ b/grc/gui_qt/components/canvas/flowgraph.py
@@ -23,7 +23,7 @@ import functools
 
 from qtpy import QtGui, QtCore, QtWidgets, QT6
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QGraphicsTextItem
 
 from itertools import count
 
@@ -278,7 +278,7 @@ class FlowgraphScene(QtWidgets.QGraphicsScene, base.Component):
 
     def mousePressEvent(self, event):
         g_item = self.itemAt(event.scenePos(), QtGui.QTransform())
-        if not g_item:  # Nothing selected
+        if not g_item or isinstance(g_item, QGraphicsTextItem):  # Nothing (or just a comment) selected
             event.ignore()
             return
 


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
In the current GRC Qt, the comment text field is drawn as a part of the block, and thus the bounding rectangle must be bigger than the actual block itself. This means that blocks can be literally dragged by their comments, and this is undesirable.

This PR fixes that by creating a separate QGraphicsTextItem for the comment field.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes https://github.com/gnuradio/gnuradio/issues/7592

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
GRC Qt

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Tested consistency with GRC Gtk. Noticed that disabled blocks in GRC Gtk actually don't draw/paint their comments, even though the code (block.py) seems to have other plans:
https://github.com/gnuradio/gnuradio/blob/f563293e892fa6b3c747d3a6beeee341e8a88361/grc/gui/canvas/block.py#L262-L263

Gtk on the left, Qt on the right:
<img width="1751" height="354" alt="grcqt_comment" src="https://github.com/user-attachments/assets/b6568779-403f-42ff-9966-4eea5dc1c0cf" />



## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
