### PR TITLE
runtime: lock the mutex when reading a message queue's depth

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -281,6 +281,7 @@ public:
     //! How many messages in the queue?
     size_t nmsgs(pmt::pmt_t which_port)
     {
+        gr::thread::scoped_lock guard(mutex);
         if (msg_queue.find(which_port) == msg_queue.end())
             throw std::runtime_error("port does not exist!");
         return msg_queue[which_port].size();

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(basic_block.h)                                             */
-/* BINDTOOL_HEADER_FILE_HASH(ec5e22df23ed02772ff9008b0f97b111)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5e6544d322c3ce150f464045119e1496)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description

`basic_block::nmsgs()` reads `msg_queue[port].size()` without holding the block's mutex, which is not thread safe. libstdc++ computes `deque::size()` from several pointers, so a read racing a push can return an arbitrary value.

A specific problem that arises from this: `tpb_thread_body` calls `nmsgs()` once per scheduler pass for every port that has no registered message handler, and deletes the head of the queue when the count exceeds `max_messages`. A corrupted read typically satisfies the threshold (some bogus value like 18446744073709551615), so a valid message is discarded from the queue even if it's actually below `max_messages`.

The blocks that reach this branch are the ones polling their own message port from the work path instead of registering a handler: `pdu_to_tagged_stream`, `hdlc_framer_pb` and `rep_msg_sink`.

This was discovered when tracking down the root cause of rare, seemingly random warnings emitted by `pdu_to_tagged_stream` when I was very confident that the queue was nowhere near full at any point.

```
tpb_thread_body :warning: pdu_to_tagged_stream(N) received a message to port
pdus which has no handler registered. Message discarded.
```

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue

#7970 is superficially related since the reporter got the same `pdu_to_tagged_stream` warnings, but in that case it appears that the messages may have actually been piling up in the queue and exceeding the `max_messages` depth.

Otherwise I did not find related issues or discussion of this.

## Which blocks/areas does this affect?

Blocks that read from their own message ports in `work()` without registering a message handler.

## Testing Done

I came up with a minimal C++ test case that reliably reproduces the issue, and confirmed that it fails consistently before this fix (8/8 runs got glaringly wrong return values from `nmsgs()` at least once) and consistently passes (20/20 runs) with the fix. It runs without the scheduler involved so it can trigger the race more frequently and thus not take nearly as long to get a result, but I believe it's still a valid demonstration. Since it's a race condition detector it's non-deterministic so probably not suitable for a unit test.

[qa_basic_block.cpp](https://github.com/user-attachments/files/31322572/qa_basic_block.cpp)

For good measure I also tested before and after the fix with a real flowgraph (`random_pdu` into `pdu_to_tagged_stream`). Without the fix 18 PDUs were dropped out of 33.3M. After the fix, same test dropped 0 PDUs. In both cases I had set `max_messages` to 1,000,000,000 (1B) to effectively rule out dropped PDUs being caused by a backed up queue.

## Checklist

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass. (**I'm not aware of a way to deterministically test for this failure mode**)
