### PR TITLE
uhd: cmake: Fix PyQt6 module check

### DIFF
--- a/gr-uhd/CMakeLists.txt
+++ b/gr-uhd/CMakeLists.txt
@@ -24,7 +24,11 @@ else()
     set(UHD_FOUR_POINT_OH_RFNOC FALSE)
 endif()
 
-gr_python_check_module("PyQt6" PyQt6 True PYQT_FOUND)
+gr_python_check_module(
+    DESC "PyQt6"
+    MODULE PyQt6
+    VAR PYQT_FOUND
+)
 
 # Check for plotting dependencies
 gr_python_check_module(

--- a/gr-uhd/CMakeLists.txt
+++ b/gr-uhd/CMakeLists.txt
@@ -24,7 +24,11 @@ else()
     set(UHD_FOUR_POINT_OH_RFNOC FALSE)
 endif()
 
-gr_python_check_module("PyQt5" PyQt5 True PYQT5_FOUND)
+gr_python_check_module(
+    DESC "PyQt5"
+    MODULE PyQt5
+    VAR PYQT5_FOUND
+)
 
 # Check for plotting dependencies
 gr_python_check_module(


### PR DESCRIPTION
The changes in 24e9f2b were not applied to gr-uhd/CMakeLists.txt, which led to a UHD-specific GUI widget (uhd_msg_push_button) to never get installed.

See commit message; we hadn't applied some changes that we applied elsewhere here, and as a consequence, a file never got installed.

## Description

The file now *does* get installed.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

(This is mandatory. If you can't build GNU Radio, please come [talk to us](https://wiki.gnuradio.org/index.php?title=Chat) before opening the PR.)

## Which blocks/areas does this affect?

UHD message push button.

## Testing Done

I built & installed GR with and without the fix. With the fix, the file is now installed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. (not necessary)
- [x] I have added tests to cover my changes, and all previous tests pass.
