### PR TITLE
grc/CMake: Include what you use; in the volk-less case, grc still buildable

### DIFF
--- a/grc/scripts/freedesktop/CMakeLists.txt
+++ b/grc/scripts/freedesktop/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 ########################################################################
 
+include(GrTest)
 find_program(HAVE_XDG_UTILS xdg-desktop-menu)
 
 if(UNIX AND HAVE_XDG_UTILS AND ENABLE_POSTINSTALL)


### PR DESCRIPTION
This was noticed by accidentally building missing VOLK, which disables
most of GR, but then fails on GRC.
