### PR TITLE
runtime/QA: unittest.skip[If] & from MODULE import NAME instead of NAME=MODULE.NAME

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr_unittest.py
+++ b/gnuradio-runtime/python/gnuradio/gr_unittest.py
@@ -14,6 +14,20 @@ GNU radio specific extension of unittest.
 import time
 import unittest
 
+# ruff: disable[F401]
+from unittest import (
+    FunctionTestCase,
+    TestLoader,
+    TestProgram,
+    TestResult,
+    TestSuite,
+    TextTestRunner,
+    skip,
+    skipIf
+)
+# ruff: enable[F401]
+main = TestProgram
+
 # We allow snakeCase here for consistency with unittest
 # pylint: disable=invalid-name
 
@@ -155,15 +169,6 @@ class TestCase(unittest.TestCase):
             fail_msg = fail_msg or "Timeout exceeded during call to waitFor()!"
             self.fail(fail_msg)
         return False
-
-
-TestResult = unittest.TestResult
-TestSuite = unittest.TestSuite
-FunctionTestCase = unittest.FunctionTestCase
-TestLoader = unittest.TestLoader
-TextTestRunner = unittest.TextTestRunner
-TestProgram = unittest.TestProgram
-main = TestProgram
 
 
 def run(PUT, filename=None, verbosity=1):

--- a/gr-blocks/python/blocks/qa_wavfile.py
+++ b/gr-blocks/python/blocks/qa_wavfile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2008,2010,2013,2020 Free Software Foundation, Inc.
+# Copyright 2026 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -13,7 +14,6 @@ from gnuradio import gr, gr_unittest, blocks
 
 import os
 import tempfile
-import unittest
 import wave
 from os.path import getsize
 
@@ -263,7 +263,7 @@ class test_wavefile(gr_unittest.TestCase):
 
             os.unlink(tf.name)
 
-    @unittest.skip("skipped due to bug in libsndfile < 1.2.1")
+    @gr_unittest.skip("skipped due to bug in libsndfile < 1.2.1")
     def test_read_mp3(self):
         expected_len = 2304
 
@@ -276,7 +276,7 @@ class test_wavefile(gr_unittest.TestCase):
 
         self.assertEqual(len(result), expected_len)
 
-    @unittest.skip("skipped due to bug in libsndfile < 1.2.1")
+    @gr_unittest.skip("skipped due to bug in libsndfile < 1.2.1")
     def test_read_mp3_repeat(self):
         expected_len = 2304
         repeats = 5


### PR DESCRIPTION
## Description
<!--- Why this change? What problem does it solve? -->

Needed a unittest.skipIf in a unit test. gr_unittest was lacking that. And a bit of pythonic structure.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->

## Which blocks/areas does this affect?

## Testing Done

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [/] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
