### PR TITLE
cppgen: Stop flowgraph (gently) on exit

### DIFF
--- a/grc/workflows/cpp_qt_gui/flow_graph_qt_gui.cpp.mako
+++ b/grc/workflows/cpp_qt_gui/flow_graph_qt_gui.cpp.mako
@@ -158,6 +158,8 @@ int main (int argc, char **argv) {
     app.exec();
 
 
+    top_block->tb->stop();
+    top_block->tb->wait();
     return 0;
 }
 #include "moc_${class_name}.cpp"


### PR DESCRIPTION
<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description
<!--- Why this change? What problem does it solve? -->
Without this change, GRC-generated Qt GUI C++ flowgraphs produce a segfault on exit.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->
None

## Which blocks/areas does this affect?
C++ generation
## Testing Done
Tested generating Qt C++ flowgraphs before and after this commit

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
