### PR TITLE
runtime: make qa_dictionary_logger independent of log config

### DIFF
--- a/gnuradio-runtime/lib/qa_dictionary_logger.cc
+++ b/gnuradio-runtime/lib/qa_dictionary_logger.cc
@@ -9,7 +9,6 @@
 #include <gnuradio/dictionary_logger_backend.h>
 
 #include <gnuradio/logger.h>
-#include <gnuradio/prefs.h>
 
 #include <spdlog/sinks/base_sink.h>
 #include <boost/test/tools/old/interface.hpp>
@@ -19,8 +18,12 @@
 
 BOOST_AUTO_TEST_CASE(t1)
 {
-    gr::prefs::singleton()->set_string("LOG", "log_level", "info");
     auto& logging_system = gr::logging::singleton();
+    // The default backend level is latched from prefs (config files and
+    // GR_CONF_LOG_LOG_LEVEL) when the logging singleton is constructed, so
+    // override it explicitly to keep this test independent of the
+    // environment it runs in.
+    logging_system.set_default_level(gr::log_level::info);
 
     auto backend = std::make_shared<gr::dictionary_logger_backend>(); // unfiltered
 
@@ -64,8 +67,8 @@ BOOST_AUTO_TEST_CASE(t1)
 
 BOOST_AUTO_TEST_CASE(t2)
 {
-    gr::prefs::singleton()->set_string("LOG", "log_level", "info");
     auto& logging_system = gr::logging::singleton();
+    logging_system.set_default_level(gr::log_level::info);
 
     // Filter: ignore anything starting with "ignore"
     auto backend = std::make_shared<gr::dictionary_logger_backend>(


### PR DESCRIPTION
## Description

qa_dictionary_logger fails when the surrounding GNU Radio configuration sets log_level above info. The gr::logging constructor reads LOG:log_level from prefs once and latches it into the shared dist_sink, and spdlog filters messages at that sink. So even though the test sets its loggers to info explicitly, the messages never reach the dictionary backend and the map comes up empty.

The test already tried to defend against this with prefs set_string before touching the logging singleton, but that has two holes. GR_CONF_LOG_LOG_LEVEL bypasses set_string entirely because prefs::get_string checks environment variables before the in memory map, and the trick only works while the logging singleton has not been constructed yet.

This change drops the prefs manipulation and sets the backend level directly through the public logging::set_default_level() API, which works no matter what the config file or environment says and no matter when the singleton was constructed.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue

Fixes #7046

## Which blocks/areas does this affect?

gnuradio-runtime only, and only the QA test for the dictionary logger backend. No library code changes.

## Testing Done

Reproduced the reported failure on main before the change, GR_CONF_LOG_LOG_LEVEL=error produces exactly the three check failures from the issue (qa_dictionary_logger.cc lines 46, 61, 109). After the change the test passes in all of these environments:

1. clean environment, no config
2. config.conf containing log_level = error (via GR_PREFS_PATH)
3. GR_CONF_LOG_LOG_LEVEL=error
4. both at once with log and debug levels set to off

Full ctest suite of the runtime component passes (16/16).

## Checklist

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit.
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated the documentation where necessary. (not applicable, test only change)
- [x] I have added tests to cover my changes, and all previous tests pass. (no added tests but all tests pass)