### PR TITLE
gr-qtgui: actually run tests through xvfb-run

### DIFF
--- a/gr-qtgui/python/qtgui/CMakeLists.txt
+++ b/gr-qtgui/python/qtgui/CMakeLists.txt
@@ -61,7 +61,7 @@ if(ENABLE_TESTING)
         if(CMAKE_CROSSCOMPILING)
             get_filename_component(py_qa_test_file ${py_qa_test_file} NAME)
         endif(CMAKE_CROSSCOMPILING)
-        gr_add_test(${py_qa_test_name} ${QA_PYTHON_EXECUTABLE} -B ${py_qa_test_file})
+        gr_add_test(${py_qa_test_name} ${QA_DISPLAY_SERVER} ${QA_PYTHON_EXECUTABLE} -B ${py_qa_test_file})
     endforeach(py_qa_test_file)
 endif(ENABLE_TESTING)
 


### PR DESCRIPTION
Restore the intended behavior from pull request #3545. 

The QA_DISPLAY_SERVER variable is set when xvfb-run is found, but accidentally was dropped from the gr_add_test invocation in f37a98b95af12603c4564f61707672570b3cce06, causing qa_qtgui to run without a display.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Checklist

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
