### PR TITLE
Fix agc3 analog: clamp agc3 gain to max_gain

### DIFF
--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -168,6 +168,11 @@ int agc3_cc_impl::work(int noutput_items,
         } else {
             d_gain *= 1 - d_decay;
         }
+
+        if (d_max_gain > 0.0f) {
+            d_gain = std::min(d_gain, d_max_gain);
+        }
+
         // scale output values
         for (auto out_idx = index; out_idx < index + d_iir_update_decim; ++out_idx) {
             out[out_idx] = in[out_idx] * d_gain;

--- a/gr-analog/python/analog/qa_agc.py
+++ b/gr-analog/python/analog/qa_agc.py
@@ -529,6 +529,22 @@ class test_agc(gr_unittest.TestCase):
             self.assertAlmostEqual(x, ref, None,
                                    f"failed at pos {idx} (stride = {stride})", 0.1)
 
+    def test_006_005_agc3_max_gain(self):
+        max_gain = 65536.0
+        input_data = [0j] * 16 + [3.5e-24 + 0j] + [1e-3 + 0j] * 500
+
+        src = blocks.vector_source_c(input_data)
+        agc = analog.agc3_cc(1e-1, 1e-2, 1.0, 1.0, 1, max_gain)
+        dst = blocks.vector_sink_c()
+
+        self.tb.connect(src, agc, dst)
+        self.tb.run()
+
+        self.assertLessEqual(agc.gain(), max_gain)
+
+        max_output = max(abs(x) for x in dst.data())
+        self.assertLessEqual(max_output, max_gain * 1e-3)
+
     def test_007_agc3_constructor_arguments(self):
         attack_rate = 1.1e-3
         decay_rate = 1.2e-4


### PR DESCRIPTION
## What

Clamp the `agc3_cc` IIR gain update to `max_gain`.

Without this clamp, a very small but normal input magnitude can cause the IIR update to increase `d_gain` far beyond the configured maximum gain.

## Testing

Added a regression test reproducing the issue reported in #8175.

The test uses a `3.5e-24` transient followed by `1e-3` samples and verifies that the AGC gain and output remain bounded by `max_gain`.

The regression test fails without the fix and passes with the fix.

`qa_agc`: 17 tests passed.

Fixes #8175