### PR TITLE
CI/MinGW64: use Ninja to build, for autom. parallelisation

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -274,19 +274,20 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ vars.SCCACHE_S3_KEY_ID }}
       run: |
         cmake -S . -B build \
+          -GNinja \
           -DCMAKE_INSTALL_PREFIX=${RUNNER_TEMP}/msys64/mingw64 \
           -DENABLE_DOXYGEN=OFF \
           ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
           ${{ steps.enable_sccache.outputs.C_LAUNCHER }}
-    - name: Make
+    - name: Build
       env:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_S3_KEY }}
         AWS_ACCESS_KEY_ID: ${{ vars.SCCACHE_S3_KEY_ID }}
         SCCACHE_CONF: ${{ steps.enable_sccache.outputs.SCCACHE_CONF }}
       run: cmake --build build
-    - name: Make Install
+    - name: Install
       run: cmake --install build
-    - name: Make Test
+    - name: CTest
       working-directory: ./build
       run: ctest --output-on-failure
     - name: Sccache statistics


### PR DESCRIPTION
MinGW builds currently are single-issue, which is slow.

Also, adjust names of steps to the fact that `make` isn't involved at
all. (It wasn't involved in the "Make test" step to begin with.)

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

