### PR TITLE
gr-fec: Improve LDPC generator matrix encoder perfomance

### DIFF
--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -116,6 +116,17 @@ ldpc_G_matrix_impl::ldpc_G_matrix_impl(const std::string filename) : fec_mtrx_im
 
     d_H_sptr = matrix_sptr((matrix*)H_ptr, matrix_free);
 
+    const unsigned int pcols = d_n - d_k;
+    d_P_col_indices.resize(pcols);
+
+    for (unsigned int j = 0; j < pcols; ++j) {
+        for (unsigned int i = 0; i < d_k; ++i) {
+            if (static_cast<unsigned char>(gsl_matrix_get(P, i, j)) & 0x1) {
+                d_P_col_indices[j].push_back(i);
+            }
+        }
+    }
+
     // Free memory
     gsl_matrix_free(P);
     gsl_matrix_free(P_transpose);
@@ -132,26 +143,17 @@ const gsl_matrix* ldpc_G_matrix_impl::G_transpose() const
 void ldpc_G_matrix_impl::encode(unsigned char* outbuffer,
                                 const unsigned char* inbuffer) const
 {
+    const unsigned int n_parity_bits = d_n - d_k;
 
-    unsigned int index, k = d_k, n = d_n;
-    gsl_matrix* s = gsl_matrix_alloc(k, 1);
-    for (index = 0; index < k; index++) {
-        double value = static_cast<double>(inbuffer[index]);
-        gsl_matrix_set(s, index, 0, value);
+    std::memcpy(outbuffer, inbuffer, d_k);
+
+    for (unsigned int j = 0; j < n_parity_bits; ++j) {
+        unsigned char p = 0;
+        for(const auto& idx: d_P_col_indices[j]) {
+            p ^= inbuffer[idx] & 0x1;
+        }
+        outbuffer[d_k + j] = p;
     }
-
-    // Simple matrix multiplication to get codeword
-    gsl_matrix* codeword = gsl_matrix_alloc(G_transpose()->size1, s->size2);
-    mult_matrices_mod2(codeword, G_transpose(), s);
-
-    // Output
-    for (index = 0; index < n; index++) {
-        outbuffer[index] = gsl_matrix_get(codeword, index, 0);
-    }
-
-    // Free memory
-    gsl_matrix_free(s);
-    gsl_matrix_free(codeword);
 }
 
 

--- a/gr-fec/lib/ldpc_G_matrix_impl.h
+++ b/gr-fec/lib/ldpc_G_matrix_impl.h
@@ -13,6 +13,7 @@
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_permutation.h>
 #include <gsl/gsl_randist.h>
+#include <vector>
 
 #include "fec_mtrx_impl.h"
 #include <gnuradio/fec/ldpc_G_matrix.h>
@@ -51,6 +52,7 @@ private:
 
     //! Get the generator matrix (used during encoding)
     const gsl_matrix* G_transpose() const;
+    std::vector<std::vector<unsigned int>> d_P_col_indices;
 
     gr::logger_ptr d_logger;
     gr::logger_ptr d_debug_logger;


### PR DESCRIPTION
## Description

Small PR which replaces runtime encoding in ldpc_G_matrix_impl with a naive implementation using the systematic form G=[I P]. Current code uses GSL matrix multiplication + mod 2, per-frame allocations, and gsl_matrix_get/set, which severely limits throughput for significant codes such as CCSDS (8176, 7154). I have noticed significant lack of performance (resulted in continuous stream drops) in 125kBit/s channel with up to 4 parallel encoders blocks. 

New implementation uses memcpy for systematic part, naive XOR-based parity computation using parity matrix and no GSL calls in encode(). I was able to run it on 1Mbit/s, without drops and not tried higher speed. Tested on LDPC code (8176,7154). The previous implementation is dominated by dense floating-point GEMM and performs poorly for large codes.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->

## Which blocks/areas does this affect?

gr-fec: Generator Matrix LDPC encoder

## Testing Done

If necessary, I can measure the performance improvement and provide the results.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
