### PR TITLE
qa: add regression test for Python sync_block segfault (#8137)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -34,7 +34,8 @@ if(ENABLE_TESTING)
                          qa_sys_paths.py qa_tag_utils.py)
     # This is a check for whether gr-blocks is enabled
     if(ENABLE_DEFAULT OR ENABLE_GR_BLOCKS)
-        list(APPEND py_qa_test_files qa_hier_block2.py qa_uncaught_exception.py)
+        list(APPEND py_qa_test_files qa_hier_block2.py qa_uncaught_exception.py
+                                     qa_python_block_smoke.py)
     else()
         message(
             STATUS

--- a/gnuradio-runtime/python/gnuradio/gr/qa_python_block_smoke.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_python_block_smoke.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+"""Regression test for https://github.com/gnuradio/gnuradio/issues/8137.
+
+Instantiating any pure-Python ``gr.sync_block`` in a flowgraph currently
+segfaults in a C++ worker thread launched by ``top_block.start()``,
+before any ``work()`` invocation. Reproduces across every 3.10.x package
+checked (Ubuntu 22.04/24.04/25.04, Debian bookworm) on both ``arm64``
+and ``amd64``, with numpy versions ranging from 1.21 to 2.2.
+
+Note: this bug only manifests when the flowgraph is built and started
+inside the same Python interpreter that initially imports the runtime.
+Running the same flowgraph inside a ``multiprocessing.Process`` (which
+forks after the parent has already imported ``gr``) does *not* trigger
+the crash, so the test spawns a fresh interpreter via ``subprocess``
+instead. The test passes when the underlying GR runtime bug is fixed.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+from gnuradio import gr_unittest
+
+
+# Run inline (no Process/fork): build a one-Python-block flowgraph and
+# start it. Exits 0 on success; SIGSEGV (exit -11 / 139) demonstrates
+# the regression.
+_REPRO_SOURCE = textwrap.dedent("""
+    import time
+    import numpy
+    from gnuradio import blocks, gr
+
+    class P(gr.sync_block):
+        def __init__(self):
+            gr.sync_block.__init__(
+                self, name="p",
+                in_sig=[numpy.complex64], out_sig=[numpy.complex64])
+        def work(self, ii, oi):
+            oi[0][:] = ii[0]
+            return len(oi[0])
+
+    tb = gr.top_block()
+    src = blocks.vector_source_c([complex(x, x + 1) for x in range(65536)])
+    src.set_repeat(True)
+    throttle = blocks.throttle(gr.sizeof_gr_complex, 1e6)
+    tb.connect(src, throttle, P(), blocks.null_sink(gr.sizeof_gr_complex))
+
+    tb.start()
+    time.sleep(0.3)
+    tb.stop()
+    tb.wait()
+""")
+
+
+class test_python_block_smoke(gr_unittest.TestCase):
+
+    def test_001_start_with_python_block(self):
+        """A flowgraph containing a Python sync_block must start without
+        crashing the runtime."""
+        result = subprocess.run(
+            [sys.executable, "-c", _REPRO_SOURCE],
+            timeout=20,
+            capture_output=True,
+        )
+
+        # On a healthy runtime the child exits 0. On the regression it
+        # crashes with SIGSEGV; subprocess reports this as -signal on
+        # POSIX (returncode == -11) or 139 if propagated by a shell.
+        self.assertEqual(
+            result.returncode, 0,
+            "child interpreter exited with returncode={} when running a "
+            "flowgraph containing a Python sync_block (negative codes "
+            "are POSIX signals; -11 is SIGSEGV). See "
+            "https://github.com/gnuradio/gnuradio/issues/8137\n"
+            "stderr:\n{}".format(
+                result.returncode,
+                result.stderr.decode(errors="replace")))
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_python_block_smoke)


### PR DESCRIPTION
## What

Adds `gnuradio-runtime/python/gnuradio/gr/qa_python_block_smoke.py`, a minimal regression test that demonstrates the bug reported in #8137: instantiating any pure-Python `gr.sync_block` in a flowgraph and calling `top_block.start()` segfaults in a C++ worker thread, before any `work()` call.

The test runs the offending flowgraph in a fresh interpreter via `subprocess`. (Worth noting: I first tried `multiprocessing.Process`, but `fork()` happens to inherit enough parent state that the bug does *not* reproduce in the child — a useful clue for whoever triages the underlying issue. Crash only happens when the runtime is imported and the flowgraph runs in the same interpreter.) The test asserts that the child exits with returncode 0.

## Status

**This is a draft / failing test on purpose** — it currently fails with `returncode=-11` (SIGSEGV) on every 3.10.x environment I could test:

| Image | GR | numpy | Arch |
|---|---|---|---|
| `ubuntu:22.04` | 3.10.1.1 | 1.21.5 | arm64 |
| `ubuntu:24.04` | 3.10.9.2 | 1.26.4 | arm64 |
| `ubuntu:25.04` | 3.10.11.0 | 2.2.3 | arm64 |
| `debian:bookworm` | 3.10.5.1 | 1.24.2 | arm64 |
| source-build `maint-3.10` HEAD | 3.10.12.0 | 1.26.4 | arm64 |
| GitHub Actions `ubuntu-latest` | 3.10.x | recent | amd64 |

Once the runtime bug is fixed, the test should pass without modification — it's structured so that "test passes" is "regression is fixed."

## Test sketch

```python
class P(gr.sync_block):
    def __init__(self):
        gr.sync_block.__init__(self, name="p",
            in_sig=[numpy.complex64], out_sig=[numpy.complex64])
    def work(self, ii, oi):
        oi[0][:] = ii[0]
        return len(oi[0])

tb = gr.top_block()
src = blocks.vector_source_c([complex(x, x + 1) for x in range(65536)])
src.set_repeat(True)
tb.connect(src, blocks.throttle(gr.sizeof_gr_complex, 1e6),
           P(), blocks.null_sink(gr.sizeof_gr_complex))

tb.start()    # SIGSEGV here (C++ worker thread, no Python frame)
time.sleep(0.3)
tb.stop(); tb.wait()
```

Registered under the same `ENABLE_GR_BLOCKS` guard as `qa_uncaught_exception.py` (only `gr-blocks` dependency). Test isolation pattern mirrors that file.

## Marking as draft

Happy to convert to ready once a maintainer either confirms the underlying bug exists or wants the test merged as-is to make the regression visible in CI.

Closes: nothing — leaves #8137 open until the runtime fix lands.

Signed-off-by: Örjan Lundberg <orjan@lundberg.me>