### PR TITLE
grc: Fix incorrect parameter documentation

### DIFF
--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -26,7 +26,7 @@ class DrawingArea(Gtk.DrawingArea):
         Connect event handlers.
 
         Args:
-            main_window: the main_window containing all flow graphs
+            flow_graph: the flow graph to draw
         """
         Gtk.DrawingArea.__init__(self)
 

--- a/grc/gui/ParserErrorsDialog.py
+++ b/grc/gui/ParserErrorsDialog.py
@@ -22,7 +22,7 @@ class ParserErrorsDialog(Gtk.Dialog):
         Properties dialog constructor.
 
         Args:
-            block: a block instance
+            error_logs: the parser error logs to display
         """
         GObject.GObject.__init__(self, title='Parser Errors', buttons=(
             Gtk.STOCK_CLOSE, Gtk.ResponseType.ACCEPT))

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -206,8 +206,6 @@ class FlowGraph(CoreFlowgraph, Drawable):
         """
         Reload flow-graph (with updated blocks)
 
-        Args:
-            page: the page to reload (None means current)
         Returns:
             False if some error occurred during import
         """

--- a/grc/workflows/common.py
+++ b/grc/workflows/common.py
@@ -26,7 +26,7 @@ def add_xterm_to_run_command(run_command_args, xterm_executable):
     """Add xterm to the run command.
 
     Args:
-        run_command: the run command
+        run_command_args: the run command arguments
 
     Returns:
         the run command with xterm added


### PR DESCRIPTION
## Description

Several docstrings in GRC (GNU Radio Companion) document parameters that do not match their function signatures:

- `DrawingArea.__init__` documents `main_window`, but the parameter is `flow_graph`.
- `add_xterm_to_run_command` documents `run_command`, but the parameter is `run_command_args`.
- `ParserErrorsDialog.__init__` documents `block` ("a block instance"), but the parameter is `error_logs`.
- `FlowGraph.reload` takes no arguments, but documents a `page` parameter.

This corrects the documented names/entries to match each signature. Documentation-only change; no behaviour is affected.
