### PR TITLE
8160: Ensure fft result size is verified before truncation

### DIFF
--- a/gr-fft/python/fft/qa_fft.py
+++ b/gr-fft/python/fft/qa_fft.py
@@ -129,6 +129,7 @@ class test_fft(gr_unittest.TestCase):
         pass
 
     def assert_fft_ok2(self, expected_result, result_data):
+        self.assertEqual(self.fft_size, len(result_data))
         expected_result = expected_result[:len(result_data)]
         self.assertComplexTuplesAlmostEqual2(expected_result, result_data,
                                              abs_eps=1e-9, rel_eps=4e-4)


### PR DESCRIPTION
This prevents qa_fft tests silently passing if the resulting data is smaller then the fft_size

## Description
This change prevents a potential issue of undetected test failures in qa_fft

## Declaration of Willingness To Own

- [X] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Which blocks/areas does this affect?

## Testing Done

Tests pass

## Checklist
- [X] I am proposing a change I understand and have tested to be effective.
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.

This closes issue 8160..