### PR TITLE
check for pygccxml dependency before binding

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
@@ -41,6 +41,15 @@ name = args.module
 namespace = ['gr', name]
 prefix_include_root = "gnuradio/" + name
 
+flag_pygccxml = True if args.flag_pygccxml.lower() in ['1', 'true'] else False
+
+if flag_pygccxml:
+    try:
+        import pygccxml
+    except ImportError:
+        import sys
+        print("Error: pygccxml is required to generate C++ bindings.")
+        sys.exit(1)
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -50,5 +59,5 @@ with warnings.catch_warnings():
                           catch_exceptions=False, write_json_output=False, status_output=args.status,
                           flag_automatic=True if args.flag_automatic.lower() in [
                               '1', 'true'] else False,
-                          flag_pygccxml=True if args.flag_pygccxml.lower() in ['1', 'true'] else False)
+                          flag_pygccxml=flag_pygccxml)
     bg.gen_file_binding(args.filename)


### PR DESCRIPTION
<!-- modtool: check for pygccxml dependency before binding -->
## Description
Adds a check for the pygccxml dependency in bind_oot_file.py before executing the binding generator.
If the library is missing, the script now exits with a clear error message.

<!--- Why this change? What problem does it solve? -->
## Declaration of Willingness To Own

- [X] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue
Emerged from #6441, fixes a slightly different problem

## Which blocks/areas does this affect?
bind_oot_file.py

## Testing Done
Binding with and without the library.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I am proposing a change I understand and have tested to be effective.
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.