### PR TITLE
Enable testing with prepared signals

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr_unittest.py
+++ b/gnuradio-runtime/python/gnuradio/gr_unittest.py
@@ -14,6 +14,20 @@ GNU radio specific extension of unittest.
 import time
 import unittest
 
+# ruff: disable[F401]
+from unittest import (
+    FunctionTestCase,
+    TestLoader,
+    TestProgram,
+    TestResult,
+    TestSuite,
+    TextTestRunner,
+    skip,
+    skipIf
+)
+# ruff: enable[F401]
+main = TestProgram
+
 # We allow snakeCase here for consistency with unittest
 # pylint: disable=invalid-name
 
@@ -155,15 +169,6 @@ class TestCase(unittest.TestCase):
             fail_msg = fail_msg or "Timeout exceeded during call to waitFor()!"
             self.fail(fail_msg)
         return False
-
-
-TestResult = unittest.TestResult
-TestSuite = unittest.TestSuite
-FunctionTestCase = unittest.FunctionTestCase
-TestLoader = unittest.TestLoader
-TextTestRunner = unittest.TextTestRunner
-TestProgram = unittest.TestProgram
-main = TestProgram
 
 
 def run(PUT, filename=None, verbosity=1):

--- a/gr-blocks/python/blocks/qa_wavfile.py
+++ b/gr-blocks/python/blocks/qa_wavfile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2008,2010,2013,2020 Free Software Foundation, Inc.
+# Copyright 2026 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -13,7 +14,6 @@ from gnuradio import gr, gr_unittest, blocks
 
 import os
 import tempfile
-import unittest
 import wave
 from os.path import getsize
 
@@ -263,7 +263,7 @@ class test_wavefile(gr_unittest.TestCase):
 
             os.unlink(tf.name)
 
-    @unittest.skip("skipped due to bug in libsndfile < 1.2.1")
+    @gr_unittest.skip("skipped due to bug in libsndfile < 1.2.1")
     def test_read_mp3(self):
         expected_len = 2304
 
@@ -276,7 +276,7 @@ class test_wavefile(gr_unittest.TestCase):
 
         self.assertEqual(len(result), expected_len)
 
-    @unittest.skip("skipped due to bug in libsndfile < 1.2.1")
+    @gr_unittest.skip("skipped due to bug in libsndfile < 1.2.1")
     def test_read_mp3_repeat(self):
         expected_len = 2304
         repeats = 5

--- a/gr-dtv/python/dtv/qa_realsignal_online.py
+++ b/gr-dtv/python/dtv/qa_realsignal_online.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# Copyright 2026 Chie4
+# Copyright 2026 Marcus Müller
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+import logging
+import pathlib
+import shutil
+import tempfile
+from urllib import parse, request
+from functools import cache
+from os import getenv
+from typing import Optional
+
+from gnuradio import gr_unittest
+from gnuradio import gr, blocks, dtv
+
+URLS = {
+    "ofdm symbol acquisition": {
+        "url": "https://gr-pubbuck.s3.us-west-002.backblazeb2.com/dtv-ofdm-sym-acquisition.fc32",
+        "comment": "kindly provided by Chie4 in https://github.com/gnuradio/gnuradio/pull/8124",
+    }
+}
+
+
+@cache
+def online_tests_enabled() -> bool:
+    enabled = getenv("GR_ONLINE_TESTS")
+    return enabled and not (
+        enabled.upper() in ("NO", "DISABLED", "OFF", "0", "OFFLINE")
+    )
+
+
+@cache
+def download_dir() -> pathlib.Path:
+    target_dir = getenv("GR_DTV_DOWNLOADS_DIR")
+    if not target_dir:
+        target_dir = tempfile.mkdtemp(prefix="gr_online_test_", suffix=".tmp")
+    return pathlib.Path(target_dir)
+
+
+@cache
+def fetch_online(name: str) -> Optional[pathlib.Path]:
+    """Fetch all online resources and return whether that succeeded.
+
+    If it succeeded, cache the result. We don't want to re-download for every
+    test method, so we can't do this in TestCase.__init__ or .setUp"""
+    url = URLS[name]["url"]
+    target_dir = download_dir()
+    parts = parse.urlsplit(url)
+    filename = pathlib.PosixPath(parts.path).parts[-1]
+    local_file = target_dir / filename
+    if local_file.exists():
+        logging.info(f"returning pre-downloaded {local_file}")
+        return local_file
+    if not online_tests_enabled():
+        logging.warning(
+            f'Online tests disabled (environment variable "GR_ONLINE_TESTS") \
+            and {filename} not pre-downloaded'
+        )
+        return None
+    try:
+        logging.info(f"opening {url}")
+        with request.urlopen(url) as response:
+            with open(local_file, "wb") as f:
+                logging.info(f"writing {url} to {local_file}")
+                shutil.copyfileobj(response, f)
+        logging.info(f"closed {local_file}")
+        return local_file
+    except Exception as e:
+        logging.warning(f"Couldn't download {url}: {e}")
+
+
+@gr_unittest.skipIf(not online_tests_enabled, "Online testing not enabled")
+class online_tests(gr_unittest.TestCase):
+    downloaded_files = {"dummy": None}
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    @gr_unittest.skipIf(
+        not fetch_online("ofdm symbol acquisition"),
+        "couldn't download",
+    )
+    def test_001_OFDM_symbol_acquisition(self):
+        """Test against a known recording.
+
+        This led to segfaults as reported in #8124.
+        """
+        fname = fetch_online("ofdm symbol acquisition")
+        src = blocks.file_source(gr.sizeof_gr_complex, str(fname), False)
+        acq = dtv.dvbt_ofdm_sym_acquisition(1, 2048, 1705, 64, 8.0)
+        null = blocks.null_sink(gr.sizeof_gr_complex * 2048)
+        self.tb.connect(src, acq, null)
+        self.tb.run()
+
+
+if __name__ == "__main__":
+    gr_unittest.run(online_tests)


### PR DESCRIPTION
- **runtime/QA: unittest.skip[If] & from MODULE import NAME instead of NAME=MODULE.NAME**
- **DTV: add OFDM Symbol Acquisition realworld signal test**

<!-- PR TITLE: DESCRIBE IN FEW WORDS WHAT IS DONE; for example: -->
<!-- Buffer overflow: Avoid destruction of universe in gfsk_mod_cc -->
## Description
<!--- Why this change? What problem does it solve? -->

in the latest DVB report, a recording that made the receiver crash was shared. This is great; we need more of that!

So, here's the infra to fetch these recordings from CI.

Note that you need to enable the actual fetching explicitly by having an environment variable.

This PR does *not* set the environment variable for CI – and should hence "successfully" skip the test.

The idea is that we add the variable in the fix provided along with the recording, so that we have something that was broken before and works after!

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Related Issue
<!--- If this PR fully addresses an issue, please say "Fixes #1234" -->

## Which blocks/areas does this affect?

## Testing Done

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
