### PR TITLE
Fix: Set parameter Endianess of both blocks as type enum and not raw

### DIFF
--- a/gr-blocks/grc/blocks_packed_to_unpacked_xx.block.yml
+++ b/gr-blocks/grc/blocks_packed_to_unpacked_xx.block.yml
@@ -16,7 +16,8 @@ parameters:
     default: '2'
 -   id: endianness
     label: Endianness
-    dtype: raw
+    dtype: enum
+    default: 'gr.GR_MSB_FIRST'
     options: [gr.GR_MSB_FIRST, gr.GR_LSB_FIRST]
     option_labels: [MSB, LSB]
 -   id: num_ports

--- a/gr-blocks/grc/blocks_unpacked_to_packed_xx.block.yml
+++ b/gr-blocks/grc/blocks_unpacked_to_packed_xx.block.yml
@@ -16,7 +16,8 @@ parameters:
     default: '2'
 -   id: endianness
     label: Endianness
-    dtype: raw
+    dtype: enum
+    default: 'gr.GR_MSB_FIRST'
     options: [gr.GR_MSB_FIRST, gr.GR_LSB_FIRST]
     option_labels: [MSB, LSB]
 -   id: num_ports


### PR DESCRIPTION
Signed-off-by: Der Siebte Schatten

# FIXES PARAMETER ENDIANESS OF BOTH UNPACKED TO PACKED BITS BLOCK AND ITS OPPOSITE
## Description
Parameter 'Endianess' was wrongly set as 'raw'. Since recently, both blocks "Packed to unpacked bits" and "Unpacked to packed bits" were not working as GNU Radio would complain of gr not being defined.
This issue was particularly annoying for SatNOGS ground stations, as satnogs-flowgraphs require both blocks to build properly.
Parameter is now set correctly to 'enum', with 'gr.GR_MSB_FIRST' set as default value, like it should.

Built and tested successfully on Raspberry Pi running Ubuntu 24.04

## Declaration of Willingness To Own

- [X] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
Fixes #7963
Replaces #7969 

## Which blocks/areas does this affect?
Packed to Unpacked bits
Unpacked to Packed bits

## Testing Done

Building on Ubuntu 24.04-aarch64
Testing both blocks in a flowgraph
Building gr-satnogs from source (required dependency)
Building satnogs-flowgraph from source

## Checklist

- [X] I am proposing a change I understand and have tested to be effective.
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
