### PR TITLE
RFNoC: Fix Window + Fosphor Block (image builder mode)

### DIFF
--- a/gr-uhd/grc/CMakeLists.txt
+++ b/gr-uhd/grc/CMakeLists.txt
@@ -77,6 +77,7 @@ if(ENABLE_UHD_RFNOC)
         uhd_fpga_switchboard.block.yml
         uhd_fpga_vector_iir.block.yml
         uhd_fpga_logpwr.block.yml
+        uhd_fpga_window.block.yml
         # GRC Bindings for RFNoC Image Builder files (domains)
         uhd_fpga_clk.domain.yml
         uhd_fpga_ctrl.domain.yml

--- a/gr-uhd/grc/uhd.tree.yml
+++ b/gr-uhd/grc/uhd.tree.yml
@@ -34,6 +34,7 @@
       - uhd_fpga_vector
       - uhd_fpga_fir_filter
       - uhd_fpga_logpwr
+      - uhd_fpga_window
     - Core:
       - uhd_fpga_sep
       - uhd_fpga_device_bsp

--- a/gr-uhd/grc/uhd_fpga_fosphor.block.yml
+++ b/gr-uhd/grc/uhd_fpga_fosphor.block.yml
@@ -14,20 +14,20 @@ parameters:
     hide: all
 
 inputs:
+-   domain: rfnoc.clk
+    id: ce_clk
+    dtype: message
 -   domain: rfnoc.data
     id: fft_in
     dtype: fc32
-    multiplicity: ${ NUM_PORTS }
 
 outputs:
 -   domain: rfnoc.data
     id: hist
     dtype: fc32
-    multiplicity: ${ NUM_PORTS }
 -   domain: rfnoc.data
     id: wf
     dtype: fc32
-    multiplicity: ${ NUM_PORTS }
 
 documentation: |-
   RFNoC F15 (fosphor) (FPGA Implementation).

--- a/gr-uhd/grc/uhd_fpga_window.block.yml
+++ b/gr-uhd/grc/uhd_fpga_window.block.yml
@@ -1,0 +1,51 @@
+id: uhd_fpga_window
+label: RFNoC Window
+
+parameters:
+-   id: type
+    label: RFNoC Block Type
+    dtype: enum
+    default: 'block'
+    options: ['block', 'sep', 'device']
+    hide: all
+-   id: desc
+    label: Block Descriptor
+    dtype: string
+    default: 'window.yml'
+    hide: all
+-   id: NUM_PORTS
+    label: Number of Ports
+    dtype: int
+    default: 1
+    hide: part
+-   id: MAX_WINDOW_SIZE
+    label: Maximum number of window coefficients
+    dtype: int
+    default: 4096
+    hide: part
+
+inputs:
+-   domain: rfnoc.clk
+    id: ce_clk
+    dtype: message
+-   domain: rfnoc.data
+    id: in_
+    dtype: fc32
+    multiplicity: ${ NUM_PORTS }
+
+outputs:
+-   domain: rfnoc.data
+    id: out_
+    dtype: fc32
+    multiplicity: ${ NUM_PORTS }
+
+doc_url: UHD_FPGA_WINDOW
+
+documentation: |-
+  RFNoC Window (FPGA Implementation).
+  Instantiates a Window block in the FPGA bitfile.
+  This block is used to apply a window function to a time-domain signal before
+  passing it on to the FFT block.
+
+file_format: 1
+


### PR DESCRIPTION
<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description

Without this change, it is not possible to build RFNoC bitfiles with window block or the fosphor block from GRC.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Which blocks/areas does this affect?

## Testing Done

I ran this GRC file through the image builder (note: there was another bug in the image builder that only triggered on the fosphor block because that doesn't have parameters, I have a separate bugfix in UHD incoming. If you leave out the fosphor block, it creates the correct design though).

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
