### PR TITLE
qtgui: fix out-of-bounds read in vector sink

### DIFF
--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -279,7 +279,7 @@ int vector_sink_f_impl::work(int noutput_items,
     for (int i = 0; i < noutput_items; i++) {
         if (gr::high_res_timer_now() - d_last_time > d_update_time) {
             for (int n = 0; n < d_nconnections; n++) {
-                in = ((const float*)input_items[n]) + d_vlen;
+                in = ((const float*)input_items[n]) + i * d_vlen;
                 for (unsigned int x = 0; x < d_vlen; x++) {
                     d_magbufs[n][x] =
                         (double)((1.0 - d_vecavg) * d_magbufs[n][x] + (d_vecavg)*in[x]);


### PR DESCRIPTION
## Description
The QT GUI Vector Sink exhibits a massive rendering delay and reads garbage data when input vectors are supplied slowly. The root cause is an incorrect buffer offset calculation in the work loop: `in = ((const float*)input_items[n]) + d_vlen;`. This ignores the outer chunk iterator `i` and hardcodes a read starting from the second vector. When `noutput_items` is 1, this reads `d_vlen` floats past the end of the provided buffer into uninitialized or stale ring buffer memory.

The fixed offset `+ d_vlen` was replaced with `+ i * d_vlen`. This properly indexes the `i`-th contiguous vector inside `input_items[n]`, preventing out-of-bounds reads and ensuring the vector sink displays the mathematically correct input item. 

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue
Fixes #8152

## Which blocks/areas does this affect?
qtgui / vector_sink_f

## Testing Done
- Traced `sync_block` signature mapping to confirm `sizeof(float) * vlen` translates to exact item counts matching `noutput_items`.
- Verified offset semantics against GNU Radio's internal ring buffer bounds.
- Validated that indexing via `i * d_vlen` perfectly aligns with memory layout inside the `for (int i = 0; i < noutput_items; i++)` bounds.

## Checklist
- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
