### PR TITLE
runtime/vmcircbuf: logging was confusing, things that should be warnings went to stdout.

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -48,15 +48,14 @@ vmcircbuf_factory* vmcircbuf_sysconfig::get_default_factory()
 
     std::vector<gr::vmcircbuf_factory*> all = all_factories();
 
-    logger_ptr logger, debug_logger;
-    gr::configure_default_loggers(logger, debug_logger, "vmcircbuf_sysconfig");
+    gr::logger logger("vmcircbuf_sysconfig");
 
-    auto name = gr::vmcircbuf_prefs::get(FACTORY_PREF_KEY);
-    if (!name.empty()) {
-        for (auto& factory : all) {
+    const auto name = gr::vmcircbuf_prefs::get(FACTORY_PREF_KEY);
+    if (name) {
+        for (const auto& factory : all) {
             if (name == factory->name()) {
                 s_default_factory = factory;
-                debug_logger->info("Using {:s}", s_default_factory->name());
+                logger.info("Using {:s}", s_default_factory->name());
                 return s_default_factory;
             }
         }
@@ -64,18 +63,20 @@ vmcircbuf_factory* vmcircbuf_sysconfig::get_default_factory()
 
     // either we don't have a default, or the default named is not in our
     // list of factories.  Find the first factory that works.
+    logger.info("No vmcircbuf preference read; this isn't inherently a problem. "
+                "Defaulting to the highest-priority working factory...");
 
-    debug_logger->info("finding a working factory...");
-
-    for (auto& factory : all) {
+    for (const auto& factory : all) {
         if (test_factory(factory, verbose)) {
+            logger.info("Using {:s} factory. Trying to save this configuration…",
+                        factory->name());
             set_default_factory(factory);
             return s_default_factory;
         }
     }
 
     // We're screwed!
-    logger->error("unable to find a working factory!");
+    logger.error("unable to find a working factory!");
     throw std::runtime_error("gr::vmcircbuf_sysconfig");
 }
 
@@ -112,11 +113,11 @@ static void init_buffer(const vmcircbuf& c, int counter, int size)
 }
 
 static bool check_mapping(
-    const vmcircbuf& c, int counter, int size, const char* msg, logger_ptr debug_logger)
+    const vmcircbuf& c, int counter, int size, const char* msg, gr::logger& logger)
 {
     bool ok = true;
 
-    debug_logger->info("{:s}", msg);
+    logger.info("{:s}", msg);
 
     unsigned int* p1 = (unsigned int*)c.pointer_to_first_copy();
     unsigned int* p2 = (unsigned int*)c.pointer_to_second_copy();
@@ -124,17 +125,17 @@ static bool check_mapping(
     for (unsigned int i = 0; i < size / sizeof(int); i++) {
         if (p1[i] != counter + i) {
             ok = false;
-            debug_logger->error("p1[{:d}] == {:d}, expected {:d}", i, p1[i], counter + i);
+            logger.error("p1[{:d}] == {:d}, expected {:d}", i, p1[i], counter + i);
             break;
         }
         if (p2[i] != counter + i) {
-            debug_logger->error("p2[{:d}] == {:d}, expected {:d}", i, p2[i], counter + i);
+            logger.error("p2[{:d}] == {:d}, expected {:d}", i, p2[i], counter + i);
             ok = false;
             break;
         }
     }
     if (ok) {
-        debug_logger->info("mapping OK");
+        logger.info("mapping OK");
     }
     return ok;
 }
@@ -160,18 +161,17 @@ test_a_bunch(vmcircbuf_factory* factory, int n, int size, int* start_ptr, bool v
     std::vector<std::unique_ptr<vmcircbuf>> c(n);
     int cum_size = 0;
 
-    logger_ptr logger, debug_logger;
-    gr::configure_default_loggers(logger, debug_logger, "gr::test_a_bunch");
+    gr::logger logger("gr::test_a_bunch");
 
     for (int i = 0; i < n; i++) {
         counter[i] = *start_ptr;
         *start_ptr += size;
         if ((c[i] = std::unique_ptr<vmcircbuf>(factory->make(size))) == 0) {
-            debug_logger->info("Failed to allocate gr::vmcircbuf "
-                               "number {:d} of size {:d} (cum = {:s})",
-                               i + 1,
-                               size,
-                               memsize(cum_size));
+            logger.info(
+                "Failed to allocate gr::vmcircbuf number {:d} of size {:d} (cum = {:s})",
+                i + 1,
+                size,
+                memsize(cum_size));
             return false;
         }
         init_buffer(*c[i], counter[i], size);
@@ -181,17 +181,16 @@ test_a_bunch(vmcircbuf_factory* factory, int n, int size, int* start_ptr, bool v
     for (int i = 0; i < n; i++) {
         std::string msg = "test_a_bunch_" + std::to_string(n) + "x" + memsize(size) +
                           "[" + std::to_string(i) + "]";
-        ok = check_mapping(*c[i], counter[i], size, msg.c_str(), debug_logger) && ok;
+        ok = check_mapping(*c[i], counter[i], size, msg.c_str(), logger) && ok;
     }
     return ok;
 }
 
 static bool standard_tests(vmcircbuf_factory* f, int verbose)
 {
-    logger_ptr logger, debug_logger;
-    gr::configure_default_loggers(logger, debug_logger, "standard_tests");
 
-    debug_logger->info("Testing {:s}...", f->name());
+    gr::logger logger("standard tests");
+    logger.info("Testing {:s}...", f->name());
 
     bool v = verbose >= 2;
     int granularity = f->granularity();
@@ -207,14 +206,13 @@ static bool standard_tests(vmcircbuf_factory* f, int verbose)
         //  = 64MB
     }
 
-    debug_logger->info("{:s}: {:s}", f->name(), ok ? "OK" : "Doesn't work");
+    logger.info("{:s}: {:s}", f->name(), ok ? "OK" : "Doesn't work");
     return ok;
 }
 
 bool vmcircbuf_sysconfig::test_factory(vmcircbuf_factory* f, int verbose)
 {
-    logger_ptr logger, debug_logger;
-    gr::configure_default_loggers(logger, debug_logger, "gr::vmcircbuf_sysconfig");
+    gr::logger logger("gr::vmcircbuf_sysconfig");
     // Install local signal handlers for SIGSEGV and SIGBUS.
     // If something goes wrong, these signals may be invoked.
 
@@ -231,13 +229,13 @@ bool vmcircbuf_sysconfig::test_factory(vmcircbuf_factory* f, int verbose)
     try {
         return standard_tests(f, verbose);
     } catch (gr::signal& sig) {
-        debug_logger->info(
+        logger.info(
             "vmcircbuf_factory::test_factory ({:s}): caught {:s}", f->name(), sig.name());
         return false;
     } catch (...) {
-        debug_logger->warn("vmcircbuf_factory::test_factory ({:s}) some "
-                           "kind of uncaught exception.",
-                           f->name());
+        logger.warn(
+            "vmcircbuf_factory::test_factory ({:s}) some kind of uncaught exception.",
+            f->name());
         return false;
     }
     return false; // never gets here.  shut compiler up.

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -7,17 +7,13 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
  */
-
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "vmcircbuf.h"
 #include "vmcircbuf_prefs.h"
 #include <gnuradio/sys_paths.h>
 #include <string_view>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <string>
 namespace fs = std::filesystem;
 
@@ -47,29 +43,33 @@ log_ioerror(const std::string& who, const fs::path& path, const stream_t& stream
 {
     gr::logger logger(std::string{ "vmcircbuf_prefs::" } + who);
     logger.set_level(logging::singleton().default_level());
-    logger.info("{} failed to open: bad {}, fail {}, eof {}",
+    logger.warn("{} failed to open: bad {}, fail {}, eof {}",
                 path.string(),
                 static_cast<bool>(stream.badbit),
                 static_cast<bool>(stream.failbit),
                 static_cast<bool>(stream.eofbit));
 }
 
-std::string vmcircbuf_prefs::get(std::string_view key)
+std::optional<std::string> vmcircbuf_prefs::get(std::string_view key)
 {
     auto path = pathname(key);
     gr::thread::scoped_lock guard(s_vm_mutex);
     std::ifstream in_file(path, std::ios::in | std::ios::binary);
     if (!in_file.good()) {
-        log_ioerror("get", path, in_file);
+        log_ioerror("get(open)", path, in_file);
         return {};
     }
-    // enable exceptions now, after we've gracefully return empty string for non-existent
-    // files etc
-    in_file.exceptions(std::ios_base::badbit | std::ios_base::failbit);
-    return { std::istreambuf_iterator<char>{ in_file }, {} };
+
+    try {
+        in_file.exceptions(std::ios_base::badbit | std::ios_base::failbit);
+        return { { std::istreambuf_iterator<char>{ in_file }, {} } };
+    } catch (const std::ios_base::failure& fail) {
+        log_ioerror("get(read)", path, in_file);
+        return {};
+    }
 }
 
-void vmcircbuf_prefs::set(std::string_view key, std::string_view value)
+bool vmcircbuf_prefs::set(std::string_view key, std::string_view value)
 {
     gr::logger logger("vmcircbuf_prefs::set");
     logger.set_level(logging::singleton().default_level());
@@ -80,12 +80,20 @@ void vmcircbuf_prefs::set(std::string_view key, std::string_view value)
 
     std::ofstream out_file(path, std::ios::out | std::ios::binary | std::ios::trunc);
     if (!out_file.good()) {
-        log_ioerror("set", path, out_file);
-        return;
+        log_ioerror("set(open)", path, out_file);
+        return false;
     }
 
-    out_file.exceptions(std::ios_base::badbit | std::ios_base::failbit);
-    out_file << value;
+    try {
+        out_file.exceptions(std::ios_base::badbit | std::ios_base::failbit);
+        out_file << value;
+        out_file.close();
+        return true;
+    } catch (const std::ios_base::failure& fail) {
+        log_ioerror("set(write)", path, out_file);
+        logger.error("Could not write vmcircbuf preference.");
+    }
+    return false;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.h
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/api.h>
 #include <string_view>
+#include <optional>
 #include <string>
 
 namespace gr {
@@ -20,8 +21,8 @@ namespace gr {
 class GR_RUNTIME_API vmcircbuf_prefs
 {
 public:
-    static std::string get(std::string_view key);
-    static void set(std::string_view key, std::string_view value);
+    static std::optional<std::string> get(std::string_view key);
+    static bool set(std::string_view key, std::string_view value);
 };
 
 } /* namespace gr */


### PR DESCRIPTION
## Description
<!--- Why this change? What problem does it solve? -->

User reported they saw errors that required them to start GNU Radio twice: they were misunderstanding the informational output that the vmcircbuf preferences file couldn't be read as error.

Fix that, and on the way, get rid of the old-style logger config.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
