### PR TITLE
 grc: make .grc files directly runnable

### DIFF
--- a/grc/blocks/python_bokeh_gui.workflow.yml
+++ b/grc/blocks/python_bokeh_gui.workflow.yml
@@ -6,6 +6,7 @@ generator_module: gnuradio.grc.workflows.python_bokeh_gui
 generator_class: TopBlockGenerator
 generate_options: bokeh_gui
 generate_options_label: Bokeh GUI
+is_executable: True
 parameters:
 -   id: placement
     label: Widget Placement

--- a/grc/blocks/python_nogui.workflow.yml
+++ b/grc/blocks/python_nogui.workflow.yml
@@ -6,6 +6,7 @@ generator_module: gnuradio.grc.workflows.python_nogui
 generator_class: PythonNoGuiGenerator
 generate_options: no_gui
 generate_options_label: No GUI
+is_executable: True
 parameters:
 -   id: run_options
     label: Run Options

--- a/grc/blocks/python_qt_gui.workflow.yml
+++ b/grc/blocks/python_qt_gui.workflow.yml
@@ -6,6 +6,7 @@ generator_module: gnuradio.grc.workflows.python_qt_gui
 generator_class: PythonQtGuiGenerator
 generate_options: qt_gui
 generate_options_label: QT GUI
+is_executable: True
 parameters:
 -   id: run
     label: Run

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -53,6 +53,9 @@ TOP_BLOCK_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP 
     stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH
 HIER_BLOCK_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH
 
+# Executable flow graph shebang
+EXECUTABLE_FLOWGRAPH_SHEBANG = "#!/usr/bin/env -S grcc --run\n"
+
 PARAM_TYPE_NAMES = {
     'raw', 'enum',
     'complex', 'real', 'float', 'int', 'short', 'byte',

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -403,11 +403,27 @@ class Platform(Element):
         ]
         for r in replace:
             out = out.replace(*r)
+        is_executable = False
+        try:
+            is_executable = flow_graph.options_block.current_workflow.is_executable
+        except Exception:
+            pass
+        if is_executable:
+            out = Constants.EXECUTABLE_FLOWGRAPH_SHEBANG + out
 
         with open(filename, 'w', encoding='utf-8') as fp:
             fp.write(out)
 
+        if is_executable:
+            try:
+                import stat
+                current_mode = os.stat(filename).st_mode
+                os.chmod(filename, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            except OSError:
+                pass
+
     def get_generate_options(self):
+
         for param in self.block_classes['options'].parameters_data:
             if param.get('id') == 'generate_options':
                 break

--- a/grc/core/workflow.py
+++ b/grc/core/workflow.py
@@ -17,6 +17,7 @@ class Workflow:
         generator_module (str): Module name of where the code generator class is located
         generate_options (str): Used to select a workflow
         generate_options_label (str): Information for users to select a workflow
+        is_executable (bool): If True, .grc file can be executed directly
         parameters (arr of dict): parameters for options block
         asserts (arr): array of assert statements
         context (dict): additional workflow parameters
@@ -37,6 +38,7 @@ class Workflow:
         self.generator_module = self.workflow_params.pop('generator_module')
         self.generate_options = self.workflow_params.pop('generate_options')
         self.generate_options_label = self.workflow_params.pop('generate_options_label')
+        self.is_executable = self.workflow_params.pop('is_executable', False)
         self.parameters = self.workflow_params.pop('parameters', [])
         self.asserts = self.workflow_params.pop('asserts', [])
         self.context = self.workflow_params  # additional workflow parameters


### PR DESCRIPTION

## Description

This PR implements the feature requested in #7691: making certain `.grc` files
directly runnable on Unix-like systems.

For flowgraphs that generate runnable Python output
(`qt_gui`, `no_gui`, `bokeh_gui`), the saved `.grc` file now:

- Prepends a shebang line:
  `#!/usr/bin/env -S grcc --run`
- Sets the executable bit on the file

This allows running a flowgraph directly, e.g.:

```bash
./flowgraph.grc
```

## Related Issue

#7691

## Which blocks/areas does this affect?

- GNU Radio Companion (GRC)
- Flowgraph save/export logic
- Handling of runnable `.grc` files

## Testing Done

- Tested on Ubuntu Linux
- Rebuilt GNU Radio after applying the change
- Created flowgraphs using different `generate_options`
- Verified that for runnable options (`qt_gui`, `no_gui`, `bokeh_gui`):
  - The saved `.grc` file contains the shebang line
  - The file is marked executable
  - The flowgraph can be executed directly via `./flowgraph.grc`
- Verified that non-runnable options do not add a shebang and are not made executable

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
