### PR TITLE
runtime: fix Python sync_block segfault during top_block.start() (#8137)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -43,7 +43,8 @@ if(ENABLE_TESTING)
     )
     # This is a check for whether gr-blocks is enabled
     if(ENABLE_DEFAULT OR ENABLE_GR_BLOCKS)
-        list(APPEND py_qa_test_files qa_hier_block2.py qa_uncaught_exception.py)
+        list(APPEND py_qa_test_files qa_hier_block2.py qa_python_block_segfault.py
+             qa_uncaught_exception.py)
     else()
         message(
             STATUS

--- a/gnuradio-runtime/python/gnuradio/gr/hier_block2.py
+++ b/gnuradio-runtime/python/gnuradio/gr/hier_block2.py
@@ -16,7 +16,22 @@ from .gr_python import logger
 import pmt
 
 
+def _endpoint_block(point):
+    """
+    Extract the block object from a connect endpoint, which is either a
+    block instance or a (block, port) tuple/list.
+    """
+    if hasattr(point, "to_basic_block"):
+        return point
+    try:
+        return point[0]
+    except (TypeError, IndexError):
+        return None
+
+
 def _multiple_endpoints(func):
+    retain = func.__name__ == "connect"
+
     @functools.wraps(func)
     def wrapped(self, *points):
         if not points:
@@ -26,6 +41,8 @@ def _multiple_endpoints(func):
                 block = points[0].to_basic_block()
             except AttributeError:
                 raise ValueError("At least two endpoints required for " + func.__name__)
+            if retain:
+                self._retain_python_refs(points)
             func(self, block)
         else:
             try:
@@ -36,6 +53,8 @@ def _multiple_endpoints(func):
             except (ValueError, TypeError, AttributeError) as err:
                 raise ValueError("Unable to coerce endpoints: " + str(err))
 
+            if retain:
+                self._retain_python_refs(points)
             for (src, src_port), (dst, dst_port) in zip(endp, endp[1:]):
                 func(self, src, src_port, dst, dst_port)
 
@@ -43,6 +62,8 @@ def _multiple_endpoints(func):
 
 
 def _optional_endpoints(func):
+    retain = func.__name__ == "msg_connect"
+
     @functools.wraps(func)
     def wrapped(self, src, srcport, dst=None, dstport=None):
         if dst is None and dstport is None:
@@ -50,6 +71,8 @@ def _optional_endpoints(func):
                 (src, srcport), (dst, dstport) = src, srcport
             except (ValueError, TypeError) as err:
                 raise ValueError("Unable to coerce endpoints: " + str(err))
+        if retain:
+            self._retain_python_refs((src, dst))
         func(self, src.to_basic_block(), srcport, dst.to_basic_block(), dstport)
 
     return wrapped
@@ -106,6 +129,33 @@ class hier_block2(object):
         Return a string representation useful for human-aimed printing
         """
         return f"Python hierarchical block {self.name()}"
+
+    def _retain_python_refs(self, points):
+        """
+        Keep strong Python references to connected block objects alive for
+        the lifetime of this flowgraph.
+
+        The C++ ``block_gateway`` backing a pure-Python block holds only a
+        non-owning handle back to the Python block object (see ``gateway.py``
+        and ``bindings/block_gateway.h``). If such a block is connected but
+        not otherwise retained by the caller -- e.g. created as a local inside
+        ``__init__`` -- it can be garbage-collected before the scheduler runs,
+        leaving the gateway with a dangling handle. The worker thread then
+        dereferences freed memory and segfaults during ``start()`` (issue
+        #8137). Holding the Python object here ties its lifetime to the
+        flowgraph that owns it, which avoids both the crash and the
+        uncollectable reference cycle a C++-side strong reference would create.
+
+        References are keyed by ``id()`` so blocks need not be hashable and
+        repeated connections do not accumulate duplicates.
+        """
+        refs = self.__dict__.setdefault("_py_block_refs", {})
+        for point in points:
+            block = _endpoint_block(point)
+            # Skip self-connections (hier block wiring to its own ports) so we
+            # don't create a reference cycle that needs the cyclic collector.
+            if block is not None and block is not self:
+                refs[id(block)] = block
 
     # FIXME: these should really be implemented
     # in the original C++ class (gr_hier_block2), then they would all be inherited here

--- a/gnuradio-runtime/python/gnuradio/gr/qa_python_block_segfault.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_python_block_segfault.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Örjan Lundberg
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+# Regression test for https://github.com/gnuradio/gnuradio/issues/8137
+#
+# A pure-Python gr.sync_block that was connected into a flowgraph but not
+# otherwise retained by the caller (e.g. created as a local in __init__) used
+# to be garbage-collected before the scheduler started. The C++ block_gateway
+# keeps only a non-owning handle back to the Python block, so the worker thread
+# dereferenced freed memory and segfaulted (SIGSEGV, exit code -11) in
+# top_block.start(), before any work() call ran.
+#
+# The crash only manifests in a fresh interpreter where the block's reference
+# count actually drops to zero -- it does not reproduce when the surrounding
+# function (and thus the local reference) is still on the stack during run().
+# We therefore launch a fresh interpreter via subprocess to actually trigger
+# it, mirroring the manual reproducer in the issue.
+
+import subprocess
+import sys
+
+from gnuradio import gr, gr_unittest
+
+# Source for the child interpreter. The Python sync_block `P` is created as a
+# local inside TB.__init__ and is *not* stored as an attribute, so before the
+# fix its only strong reference disappears when __init__ returns.
+_REPRO = """
+import time
+import numpy as np
+from gnuradio import blocks, gr
+
+
+class P(gr.sync_block):
+    def __init__(self):
+        gr.sync_block.__init__(
+            self, name="p",
+            in_sig=[np.complex64], out_sig=[np.complex64])
+
+    def work(self, ii, oi):
+        oi[0][:] = ii[0]
+        return len(oi[0])
+
+
+class TB(gr.top_block):
+    def __init__(self):
+        super().__init__()
+        src_data = [complex(x, x + 1) for x in range(65536)]
+        s = blocks.vector_source_c(src_data, True)
+        t = blocks.throttle(gr.sizeof_gr_complex, 1e6)
+        p, n = P(), blocks.null_sink(gr.sizeof_gr_complex)
+        self.connect(s, t, p, n)
+
+
+tb = TB()
+tb.start()
+time.sleep(0.3)
+tb.stop()
+tb.wait()
+print("OK")
+"""
+
+
+class test_python_block_segfault(gr_unittest.TestCase):
+
+    def test_start_does_not_segfault(self):
+        # Run the reproducer in a fresh interpreter; before the fix this exits
+        # with the SIGSEGV return code (-11 on POSIX).
+        result = subprocess.run(
+            [sys.executable, "-c", _REPRO],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg="Python sync_block flowgraph crashed during start() "
+            "(returncode={}):\n{}".format(
+                result.returncode, result.stderr.decode(errors="replace")),
+        )
+        self.assertIn(b"OK", result.stdout)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_python_block_segfault)


### PR DESCRIPTION
## Summary

Fixes #8137 — instantiating any pure-Python `gr.sync_block`, connecting it into a flowgraph, and calling `top_block.start()` segfaults (SIGSEGV / exit 139) in a C++ worker thread before any `work()` call runs.

## Root cause

`block_gateway` (C++) stores the Python block object as a **non-owning** `py::handle` (`bindings/block_gateway.h`), never inc_ref'ing it. The only reference chain is:

```
P (Python block) -> self.gateway (C++ block_gateway) -> weak py::handle -> P
```

In the reproducer, the block is a local in `__init__` and is connected via `self.connect(...)`. Neither Python nor the C++ flowgraph holds a *strong* reference to the Python object, so it is garbage-collected when `__init__` returns. `start()` then launches worker threads that call `d_py_handle.attr("start"/"forecast"/...)` on the freed `PyObject` → SIGSEGV in a worker thread with `<no Python frame>`, matching the report.

This explains the observations in the issue:
- GRC-generated graphs survive only because they keep `self.<name> = block` alive.
- `qa_uncaught_exception.py` survives because its blocks stay on the stack during the blocking `run()`.

## Fix

Tie the Python block's lifetime to the flowgraph that owns it: `connect()` and `msg_connect()` now hold strong Python references to the connected block objects on the hier/top block (`_py_block_refs`, keyed by `id()`).

A C++-side strong reference was deliberately **not** used: it would create a `P -> wrapper -> C++ block -> P` cycle whose C++→Python edge is invisible to Python's cyclic GC, leaking every Python block. The Python-side references drop naturally when the top/hier block is destroyed — no crash, no leak.

## Test

Adds `qa_python_block_segfault.py`, which runs the issue reproducer in a fresh interpreter via `subprocess` (the crash only manifests when the block's refcount actually reaches zero, which needs a fresh interpreter rather than a `multiprocessing` fork) and asserts a clean exit. It fails (returncode -11) on `main` and passes with this fix.

## Related

- Supersedes the test-only draft #8138.
- Same general area as #7711 (different failure mode).