### PR TITLE
blocks: add fail_if_exists option to file_sink

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/file_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink.h
@@ -34,8 +34,14 @@ public:
      * \param filename name of the file to open and write output to.
      * \param append if true, data is appended to the file instead of
      *        overwriting the initial content.
+     * \param fail_if_exists if true, the constructor throws instead of
+     *        opening the file when \p filename already exists. Takes
+     *        precedence over \p append.
      */
-    static sptr make(size_t itemsize, const char* filename, bool append = false);
+    static sptr make(size_t itemsize,
+                     const char* filename,
+                     bool append = false,
+                     bool fail_if_exists = false);
 };
 
 } /* namespace blocks */

--- a/gr-blocks/include/gnuradio/blocks/file_sink_base.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink_base.h
@@ -32,11 +32,15 @@ protected:
     gr::thread::mutex d_mutex;
     bool d_unbuffered;
     bool d_append;
+    bool d_fail_if_exists;
     gr::logger_ptr d_base_logger;
     gr::logger_ptr d_base_debug_logger;
 
 protected:
-    file_sink_base(const char* filename, bool is_binary, bool append);
+    file_sink_base(const char* filename,
+                   bool is_binary,
+                   bool append,
+                   bool fail_if_exists = false);
 
 public:
     file_sink_base() {}

--- a/gr-blocks/lib/file_sink_base.cc
+++ b/gr-blocks/lib/file_sink_base.cc
@@ -42,8 +42,16 @@
 namespace gr {
 namespace blocks {
 
-file_sink_base::file_sink_base(const char* filename, bool is_binary, bool append)
-    : d_fp(0), d_new_fp(0), d_updated(false), d_is_binary(is_binary), d_append(append)
+file_sink_base::file_sink_base(const char* filename,
+                               bool is_binary,
+                               bool append,
+                               bool fail_if_exists)
+    : d_fp(0),
+      d_new_fp(0),
+      d_updated(false),
+      d_is_binary(is_binary),
+      d_append(append),
+      d_fail_if_exists(fail_if_exists)
 {
     gr::configure_default_loggers(d_base_logger, d_base_debug_logger, "file_sink_base");
     if (!open(filename))
@@ -69,7 +77,11 @@ bool file_sink_base::open(const char* filename)
     int fd;
     int flags;
 
-    if (d_append) {
+    if (d_fail_if_exists) {
+        // O_EXCL makes the existence check and the create atomic, so a file
+        // that appears between a stat() and an open() can't slip through.
+        flags = O_WRONLY | O_CREAT | O_EXCL | OUR_O_LARGEFILE | OUR_O_BINARY;
+    } else if (d_append) {
         flags = O_WRONLY | O_CREAT | O_APPEND | OUR_O_LARGEFILE | OUR_O_BINARY;
     } else {
         flags = O_WRONLY | O_CREAT | O_TRUNC | OUR_O_LARGEFILE | OUR_O_BINARY;

--- a/gr-blocks/lib/file_sink_impl.cc
+++ b/gr-blocks/lib/file_sink_impl.cc
@@ -19,15 +19,20 @@
 namespace gr {
 namespace blocks {
 
-file_sink::sptr file_sink::make(size_t itemsize, const char* filename, bool append)
+file_sink::sptr
+file_sink::make(size_t itemsize, const char* filename, bool append, bool fail_if_exists)
 {
-    return gnuradio::make_block_sptr<file_sink_impl>(itemsize, filename, append);
+    return gnuradio::make_block_sptr<file_sink_impl>(
+        itemsize, filename, append, fail_if_exists);
 }
 
-file_sink_impl::file_sink_impl(size_t itemsize, const char* filename, bool append)
+file_sink_impl::file_sink_impl(size_t itemsize,
+                               const char* filename,
+                               bool append,
+                               bool fail_if_exists)
     : sync_block(
           "file_sink", io_signature::make(1, 1, itemsize), io_signature::make(0, 0, 0)),
-      file_sink_base(filename, true, append),
+      file_sink_base(filename, true, append, fail_if_exists),
       d_itemsize(itemsize)
 {
 }

--- a/gr-blocks/lib/file_sink_impl.h
+++ b/gr-blocks/lib/file_sink_impl.h
@@ -22,7 +22,10 @@ private:
     const size_t d_itemsize;
 
 public:
-    file_sink_impl(size_t itemsize, const char* filename, bool append = false);
+    file_sink_impl(size_t itemsize,
+                   const char* filename,
+                   bool append = false,
+                   bool fail_if_exists = false);
     ~file_sink_impl() override;
 
     int work(int noutput_items,

--- a/gr-blocks/python/blocks/bindings/file_sink_base_python.cc
+++ b/gr-blocks/python/blocks/bindings/file_sink_base_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(file_sink_base.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(ce5dcca3a52128c3c675442eb76dc69f)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7ea7326a184a9cee76cde912a5d8cf36)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/bindings/file_sink_python.cc
+++ b/gr-blocks/python/blocks/bindings/file_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(file_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(7d4fa47d3509d715bbf1dd940304cadf)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c2a110b911bb6f70f2c9944c8c2003d6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -44,6 +44,7 @@ void bind_file_sink(py::module& m)
              py::arg("itemsize"),
              py::arg("filename"),
              py::arg("append") = false,
+             py::arg("fail_if_exists") = false,
              D(file_sink, make))
 
 

--- a/gr-blocks/python/blocks/qa_file_sink.py
+++ b/gr-blocks/python/blocks/qa_file_sink.py
@@ -48,6 +48,46 @@ class test_file_sink(gr_unittest.TestCase):
             result_data.fromfile(datafile, len(data))
         self.assertFloatTuplesAlmostEqual(expected_result, result_data)
 
+    def test_fail_if_exists_raises_when_file_exists(self):
+        # self._datafilename was already created by setUp via
+        # NamedTemporaryFile, so this must fail immediately.
+        self.assertRaises(
+            RuntimeError,
+            blocks.file_sink,
+            gr.sizeof_float,
+            self._datafilename,
+            False,
+            True,
+        )
+
+    def test_fail_if_exists_succeeds_for_new_file(self):
+        os.unlink(self._datafilename)
+
+        data = range(1000)
+        src = blocks.vector_source_f(data)
+        snk = blocks.file_sink(gr.sizeof_float, self._datafilename, False, True)
+        snk.set_unbuffered(True)
+        self.tb.connect(src, snk)
+        self.tb.run()
+        snk.close()
+
+        file_size = os.stat(self._datafilename).st_size
+        self.assertEqual(file_size, 4 * len(data))
+
+    def test_fail_if_exists_false_still_overwrites(self):
+        # default (fail_if_exists=False) must keep working exactly as before
+        # on a file that already exists.
+        data = range(10)
+        src = blocks.vector_source_f(data)
+        snk = blocks.file_sink(gr.sizeof_float, self._datafilename, False, False)
+        snk.set_unbuffered(True)
+        self.tb.connect(src, snk)
+        self.tb.run()
+        snk.close()
+
+        file_size = os.stat(self._datafilename).st_size
+        self.assertEqual(file_size, 4 * len(data))
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_file_sink)


### PR DESCRIPTION
## Description

file_sink currently only supports append or overwrite, so a user who forgets to change the output filename between runs silently loses or corrupts prior data. Add a fail_if_exists constructor argument that, when set, opens the file with O_EXCL so the constructor throws instead of touching an existing file. O_EXCL keeps the existence check and the create atomic, avoiding a TOCTOU race between checking and opening.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue

Fixes #1288

## Which blocks/areas does this affect?

gr-blocks only: `file_sink` / `file_sink_base` (lib, public headers, and their Python bindings).

## Testing Done

Extended `gr-blocks/python/blocks/qa_file_sink.py` with three cases: `fail_if_exists=True` raises when the target file already exists, `fail_if_exists=True` succeeds and writes correctly when the file is new, and the existing default (`fail_if_exists=False`) behavior of overwriting is unchanged. All three pass, and the full `ctest` suite passes except one pre-existing, unrelated failure (`qa_repeat`) that is not touched by this change and fails the same way on `main` without it.

## Checklist

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit.
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
