### PR TITLE
gr-dtv: fix heap buffer overflow in dvbt_ofdm_sym_acquisition

### DIFF
--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
@@ -316,13 +316,18 @@ int dvbt_ofdm_sym_acquisition_impl::general_work(int noutput_items,
         } else {
             // If we are here it means that in the previous iteration we found the CP. We
             // now thus only search near it.
-            d_cp_found = ml_sync(&in[d_consumed],
-                                 d_cp_start + 8,
-                                 std::max(d_cp_start - 8, d_cp_length + d_fft_length - 1),
-                                 &d_cp_start,
-                                 &d_derot[0],
-                                 &d_to_consume,
-                                 &d_to_out);
+            if (d_cp_start + 8 <= 2 * d_fft_length + d_cp_length - 1) {
+                d_cp_found =
+                    ml_sync(&in[d_consumed],
+                            d_cp_start + 8,
+                            std::max(d_cp_start - 8, d_cp_length + d_fft_length - 1),
+                            &d_cp_start,
+                            &d_derot[0],
+                            &d_to_consume,
+                            &d_to_out);
+            } else {
+                d_cp_found = 0;
+            }
             if (!d_cp_found) {
                 // We may have not found the CP because the smaller search range was too
                 // small (rare, but possible). We re-try with the whole search range.


### PR DESCRIPTION
**Description**
In general_work(), the tracking path calls ml_sync() with lookup_start = d_cp_start + 8. The internal buffers d_norm and d_corr are sized for lookup_start <= 2*fft_length + cp_length - 1 (4159 in 2K mode). However d_cp_start can reach 4153 after initial acquisition, making d_cp_start + 8 = 4161 and writing 2 elements past the end of the heap buffer. With a weak/noisy signal d_cp_start drifts further, causing double free or corruption (SIGABRT) at a data-dependent position in the input stream.
Fix: check that d_cp_start + 8 is within bounds before the narrow tracking search. If not, skip to the existing full-range retry which resets d_cp_start to a valid value.
**Related Issue**
None
**Which blocks/areas does this affect?**
gr-dtv: dvbt_ofdm_sym_acquisition
**Testing Done**
Reproduced the crash with a real DVB-T 2K signal recording that drops to noise midway. After the fix the crash no longer occurs.