### PR TITLE
docs: fix DocBook DTD path for xml validation

### DIFF
--- a/gr-trellis/docs/gr-trellis.xml
+++ b/gr-trellis/docs/gr-trellis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-          "docbookx.dtd" [
+          "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" [
   <!ENTITY test_tcm_listing SYSTEM "test_tcm.py.xml">
   <!ENTITY test_viterbi_equalization1_listing SYSTEM "test_viterbi_equalization1.py.xml">
 ]>


### PR DESCRIPTION
<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description
Fixes a documentation build failure when generating man pages using xmlto.

The DocBook DOCTYPE previously referenced a local "docbookx.dtd", which fails on systems where the DocBook DTD is not installed locally .

Replaced it with the official OASIS DocBook 4.2 URL to improve portability and allow successful validation across systems.


## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->
Fixes #8038

## Which blocks/areas does this affect?
Documentation (DocBook )
gr-trellis module docs

## Testing Done
Tested using xmlto validation.
## Checklist


- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
