### PR TITLE
runtime: prevent resetting logging pattern to default pattern

### DIFF
--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -34,6 +34,8 @@ logging::logging()
         prefs::singleton()->get_string("LOG", "log_level", "info")));
     _debug_backend->set_level(spdlog::level::from_str(
         prefs::singleton()->get_string("LOG", "debug_level", "info")));
+    _default_backend->set_pattern(logging::default_pattern);
+    _debug_backend->set_pattern(logging::default_pattern);
 
 
     auto debug_console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_st>();
@@ -92,7 +94,6 @@ logger::logger(const std::string& logger_name)
           std::make_shared<spdlog::logger>(_name, logging::singleton().default_backend()))
 {
     d_logger->set_level(logging::singleton().default_level());
-    d_logger->set_pattern(logging::default_pattern);
 }
 
 log_level logger::get_level() const { return d_logger->level(); }
@@ -124,11 +125,7 @@ void logger::set_level(const std::string& level)
 }
 
 const std::string& logger::name() const { return _name; }
-void logger::set_name(const std::string& name)
-{
-    _name = name;
-    d_logger->set_pattern(logging::default_pattern);
-}
+void logger::set_name(const std::string& name) { _name = name; }
 
 bool configure_default_loggers(gr::logger_ptr& l,
                                gr::logger_ptr& d,


### PR DESCRIPTION
## Description
During development we found that allowing the use of a flexible logging pattern helps once projects grow big. See also https://github.com/gnuradio/gnuradio/issues/7986

The fix disables overwrites of a default sink to use a default pattern. It should be set once during creation and be configurable afterwards (through the `spdlog` interface)

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue
Fixes https://github.com/gnuradio/gnuradio/issues/7986

## Which blocks/areas does this affect?
This affects the logic of setting up a new logger from certain defaults.
Note: I've not touched upon configuring this from a settings file _yet_. This _only_ opens the option to set it from code.
## Testing Done
I've tested this with the following, during a portion of logging setup.
```
const auto LOGGING_PATTERN = "[%Y-%m-%d %H:%M:%S,%e %l %n] %v";
gr::logging::singleton().default_backend()->set_pattern(LOGGING_PATTERN);
```
This configures the default (spdlog) sink to use this pattern. Any new generated logger uses this default sink, with the pattern preconfigured.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
