### PR TITLE
qtgui: support int32 in number sink

### DIFF
--- a/gr-qtgui/examples/Number_Sink_int32.grc
+++ b/gr-qtgui/examples/Number_Sink_int32.grc
@@ -1,0 +1,173 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: Number_Sink_int32
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Number_Sink int32 demo
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 12.0]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: amp
+  id: variable
+  parameters:
+    comment: ''
+    value: '100000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 12.0]
+    rotation: 0
+    state: enabled
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [192, 12.0]
+    rotation: 0
+    state: enabled
+- name: analog_sig_source_x_0
+  id: analog_sig_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: amp
+    comment: ''
+    freq: '0.1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: '0'
+    phase: '0'
+    samp_rate: samp_rate
+    showports: 'False'
+    type: int
+    waveform: analog.GR_COS_WAVE
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [40, 156.0]
+    rotation: 0
+    state: true
+- name: blocks_throttle2_0
+  id: blocks_throttle2
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    limit: auto
+    maximum: '0.1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: int
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [256, 188.0]
+    rotation: 0
+    state: enabled
+- name: qtgui_number_sink_0
+  id: qtgui_number_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    autoscale: 'False'
+    avg: '0'
+    color1: ("black", "black")
+    color10: ("black", "black")
+    color2: ("black", "black")
+    color3: ("black", "black")
+    color4: ("black", "black")
+    color5: ("black", "black")
+    color6: ("black", "black")
+    color7: ("black", "black")
+    color8: ("black", "black")
+    color9: ("black", "black")
+    comment: ''
+    factor1: '1'
+    factor10: '1'
+    factor2: '1'
+    factor3: '1'
+    factor4: '1'
+    factor5: '1'
+    factor6: '1'
+    factor7: '1'
+    factor8: '1'
+    factor9: '1'
+    graph_type: qtgui.NUM_GRAPH_HORIZ
+    gui_hint: ''
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    max: amp
+    min: -amp
+    name: '"int32 input"'
+    nconnections: '1'
+    type: int
+    unit1: ''
+    unit10: ''
+    unit2: ''
+    unit3: ''
+    unit4: ''
+    unit5: ''
+    unit6: ''
+    unit7: ''
+    unit8: ''
+    unit9: ''
+    update_time: '0.10'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [432, 172.0]
+    rotation: 0
+    state: true
+
+connections:
+- [analog_sig_source_x_0, '0', blocks_throttle2_0, '0']
+- [blocks_throttle2_0, '0', qtgui_number_sink_0, '0']
+
+metadata:
+  file_format: 1

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -12,9 +12,12 @@ parameters:
     label: Input Type
     category: General
     dtype: enum
-    options: [float, short, byte]
+    options: [float, int, short, byte]
     option_attributes:
-        size: [gr.sizeof_float, gr.sizeof_short, gr.sizeof_char]
+        itemtype: [qtgui.number_sink.item_type_t.FLOAT32, qtgui.number_sink.item_type_t.INT32,
+            qtgui.number_sink.item_type_t.INT16, qtgui.number_sink.item_type_t.INT8]
+        cpp_itemtype: ["qtgui::number_sink::item_type_t::FLOAT32", "qtgui::number_sink::item_type_t::INT32",
+            "qtgui::number_sink::item_type_t::INT16", "qtgui::number_sink::item_type_t::INT8"]
     hide: part
 -   id: autoscale
     label: Autoscale
@@ -247,7 +250,7 @@ templates:
             win = 'self._%s_win'%id
         %>\
         qtgui.number_sink(
-            ${type.size},
+            ${type.itemtype},
             ${avg},
             ${graph_type},
             ${nconnections},
@@ -293,7 +296,7 @@ cpp_templates:
             win = '_%s_win'%id
         %>\
         ${id} = qtgui::number_sink::make(
-            ${type.size},
+            ${type.cpp_itemtype},
             ${avg},
             ${graph_type.cpp_opts},
             ${nconnections},

--- a/gr-qtgui/include/gnuradio/qtgui/number_sink.h
+++ b/gr-qtgui/include/gnuradio/qtgui/number_sink.h
@@ -37,14 +37,11 @@ namespace qtgui {
  * the display simply samples a value in the data stream based on
  * the update time of this block.
  *
- * Note that due to a flaw in the implementation, this block
- * cannot receive integer value inputs. It will take chars,
- * shorts, and floats and properly convert them by setting
- * itemsize of the constructor to one of these three values
- * (sizeof_char, sizeof_short, and sizeof_float, respectively). If
- * using integers, the block treats these as floats. Instead, put
- * the integer input stream through an gr::blocks::int_to_float
- * converter block.
+ * The block reads 32-bit floats and 32-, 16- and 8-bit signed
+ * integers. The type of the input streams is selected with the
+ * item_type_t argument of the constructor. Items are converted to
+ * float before they are displayed, so integers that need more than 24
+ * bits of mantissa are rounded.
  */
 class QTGUI_API number_sink : virtual public sync_block
 {
@@ -53,7 +50,37 @@ public:
     typedef std::shared_ptr<number_sink> sptr;
 
     /*!
+     * \brief Type of the items on the input streams
+     */
+    enum class item_type_t {
+        FLOAT32, //!< 32 bit floating point
+        INT32,   //!< 32 bit signed integer
+        INT16,   //!< 16 bit signed integer
+        INT8,    //!< 8 bit signed integer
+    };
+
+    /*!
      * \brief Build a number sink
+     *
+     * \param itemtype Type of the items on the input streams
+     * \param average Averaging coefficient (0 - 1)
+     * \param graph_type Type of graph to use (number_sink::graph_t)
+     * \param nconnections number of signals connected to sink
+     * \param parent a QWidget parent object, if any
+     */
+    static sptr make(item_type_t itemtype,
+                     float average = 0,
+                     graph_t graph_type = NUM_GRAPH_HORIZ,
+                     int nconnections = 1,
+                     QWidget* parent = NULL);
+
+    /*!
+     * \brief Build a number sink from an item size
+     *
+     * Kept for backwards compatibility. One byte selects INT8, two bytes
+     * INT16 and four bytes FLOAT32; any other size throws
+     * std::runtime_error. Four bytes cannot mean INT32 here, so int32
+     * inputs need the item_type_t overload.
      *
      * \param itemsize Size of input item stream
      * \param average Averaging coefficient (0 - 1)

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -40,7 +40,7 @@ namespace qtgui {
 
 namespace {
 
-size_t item_size(number_sink::item_type_t itemtype)
+constexpr size_t item_size(number_sink::item_type_t itemtype)
 {
     switch (itemtype) {
     case number_sink::item_type_t::FLOAT32:
@@ -55,7 +55,7 @@ size_t item_size(number_sink::item_type_t itemtype)
     throw std::runtime_error("number_sink: unknown item type");
 }
 
-number_sink::item_type_t item_type_from_size(size_t itemsize)
+constexpr number_sink::item_type_t item_type_from_size(size_t itemsize)
 {
     // Four bytes keep meaning float here: an item size cannot tell FLOAT32
     // and INT32 apart, and float is what this constructor has always meant.

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -21,7 +21,10 @@
 #include <volk/volk.h>
 
 #include <cmath>
+#include <cstdint>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 
 #ifdef _MSC_VER
 #define isfinite _finite
@@ -35,19 +38,66 @@ using ::_finite;
 namespace gr {
 namespace qtgui {
 
+namespace {
+
+size_t item_size(number_sink::item_type_t itemtype)
+{
+    switch (itemtype) {
+    case number_sink::item_type_t::FLOAT32:
+        return sizeof(float);
+    case number_sink::item_type_t::INT32:
+        return sizeof(int32_t);
+    case number_sink::item_type_t::INT16:
+        return sizeof(int16_t);
+    case number_sink::item_type_t::INT8:
+        return sizeof(int8_t);
+    }
+    throw std::runtime_error("number_sink: unknown item type");
+}
+
+number_sink::item_type_t item_type_from_size(size_t itemsize)
+{
+    // Four bytes keep meaning float here: an item size cannot tell FLOAT32
+    // and INT32 apart, and float is what this constructor has always meant.
+    switch (itemsize) {
+    case sizeof(int8_t):
+        return number_sink::item_type_t::INT8;
+    case sizeof(int16_t):
+        return number_sink::item_type_t::INT16;
+    case sizeof(float):
+        return number_sink::item_type_t::FLOAT32;
+    }
+    throw std::runtime_error("number_sink: unsupported item size " +
+                             std::to_string(itemsize));
+}
+
+} // namespace
+
+number_sink::sptr number_sink::make(item_type_t itemtype,
+                                    float average,
+                                    graph_t graph_type,
+                                    int nconnections,
+                                    QWidget* parent)
+{
+    return gnuradio::make_block_sptr<number_sink_impl>(
+        itemtype, average, graph_type, nconnections, parent);
+}
+
 number_sink::sptr number_sink::make(
     size_t itemsize, float average, graph_t graph_type, int nconnections, QWidget* parent)
 {
-    return gnuradio::make_block_sptr<number_sink_impl>(
-        itemsize, average, graph_type, nconnections, parent);
+    return make(item_type_from_size(itemsize), average, graph_type, nconnections, parent);
 }
 
-number_sink_impl::number_sink_impl(
-    size_t itemsize, float average, graph_t graph_type, int nconnections, QWidget* parent)
+number_sink_impl::number_sink_impl(item_type_t itemtype,
+                                   float average,
+                                   graph_t graph_type,
+                                   int nconnections,
+                                   QWidget* parent)
     : sync_block("number_sink",
-                 io_signature::make(nconnections, nconnections, itemsize),
+                 io_signature::make(nconnections, nconnections, item_size(itemtype)),
                  io_signature::make(0, 0, 0)),
-      d_itemsize(itemsize),
+      d_itemtype(itemtype),
       d_average(average),
       d_type(graph_type),
       d_nconnections(nconnections),
@@ -61,7 +111,7 @@ number_sink_impl::number_sink_impl(
     }
 
     // Set alignment properties for VOLK
-    const int alignment_multiple = volk_get_alignment() / d_itemsize;
+    const int alignment_multiple = volk_get_alignment() / item_size(d_itemtype);
     set_alignment(std::max(1, alignment_multiple));
 
     initialize();
@@ -83,13 +133,14 @@ void number_sink_impl::initialize()
     }
 
     d_main_gui = new NumberDisplayForm(d_nconnections, d_type, d_parent);
-    switch (d_itemsize) {
-    case sizeof(char):
-    case sizeof(short):
-        d_main_gui->set_display_format(NumberDisplayForm::FORMAT_INT);
-        break;
-    default:
+    switch (d_itemtype) {
+    case item_type_t::FLOAT32:
         d_main_gui->set_display_format(NumberDisplayForm::FORMAT_FLOAT);
+        break;
+    case item_type_t::INT32:
+    case item_type_t::INT16:
+    case item_type_t::INT8:
+        d_main_gui->set_display_format(NumberDisplayForm::FORMAT_INT);
         break;
     }
     d_main_gui->setAverage(d_average);
@@ -242,27 +293,17 @@ void number_sink_impl::_gui_update_trigger()
 
 float number_sink_impl::get_item(const void* input_items, int n)
 {
-    const char* inc;
-    const short* ins;
-    const float* inf;
-
-    switch (d_itemsize) {
-    case (1):
-        inc = (const char*)input_items;
-        return static_cast<float>(inc[n]);
-        break;
-    case (2):
-        ins = (const short*)input_items;
-        return static_cast<float>(ins[n]);
-        break;
-    case (4):
-        inf = (const float*)input_items;
-        return static_cast<float>(inf[n]);
-        break;
-    default:
-        throw std::runtime_error("item size not supported");
+    switch (d_itemtype) {
+    case item_type_t::FLOAT32:
+        return static_cast<const float*>(input_items)[n];
+    case item_type_t::INT32:
+        return static_cast<float>(static_cast<const int32_t*>(input_items)[n]);
+    case item_type_t::INT16:
+        return static_cast<float>(static_cast<const int16_t*>(input_items)[n]);
+    case item_type_t::INT8:
+        return static_cast<float>(static_cast<const int8_t*>(input_items)[n]);
     }
-    return 0;
+    throw std::runtime_error("number_sink: unknown item type");
 }
 
 int number_sink_impl::work(int noutput_items,

--- a/gr-qtgui/lib/number_sink_impl.h
+++ b/gr-qtgui/lib/number_sink_impl.h
@@ -25,7 +25,7 @@ class QTGUI_API number_sink_impl : public number_sink
 private:
     void initialize();
 
-    size_t d_itemsize;
+    const item_type_t d_itemtype;
     float d_average;
     graph_t d_type;
     int d_nconnections;
@@ -57,7 +57,7 @@ private:
     float get_item(const void* input_items, int n);
 
 public:
-    number_sink_impl(size_t itemsize,
+    number_sink_impl(item_type_t itemtype,
                      float average = 0,
                      graph_t graph_type = NUM_GRAPH_HORIZ,
                      int nconnections = 1,

--- a/gr-qtgui/python/qtgui/bindings/docstrings/number_sink_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/number_sink_pydoc_template.h
@@ -24,7 +24,10 @@ static const char* __doc_gr_qtgui_number_sink_number_sink_0 = R"doc()doc";
 static const char* __doc_gr_qtgui_number_sink_number_sink_1 = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_number_sink_make = R"doc()doc";
+static const char* __doc_gr_qtgui_number_sink_make_0 = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_number_sink_make_1 = R"doc()doc";
 
 
 static const char* __doc_gr_qtgui_number_sink_exec_ = R"doc()doc";

--- a/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
@@ -43,15 +43,39 @@ void bind_number_sink(py::module& m)
                gr::sync_block,
                gr::block,
                gr::basic_block,
-               std::shared_ptr<number_sink>>(m, "number_sink", D(number_sink))
+               std::shared_ptr<number_sink>>
+        number_sink_class(m, "number_sink", D(number_sink));
 
-        .def(py::init(&number_sink::make),
+    py::enum_<number_sink::item_type_t>(number_sink_class, "item_type_t")
+        .value("FLOAT32", number_sink::item_type_t::FLOAT32)
+        .value("INT32", number_sink::item_type_t::INT32)
+        .value("INT16", number_sink::item_type_t::INT16)
+        .value("INT8", number_sink::item_type_t::INT8);
+
+    number_sink_class
+
+        .def(py::init(py::overload_cast<number_sink::item_type_t,
+                                        float,
+                                        ::gr::qtgui::graph_t,
+                                        int,
+                                        QWidget*>(&number_sink::make)),
+             py::arg("itemtype"),
+             py::arg("average") = 0,
+             py::arg("graph_type") = ::gr::qtgui::graph_t::NUM_GRAPH_HORIZ,
+             py::arg("nconnections") = 1,
+             py::arg("parent") = nullptr,
+             D(number_sink, make, 0))
+
+
+        .def(py::init(
+                 py::overload_cast<size_t, float, ::gr::qtgui::graph_t, int, QWidget*>(
+                     &number_sink::make)),
              py::arg("itemsize"),
              py::arg("average") = 0,
              py::arg("graph_type") = ::gr::qtgui::graph_t::NUM_GRAPH_HORIZ,
              py::arg("nconnections") = 1,
              py::arg("parent") = nullptr,
-             D(number_sink, make))
+             D(number_sink, make, 1))
 
 
         .def("exec_", &number_sink::exec_, D(number_sink, exec_))

--- a/gr-qtgui/python/qtgui/qa_number_sink.py
+++ b/gr-qtgui/python/qtgui/qa_number_sink.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+from gnuradio import blocks, gr, gr_unittest, qtgui
+
+try:
+    import sip
+except ImportError:
+    from PyQt5 import sip
+
+from PyQt5 import QtWidgets
+
+item_type_t = qtgui.number_sink.item_type_t
+
+# The sink aligns its input on a VOLK boundary, so for single byte items the
+# scheduler only runs it once a fair number of items have piled up.
+NITEMS = 256
+
+
+class test_number_sink(gr_unittest.TestCase):
+
+    def make_sink(self, itemtype_or_size, nconnections=1):
+        return qtgui.number_sink(itemtype_or_size, 0,
+                                 qtgui.NUM_GRAPH_NONE, nconnections, None)
+
+    def value_box(self, sink):
+        """The label showing the value of the first stream.
+
+        NumberDisplayForm arranges its widgets in a grid. Without a bar
+        graph and without a title, the value of stream i sits at row 1,
+        column i, below its name label.
+        """
+        widget = sip.wrapinstance(sink.qwidget(), QtWidgets.QWidget)
+        item = widget.layout().itemAtPosition(1, 0)
+        self.assertIsNotNone(item, "no widget at the value position")
+        box = item.widget()
+        self.assertIsInstance(box, QtWidgets.QLabel)
+        return box
+
+    def displayed_text(self, itemtype_or_size, source):
+        """Run a one source flowgraph and return the text the sink shows."""
+        sink = self.make_sink(itemtype_or_size)
+        tb = gr.top_block()
+        tb.connect(source, sink)
+        tb.run()
+        # run() returns once the sink has posted its update, so a single
+        # pass over the event queue is enough to deliver it.
+        QtWidgets.QApplication.instance().processEvents()
+        return self.value_box(sink).text()
+
+    def display(self, itemtype_or_size, source):
+        return float(self.displayed_text(itemtype_or_size, source))
+
+    def test_item_type_sizes(self):
+        for itemtype, itemsize in ((item_type_t.FLOAT32, gr.sizeof_float),
+                                   (item_type_t.INT32, gr.sizeof_int),
+                                   (item_type_t.INT16, gr.sizeof_short),
+                                   (item_type_t.INT8, gr.sizeof_char)):
+            with self.subTest(itemtype=itemtype):
+                sink = self.make_sink(itemtype)
+                self.assertEqual(
+                    itemsize, sink.input_signature().sizeof_stream_item(0))
+
+    def test_nconnections(self):
+        sink = self.make_sink(item_type_t.INT32, nconnections=3)
+        self.assertEqual(3, sink.input_signature().max_streams())
+
+    def test_float32_values(self):
+        for value in (0.0, 1.5, -2.25, 42.0):
+            with self.subTest(value=value):
+                source = blocks.vector_source_f([value] * NITEMS)
+                self.assertAlmostEqual(
+                    value, self.display(item_type_t.FLOAT32, source), places=3)
+
+    def test_int32_values(self):
+        for value in (0, 1, -1, 42, 123456, -123456):
+            with self.subTest(value=value):
+                source = blocks.vector_source_i([value] * NITEMS)
+                self.assertEqual(
+                    value, self.display(item_type_t.INT32, source))
+
+    def test_int16_values(self):
+        for value in (0, 1, -1, 32767, -32768):
+            with self.subTest(value=value):
+                source = blocks.vector_source_s([value] * NITEMS)
+                self.assertEqual(
+                    value, self.display(item_type_t.INT16, source))
+
+    def test_int8_values(self):
+        # vector_source_b carries unsigned bytes, so the negative cases are
+        # written as the two's complement patterns the sink must read back as
+        # signed values, the way every other byte block in the tree does.
+        for raw, value in ((0, 0), (1, 1), (42, 42), (127, 127),
+                           (255, -1), (128, -128)):
+            with self.subTest(raw=raw):
+                source = blocks.vector_source_b([raw] * NITEMS)
+                self.assertEqual(
+                    value, self.display(item_type_t.INT8, source))
+
+    def test_int32_is_not_read_as_float32(self):
+        # int32 and float32 items are the same size, so the type has to come
+        # from the constructor. Read as float32 these bit patterns are
+        # denormals displayed as zero, not the integers they stand for.
+        for value in (42, 16777216):
+            with self.subTest(value=value):
+                source = blocks.vector_source_i([value] * NITEMS)
+                self.assertEqual(
+                    float(value), self.display(item_type_t.INT32, source))
+
+    def test_display_format_follows_item_type(self):
+        # The same number is rendered as an integer or as a float depending
+        # only on the item type, never on the widget's own state.
+        as_int = self.displayed_text(
+            item_type_t.INT32, blocks.vector_source_i([42] * NITEMS))
+        as_float = self.displayed_text(
+            item_type_t.FLOAT32, blocks.vector_source_f([42.0] * NITEMS))
+        self.assertEqual(42.0, float(as_int))
+        self.assertEqual(42.0, float(as_float))
+        self.assertNotEqual(as_int, as_float)
+
+    def test_itemsize_sizes(self):
+        for itemsize in (gr.sizeof_char, gr.sizeof_short, gr.sizeof_float):
+            with self.subTest(itemsize=itemsize):
+                sink = self.make_sink(itemsize)
+                self.assertEqual(
+                    itemsize, sink.input_signature().sizeof_stream_item(0))
+
+    def test_itemsize_four_bytes_stays_float32(self):
+        source = blocks.vector_source_f([1.5] * NITEMS)
+        self.assertAlmostEqual(
+            1.5, self.display(gr.sizeof_float, source), places=3)
+
+    def test_itemsize_rejects_unsupported_size(self):
+        for itemsize in (0, 3, gr.sizeof_double):
+            with self.subTest(itemsize=itemsize):
+                self.assertRaises(RuntimeError, self.make_sink, itemsize)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_number_sink)


### PR DESCRIPTION
## Description

`number_sink` was told the size of its input items rather than their
type. Since `float32` and `int32` items are both four bytes wide,
`get_item()` interpreted every four-byte item as a float.

For example, an `int32` source producing `42` was displayed as
`0.000000`.

The block now receives the input type explicitly.

## Implementation

- add `number_sink::item_type_t` with `FLOAT32`, `INT32`, `INT16`, and
  `INT8`
- add a typed `make()` overload while retaining the existing
  `itemsize` overload
- store the input type in the implementation and derive the item size
  only where required
- dispatch value conversion and display formatting using the input type
- expose the enum and both overloads in the Python bindings
- make GRC pass the explicit type in Python and C++ generation
- restore the `int` option in the GRC block
- add `qa_number_sink` and an `int32` example flowgraph

The binding source is maintained manually. `bindtool` does not emit the
nested enum and generates an ambiguous
`py::init(&number_sink::make)` after the overload is introduced.

## Compatibility

No existing public `number_sink::make` signature is removed. The new
typed overload is additive. Full ABI compatibility was not formally
assessed.

The existing `itemsize` overload retains its historical mapping:

- 1 byte → `INT8`
- 2 bytes → `INT16`
- 4 bytes → `FLOAT32`

It cannot represent `INT32`; callers must use the typed overload for
that case.

Unsupported sizes still raise `std::runtime_error`, now during
construction rather than during the first call to `work()`.

Byte items are read as `int8_t`, matching GNU Radio's signed byte
datatype and existing consumers such as `time_raster_sink_b` and
`char_to_float`. On platforms and toolchains where plain `char` is
unsigned, negative byte values are now displayed as negative values.

Values still pass through the existing `float` display pipeline, so
`int32` values requiring more than 24 bits of precision may be rounded.

## Testing Done

Built and tested locally on Ubuntu 24.04 with Qt 5.15 using an
out-of-tree Ninja build.

- all tests enabled by the build configuration pass: `178/178`
- `qa_number_sink` passed 100 consecutive executions
- the test reads values from the Number Sink widget and exercises the
  actual display path
- the existing and typed Python constructors were tested separately
- the existing and typed C++ constructors were compiled and executed
- invalid item sizes `0`, `3`, and `8` were tested in C++ and Python
- GRC generation was tested for `float`, `int`, `short`, and `byte` in
  both Python and C++
- generated Python flowgraphs execute successfully
- generated C++ flowgraphs compile successfully
- the existing in-tree Number Sink examples still load and generate
- the installed headers, Python module, libraries, and GRC block were
  tested from a temporary installation prefix
- before the change, an `int32` source producing `42` displayed
  `0.000000`; it now displays `42`

Some GNU Radio modules requiring unavailable external dependencies were
disabled in the local build. The `178/178` result refers to every test
enabled by that build configuration.

## Related Issue

Fixes #5056

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have squashed my commits to have one significant change per
      commit.
- [x] I have signed my commit according to the DCO.
- [x] My code follows the project coding style.
- [x] I have updated the documentation where necessary.
- [x] I have added tests covering the change, and all tests enabled by
      my build configuration pass.
