### PR TITLE
runtime: add a QA test for enable_realtime_scheduling

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -34,6 +34,7 @@ if(ENABLE_TESTING)
                             qa_prefs.py
                             qa_python_logging.py
                             qa_random.py
+                            qa_realtime.py
                             qa_sys_paths.py
                             qa_tag_utils.py
                             # Sadly, this still results in a deadlock due to

--- a/gnuradio-runtime/python/gnuradio/gr/qa_realtime.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_realtime.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 R Sai Pranav
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest
+
+
+class test_realtime(gr_unittest.TestCase):
+
+    def test_001_enable_realtime_scheduling_is_callable(self):
+        # Whether real time scheduling can actually be enabled depends on the
+        # privileges of whoever runs the suite, so this deliberately does not
+        # assert RT_OK. It asserts that the call is reachable from Python and
+        # reports a status, which is what was missing: the function had become
+        # uncallable and nothing detected it.
+        status = gr.enable_realtime_scheduling()
+
+        self.assertIsInstance(status, gr.rt_status_t)
+        self.assertIn(status,
+                      (gr.RT_OK,
+                       gr.RT_NOT_IMPLEMENTED,
+                       gr.RT_NO_PRIVS,
+                       gr.RT_OTHER_ERROR))
+
+    def test_002_status_values_are_exposed(self):
+        # The status values are what a caller checks the return against, so
+        # they have to survive the bindings as well as the function does.
+        self.assertEqual(int(gr.RT_OK), 0)
+        self.assertEqual(int(gr.RT_NOT_IMPLEMENTED), 1)
+        self.assertEqual(int(gr.RT_NO_PRIVS), 2)
+        self.assertEqual(int(gr.RT_OTHER_ERROR), 3)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_realtime)


### PR DESCRIPTION
Closes #3592.

`gr::enable_realtime_scheduling()` had once become uncallable from Python and nothing noticed, because no test ever called it. This adds `qa_realtime.py`.

## What it checks

- The function is reachable from Python and returns an `rt_status_t`.
- The `rt_status_t` values still cross the bindings, since a caller compares the return value against them. The function being reachable is not much use if `RT_NO_PRIVS` is not.

## What it deliberately does not check

It does not assert `RT_OK`. Whether real time scheduling can actually be enabled depends on the privileges of whoever runs the suite, and on hosts without `sched_setscheduler` the implementation returns `RT_NOT_IMPLEMENTED` — my machine is one, `HAVE_SCHED_SETSCHEDULER` fails there. Asserting success would pass for a developer running as root and fail everywhere else, which is worse than no test.

The issue says as much: *"Doesn't actually matter whether enabling works; the function wasn't callable and that was impossible to systematically detect."*

## The CMakeLists change

`qa_realtime.py` is added to `py_qa_test_files`. That list is not optional bookkeeping: the `file(GLOB "qa_*.py")` immediately above it is overwritten by the explicit `set()` on the next line, so a test file that is not named there is silently never executed. Adding the file alone would have looked correct and run nothing.

## Verification

Built with `-DENABLE_TESTING=ON -DENABLE_PYTHON=ON` and ran it both ways:

- **passes** as written — `Ran 2 tests ... OK`;
- **fails** when the regression it targets is simulated. Deleting the symbol before the call (`del gr.enable_realtime_scheduling`) gives `AttributeError: module 'gnuradio.gr' has no attribute 'enable_realtime_scheduling'` and `FAILED (errors=1)`.

I checked the negative case because a test that cannot fail is indistinguishable from one that passes, and this issue exists precisely because nothing was exercising the call.

One note on my environment rather than on this change: every Python QA test in the build tree fails on macOS with an `@rpath` error for `libgnuradio-runtime` — `qa_prefs`, `qa_random` and `qa_sys_paths` fail identically on this checkout without my patch. I ran the test with `DYLD_LIBRARY_PATH` pointed at the built libraries instead. That looks like a pre-existing macOS build-tree issue and I have not touched it here; happy to open a separate issue if it is not already known.
