### PR TITLE
qtgui: Fix vertical slider direction

### DIFF
--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -202,7 +202,8 @@ class RangeWidget(QtWidgets.QWidget):
                 if self.orientation == QtCore.Qt.Horizontal:
                     new = self.minimum() + ((self.maximum() - self.minimum()) * event.x()) / self.width()
                 else:
-                    new = self.minimum() + ((self.maximum() - self.minimum()) * event.y()) / self.height()
+                    # Vertical sliders have their minimum at the bottom, but mouse y grows downward
+                    new = self.minimum() + ((self.maximum() - self.minimum()) * (self.height() - event.position().y())) / self.height()
                 self.setValue(int(new))
                 event.accept()
             # Use repaint rather than calling the super mousePressEvent.
@@ -213,7 +214,7 @@ class RangeWidget(QtWidgets.QWidget):
             if self.orientation == QtCore.Qt.Horizontal:
                 new = self.minimum() + ((self.maximum() - self.minimum()) * event.x()) / self.width()
             else:
-                new = self.minimum() + ((self.maximum() - self.minimum()) * event.y()) / self.height()
+                new = self.minimum() + ((self.maximum() - self.minimum()) * (self.height() - event.position().y())) / self.height()
             self.setValue(int(new))
             event.accept()
             QtWidgets.QSlider.repaint(self)


### PR DESCRIPTION
<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description
<!--- Why this change? What problem does it solve? -->

This PR fixes the following problem: 

When vertically oriented, the Qt Range slider moves in the opposite direction of the mouse.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->
None
## Which blocks/areas does this affect?
Qt GUI Range block
## Testing Done
Manual testing
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
