### PR TITLE
grc: fix 'Main - After Init' snippet not called for hier blocks

### DIFF
--- a/grc/workflows/python_bokeh_gui/flow_graph_bokeh_gui.py.mako
+++ b/grc/workflows/python_bokeh_gui/flow_graph_bokeh_gui.py.mako
@@ -221,6 +221,9 @@ def main(top_block_cls=${class_name}, options=None):
     # Create Top Block instance
     tb = top_block_cls(${ ', '.join(params_eq_list) })
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
+    for blk in tb.__dict__.values():
+        if hasattr(blk, 'after_main_hook'):
+            blk.after_main_hook()
     try:
         tb.start()
         ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}

--- a/grc/workflows/python_hb_nogui/flow_graph_hb_nogui.py.mako
+++ b/grc/workflows/python_hb_nogui/flow_graph_hb_nogui.py.mako
@@ -159,6 +159,11 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         ${ indent(connection.rstrip()) }
         % endfor
         % endif
+% if snippets['main_after_init']:
+
+    def after_main_hook(self):
+        snippets_main_after_init(self)
+% endif
 
 ########################################################
 ## Create Callbacks

--- a/grc/workflows/python_hb_qt_gui/flow_graph_hb_qt_gui.py.mako
+++ b/grc/workflows/python_hb_qt_gui/flow_graph_hb_qt_gui.py.mako
@@ -167,6 +167,11 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         ${ indent(connection.rstrip()) }
         % endfor
         % endif
+% if snippets['main_after_init']:
+
+    def after_main_hook(self):
+        snippets_main_after_init(self)
+% endif
 
 ########################################################
 ## Create Callbacks

--- a/grc/workflows/python_nogui/flow_graph_nogui.py.mako
+++ b/grc/workflows/python_nogui/flow_graph_nogui.py.mako
@@ -222,6 +222,10 @@ def main(top_block_cls=${class_name}, options=None):
     % endif
     tb = top_block_cls(${ ', '.join(params_eq_list) })
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
+    for blk in tb.__dict__.values():
+        if hasattr(blk, 'after_main_hook'):
+            blk.after_main_hook()
+
     def sig_handler(sig=None, frame=None):
         % for m in monitors:
         % if m.params['en'].get_value() == 'True':

--- a/grc/workflows/python_qt_gui/flow_graph_qt_gui.py.mako
+++ b/grc/workflows/python_qt_gui/flow_graph_qt_gui.py.mako
@@ -280,6 +280,9 @@ def main(top_block_cls=${class_name}, options=None):
 
     tb = top_block_cls(${ ', '.join(params_eq_list) })
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
+    for blk in tb.__dict__.values():
+        if hasattr(blk, 'after_main_hook'):
+            blk.after_main_hook()
     % if flow_graph.get_option('run'):
     tb.start(${flow_graph.get_option('max_nouts') or ''})
     tb.flowgraph_started.set()


### PR DESCRIPTION
grc: fix 'Main - After Init' snippet not called for hier blocks

Add after_main_hook() to hier block classes and call it from top-block main() for all hier block sub-instances.

Fixes: https://github.com/gnuradio/gnuradio/issues/8163

## Description

In GRC, the "Main - After Init" code snippet section allows users to run custom code after a flow graph is initialized. For **top blocks**, this works correctly — the snippet is emitted as a `snippets_main_after_init()` function and called in `main()` right after the top block is instantiated.

For **hierarchical blocks**, the function was correctly *defined* at the top of the generated file, but was **never called anywhere**. Since hier blocks have no `main()` function of their own, the snippet was silently ignored.

The fix follows the approach suggested by @marcusmueller in the issue:

1. **In hier block templates** (`python_hb_nogui`, `python_hb_qt_gui`): generate an `after_main_hook()` method on the hier block class. This method calls `snippets_main_after_init(self)` and is only emitted when a "Main - After Init" snippet is present.

2. **In every top-block template** (`python_nogui`, `python_qt_gui`, `python_bokeh_gui`): after the existing `snippets_main_after_init(tb)` call, iterate `tb.__dict__.values()` to find any hier block sub-instances that expose `after_main_hook()` and call it.

**Files changed:**
- `grc/workflows/python_hb_nogui/flow_graph_hb_nogui.py.mako`
- `grc/workflows/python_hb_qt_gui/flow_graph_hb_qt_gui.py.mako`
- `grc/workflows/python_nogui/flow_graph_nogui.py.mako`
- `grc/workflows/python_qt_gui/flow_graph_qt_gui.py.mako`
- `grc/workflows/python_bokeh_gui/flow_graph_bokeh_gui.py.mako`

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue

Fixes #8163

## Which blocks/areas does this affect?

GRC Python code generation — specifically the Mako templates for hierarchical blocks (`python_hb_nogui`, `python_hb_qt_gui`) and all Python top-block workflow templates (`python_nogui`, `python_qt_gui`, `python_bokeh_gui`).

## Testing Done

- Manually inspected the generated output of a hier block with a "Main - After Init" snippet and confirmed `after_main_hook()` is now present and called.
- Verified that top blocks without any hier blocks are unaffected (the `for blk in tb.__dict__.values()` loop runs harmlessly with no `after_main_hook` matches).
- Verified that hier blocks *without* a "Main - After Init" snippet do not have `after_main_hook()` generated (guard condition is in place).

## Checklist

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit.
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
