### PR TITLE
blocktool/grc: Remove deprecated codecs.open()

### DIFF
--- a/gr-utils/blocktool/core/parseheader.py
+++ b/gr-utils/blocktool/core/parseheader.py
@@ -15,7 +15,6 @@ from ..core.iosignature import io_signature, message_port
 from ..core.base import BlockToolException, BlockTool
 import os
 import re
-import codecs
 import logging
 
 PYGCCXML_AVAILABLE = False
@@ -303,7 +302,7 @@ class BlockHeaderParser(BlockTool):
         # documentation
         try:
             _index = None
-            header_file = codecs.open(self.target_file, 'r', 'cp932')
+            header_file = open(self.target_file, 'r', encoding='cp932')
             self.parsed_data['docstring'] = re.compile(
                 r'//.*?$|/\*.*?\*/', re.DOTALL | re.MULTILINE).findall(
                     header_file.read())[2:]

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -11,7 +11,6 @@
 
 import os
 import re
-import codecs
 import logging
 
 from ..core.base import BlockToolException, BlockTool

--- a/grc/converter/main.py
+++ b/grc/converter/main.py
@@ -5,7 +5,6 @@
 #
 
 
-from codecs import open
 import json
 import logging
 import os

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -5,7 +5,6 @@
 #
 
 
-from codecs import open
 from collections import namedtuple
 from collections import ChainMap
 import os

--- a/grc/workflows/cpp_hb_nogui/cpp_hier_block.py
+++ b/grc/workflows/cpp_hb_nogui/cpp_hier_block.py
@@ -3,7 +3,6 @@
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import codecs
 import collections
 import os
 
@@ -56,7 +55,7 @@ class CppHierBlockGenerator(HierBlockGeneratorMixin, CppNoGuiTopBlockGenerator):
         for r in replace:
             data = data.replace(*r)
 
-        with codecs.open(self.file_path_yml, 'w', encoding='utf-8') as fp:
+        with open(self.file_path_yml, 'w', encoding='utf-8') as fp:
             fp.write(data)
 
         # Windows only supports S_IREAD and S_IWRITE, other flags are ignored

--- a/grc/workflows/python_hb_nogui/hier_block.py
+++ b/grc/workflows/python_hb_nogui/hier_block.py
@@ -3,7 +3,6 @@
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import codecs
 import collections
 import os
 
@@ -55,7 +54,7 @@ class PythonHierBlockNoGuiGenerator(HierBlockGeneratorMixin, PythonNoGuiGenerato
         for r in replace:
             data = data.replace(*r)
 
-        with codecs.open(self.file_path_yml, 'w', encoding='utf-8') as fp:
+        with open(self.file_path_yml, 'w', encoding='utf-8') as fp:
             fp.write(data)
 
         # Windows only supports S_IREAD and S_IWRITE, other flags are ignored


### PR DESCRIPTION
<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description
<!--- Why this change? What problem does it solve? -->

`codecs.open()` ([which seems to be a relic from Python2](https://discuss.python.org/t/deprecating-codecs-open/88135)) has been deprecated from Python 3.14 with the following warning:
```
<python-input-4>:1: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
```

Question: I might be missing something obvious, but why are we using the cp932 encoding here?
https://github.com/gnuradio/gnuradio/blob/c61887f7899cde8008267b81a75cfac64955edde/gr-utils/blocktool/core/parseheader.py#L303-L306


## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->
None

## Which blocks/areas does this affect?
blocktool and GRC, but no functional changes

## Testing Done
Manual testing

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
