### PR TITLE
uhd: cmake: Fix PyQt5 module check

### DIFF
--- a/gr-uhd/CMakeLists.txt
+++ b/gr-uhd/CMakeLists.txt
@@ -17,7 +17,11 @@ else()
     set(UHD_FOUR_POINT_OH_RFNOC FALSE)
 endif()
 
-gr_python_check_module("PyQt5" PyQt5 True PYQT5_FOUND)
+gr_python_check_module(
+    DESC "PyQt5"
+    MODULE PyQt5
+    VAR PYQT5_FOUND
+)
 
 ########################################################################
 # Register component


### PR DESCRIPTION
Copies the original #8153 to apply to maint-3.10.

(we don't do Qt5 on main anymore)

The changes in 24e9f2b were not applied to gr-uhd/CMakeLists.txt, which led to a UHD-specific GUI widget (uhd_msg_push_button) to never get installed.

See commit message; we hadn't applied some changes that we applied elsewhere here, and as a consequence, a file never got installed.
