### PR TITLE
CI: disable MinGW test

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -214,6 +214,20 @@ jobs:
       if: ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }}
       run: sccache -s
   mingw64:
+    # Disabling this test alltogether, sadly.
+    # For reasons currently not understood, MinGW builds fail with Boost
+    # linkage errors. See https://github.com/gnuradio/gnuradio/issues/8054:
+    # 
+    # 1. with the way gnuradio-runtime's cmake infra sets up boost thread
+    # linkage to boost_threads, linker complains about duplicate definitions.
+    # Same for program_options. 2. with the way cmake/Modules/GrTest sets up
+    # linkage to boost unit_test_framework, building tests fails due to
+    # undefined references to unit test symbols.
+    #
+    # Neither happens on main; neither before nor after the johnwparent/NI
+    # CMake rework. diffing the before state (e.g. 7a74e8f ) of cmake/Modules
+    # gives no obvious difference. I'm stumped.
+    if: False
     timeout-minutes: 80
   # All of these shall depend on the formatting check (needs: check-formatting)
     needs: [check-hashes, check-formatting, check-python-formatting]


### PR DESCRIPTION

MinGW builds have been very helpful. The one on maint-3.10 doesn't work anymore due to Boost linkage:

1. with the way gnuradio-runtime's cmake infra sets up boost thread linkage to boost_threads, linker complains about duplicate definitions. Same for program_options.
2. with the way cmake/Modules/GrTest sets up linkage to boost unit_test_framework, building tests fails due to undefined references to unit test symbols.

Neither happens on main; neither before nor after the johnwparent/NI CMake rework. diffing the before state (e.g. 7a74e8f4d57cd1a35157a158f4d94acdc8501565 ) of cmake/Modules gives no obvious difference. I'm stumped.

I'm removing MinGW testing from maint-3.10, which is the last I'd like to do,

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->

Related to #8054

## Which blocks/areas does this affect?

CI for maint-3.10 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
