### PR TITLE
grc: Activate the Stop/Kill button when executing a flowgraph

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -36,7 +36,7 @@ class ExecFlowGraphThread(threading.Thread):
         self.generator = self.page.get_generator()
 
         try:
-            self.process = self._popen(self.generator.get_exec_args())
+            self.process = self.page.process = self._popen(self.generator.get_exec_args())
             if not self.process:
                 return
 


### PR DESCRIPTION
<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description
<!--- Why this change? What problem does it solve? -->

Fixes bug introduced by https://github.com/gnuradio/gnuradio/pull/7548 where the Generate, Execute, Stop/Kill buttons would not respond when a flowgraph is launched. As reported by @jmfriedt in the Matrix General Chat room

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->

## Which blocks/areas does this affect?
GRC Gtk

## Testing Done
Manual testing

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
