### PR TITLE
fec: make cc_decoder streaming lookahead configurable

### DIFF
--- a/gr-fec/grc/variable_cc_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_decoder_def_list.block.yml
@@ -56,23 +56,32 @@ parameters:
     label: Byte Padding
     dtype: bool
     default: 'False'
+-   id: lookahead
+    label: Streaming Lookahead
+    dtype: int
+    default: '6'
 value: ${ fec.cc_decoder.make(framebits, k, rate, polys, state_start, state_end, mode,
-    padding) }
+    padding, lookahead) }
+
+asserts:
+- ${ lookahead >= k - 1 }
 
 templates:
     imports: from gnuradio import fec
     var_make: |-
         % if int(ndim)==0:
         self.${id} = ${id} = fec.cc_decoder.make(${framebits},\
-        ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding})\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding},\
+        ${lookahead})\
         % elif int(ndim)==1:
         self.${id} = ${id} = list(map( (lambda a: fec.cc_decoder.make(${framebits},\
-        ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding})),\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding},\
+        ${lookahead})),\
         range(0,${dim1})))
         % else:
         self.${id} = ${id} = list(map( (lambda b: list(map(\
         ( lambda a: fec.cc_decoder.make(${framebits}, ${k}, ${rate}, ${polys}, ${state_start},\
-        ${state_end}, ${mode}, ${padding})), range(0,${dim2}) ) ) ), range(0,${dim1})))\
+        ${state_end}, ${mode}, ${padding}, ${lookahead})), range(0,${dim2}) ) ) ), range(0,${dim1})))\
         % endif
 
 documentation: ""

--- a/gr-fec/include/gnuradio/fec/cc_decoder.h
+++ b/gr-fec/include/gnuradio/fec/cc_decoder.h
@@ -64,7 +64,7 @@ typedef void (*conv_kernel)(unsigned char* Y,
  * samples into the encoder, and the output stream is
  * continually encoded. This mode is the only mode for this
  * decoder that has a history requirement because it requires
- * rate*(K-1) bits more to finish the decoding properly. This
+ * rate*lookahead bits more to finish the decoding properly. This
  * mode does not work with any deployments that do not allow
  * history.
  *
@@ -104,6 +104,14 @@ public:
      * \param mode cc_mode_t mode of the encoding.
      * \param padded true if the encoded frame is padded
      *               to the nearest byte.
+     * \param lookahead Only used in CC_STREAMING mode. Number of bits
+     *        of trellis the decoder runs past each frame boundary
+     *        before committing to a decision, giving the survivor
+     *        paths that much distance to converge. Low values will
+     *        result in elevated error rates near the start and end
+     *        of each frame. A lookahead of roughly 5 * k (35 for
+     *        the default k = 7) yields good performance. Larger values
+     *        yield diminishing returns. Must be at least k - 1.
      */
     static generic_decoder::sptr make(int frame_size,
                                       int k,
@@ -112,7 +120,8 @@ public:
                                       int start_state = 0,
                                       int end_state = -1,
                                       cc_mode_t mode = CC_STREAMING,
-                                      bool padded = false);
+                                      bool padded = false,
+                                      unsigned int lookahead = 6);
 
     /*!
      * Sets the uncoded frame size to \p frame_size. If \p

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -32,10 +32,11 @@ generic_decoder::sptr cc_decoder::make(int frame_size,
                                        int start_state,
                                        int end_state,
                                        cc_mode_t mode,
-                                       bool padded)
+                                       bool padded,
+                                       unsigned int lookahead)
 {
     return generic_decoder::sptr(new cc_decoder_impl(
-        frame_size, k, rate, polys, start_state, end_state, mode, padded));
+        frame_size, k, rate, polys, start_state, end_state, mode, padded, lookahead));
 }
 
 cc_decoder_impl::cc_decoder_impl(int frame_size,
@@ -45,7 +46,8 @@ cc_decoder_impl::cc_decoder_impl(int frame_size,
                                  int start_state,
                                  int end_state,
                                  cc_mode_t mode,
-                                 bool padded)
+                                 bool padded,
+                                 unsigned int lookahead)
     : generic_decoder("cc_decoder"),
       d_parity_table(initial_parity_table()),
       d_max_frame_size(frame_size),
@@ -62,12 +64,17 @@ cc_decoder_impl::cc_decoder_impl(int frame_size,
               : 0),
       d_start_state_chaining(start_state),
       d_start_state_nonchaining(start_state),
-      d_end_state_nonchaining(end_state)
+      d_end_state_nonchaining(end_state),
+      d_lookahead(lookahead)
 {
     if (k != 7 || rate != 2) {
         // used to throw std::runtime_error("cc_decoder: parameters not supported");
         throw std::invalid_argument(
             "cc_decoder: Only k=7, rate=2 convolutional codes are supported");
+    }
+
+    if (mode == CC_STREAMING && lookahead < s_k - 1) {
+        throw std::invalid_argument("cc_decoder: lookahead must be at least k - 1");
     }
 
     switch (d_mode) {
@@ -89,7 +96,7 @@ cc_decoder_impl::cc_decoder_impl(int frame_size,
         break;
 
     case (CC_STREAMING):
-        d_veclen = d_frame_size + s_k - 1;
+        d_veclen = d_frame_size + d_lookahead;
         d_end_state = &d_end_state_chaining;
         break;
 
@@ -128,7 +135,7 @@ int cc_decoder_impl::get_input_item_size() { return 1; }
 int cc_decoder_impl::get_history()
 {
     if (d_mode == CC_STREAMING) {
-        return s_rate * (s_k - 1);
+        return s_rate * d_lookahead;
     } else {
         return 0;
     }
@@ -304,6 +311,23 @@ int cc_decoder_impl::chainback_viterbi(unsigned char* data,
     return retval >> s_ADDSHIFT;
 }
 
+unsigned int cc_decoder_impl::skip_viterbi(unsigned int endstate, unsigned int nskip)
+{
+    unsigned char* d = d_vp.decisions.data();
+    endstate = (endstate % s_numstates) << s_ADDSHIFT;
+    decision_t dec;
+
+    for (unsigned int i = d_veclen; nskip-- > 0;) {
+        --i;
+        dec.t = &d[i * s_decision_t_size];
+        int k =
+            (dec.w[(endstate >> s_ADDSHIFT) / 32] >> ((endstate >> s_ADDSHIFT) % 32)) & 1;
+        endstate = (endstate >> 1) | (k << (s_k - 2 + s_ADDSHIFT));
+    }
+
+    return endstate >> s_ADDSHIFT;
+}
+
 bool cc_decoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
@@ -331,7 +355,7 @@ bool cc_decoder_impl::set_frame_size(unsigned int frame_size)
         break;
 
     case (CC_STREAMING):
-        d_veclen = d_frame_size + s_k - 1;
+        d_veclen = d_frame_size + d_lookahead;
         break;
 
     case (CC_TERMINATED):
@@ -380,7 +404,21 @@ void cc_decoder_impl::generic_work(const void* inbuffer, void* outbuffer)
         init_viterbi(&d_vp, *d_start_state);
         break;
 
-    case (CC_STREAMING):
+    case (CC_STREAMING): {
+        update_viterbi_blk((const unsigned char*)(&in[0]), d_veclen);
+        d_end_state_chaining = find_endstate();
+        // Burn off the lookahead margin beyond the k - 1 bits chainback_viterbi
+        // itself needs, so it always reads the same decisions relative to the
+        // frame boundary regardless of d_lookahead.
+        unsigned int endstate =
+            skip_viterbi(*d_end_state, d_veclen - d_frame_size - (s_k - 1));
+        d_start_state_chaining =
+            chainback_viterbi(&out[0], d_frame_size, endstate, s_k - 1);
+
+        init_viterbi(&d_vp, *d_start_state);
+        break;
+    }
+
     case (CC_TERMINATED):
         update_viterbi_blk((const unsigned char*)(&in[0]), d_veclen);
         d_end_state_chaining = find_endstate();

--- a/gr-fec/lib/cc_decoder_impl.h
+++ b/gr-fec/lib/cc_decoder_impl.h
@@ -52,6 +52,11 @@ private:
                           unsigned int nbits,
                           unsigned int endstate,
                           unsigned int tailsize);
+    /* Walks the decision history back nskip steps from the end of the
+     * current trellis (d_veclen), without emitting any bits, and returns
+     * the state reached.
+     */
+    unsigned int skip_viterbi(unsigned int endstate, unsigned int nskip);
     int find_endstate();
 
     /* Originally a volk::vector of length
@@ -79,6 +84,7 @@ private:
     int d_end_state_chaining;
     int d_end_state_nonchaining;
     unsigned int d_veclen;
+    unsigned int d_lookahead;
 
     int parity(int x);
 
@@ -90,7 +96,8 @@ public:
                     int start_state = 0,
                     int end_state = -1,
                     cc_mode_t mode = CC_STREAMING,
-                    bool padded = false);
+                    bool padded = false,
+                    unsigned int lookahead = s_k - 1);
     ~cc_decoder_impl() override;
 
     // Disable copy because of the raw pointers.

--- a/gr-fec/python/fec/bindings/cc_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/cc_decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(cc_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d047cf6f0d6e65a23b03f1e03ee09b0d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f44571e45f8df90090e88394be495f0a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -50,6 +50,7 @@ void bind_cc_decoder(py::module& m)
                     py::arg("end_state") = -1,
                     py::arg("mode") = ::_cc_mode_t::CC_STREAMING,
                     py::arg("padded") = false,
+                    py::arg("lookahead") = 6,
                     D(code, cc_decoder, make))
 
 

--- a/gr-fec/python/fec/qa_cc_decoder_streaming_lookahead.py
+++ b/gr-fec/python/fec/qa_cc_decoder_streaming_lookahead.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Brett Gottula
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+import numpy as np
+
+from gnuradio import gr, gr_unittest
+from gnuradio import fec
+from gnuradio import blocks, analog, digital
+
+from _qa_helper import _qa_helper
+
+FRAME_SIZE = 128
+K = 7
+RATE = 2
+POLYS = [109, 79]
+
+
+class test_cc_decoder_streaming_lookahead(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_default_lookahead_unchanged(self):
+        # Decoding with the default (minimum) lookahead must be bit-exact
+        # on a noiseless channel.
+        frame_size = 30
+        enc = fec.cc_encoder_make(frame_size * 8, K, RATE, POLYS)
+        dec = fec.cc_decoder.make(frame_size * 8, K, RATE, POLYS)
+        self.test = _qa_helper(5 * frame_size, enc, dec, None)
+        self.tb.connect(self.test)
+        self.tb.run()
+
+        data_out = self.test.snk_output.data()
+        data_in = self.test.snk_input.data()[0:len(data_out)]
+        self.assertEqual(data_in, data_out)
+
+    def test_larger_lookahead_still_bit_exact(self):
+        # A non-default lookahead must still decode a noiseless channel
+        # bit-exact; only its behavior under noise should change.
+        frame_size = 30
+        enc = fec.cc_encoder_make(frame_size * 8, K, RATE, POLYS)
+        dec = fec.cc_decoder.make(frame_size * 8, K, RATE, POLYS,
+                                  mode=fec.CC_STREAMING, lookahead=35)
+        self.test = _qa_helper(5 * frame_size, enc, dec, None)
+        self.tb.connect(self.test)
+        self.tb.run()
+
+        data_out = self.test.snk_output.data()
+        data_in = self.test.snk_input.data()[0:len(data_out)]
+        self.assertEqual(data_in, data_out)
+
+    def test_lookahead_below_minimum_rejected(self):
+        with self.assertRaises(ValueError):
+            fec.cc_decoder.make(FRAME_SIZE, K, RATE, POLYS,
+                                mode=fec.CC_STREAMING, lookahead=K - 2)
+
+    def test_lookahead_narrows_frame_edge_ber(self):
+        # At the minimum lookahead (k - 1), a CC_STREAMING decoder commits to
+        # the bits nearest each frame boundary before the Viterbi survivor
+        # paths have had a chance to converge, so those bits carry an
+        # elevated error rate. A larger lookahead gives the survivor paths
+        # more distance to converge before a decision is committed. Both
+        # lookaheads decode the same noise realization here (same seed), so
+        # a larger lookahead must produce markedly fewer edge errors on it.
+        edge_errs_min_lookahead = self._edge_error_count(lookahead=K - 1)
+        edge_errs_large_lookahead = self._edge_error_count(lookahead=35)
+
+        # Sanity check that this operating point actually produces edge
+        # errors worth comparing.
+        self.assertGreater(edge_errs_min_lookahead, 20)
+        self.assertLess(edge_errs_large_lookahead, edge_errs_min_lookahead / 2)
+
+    def _edge_error_count(self, lookahead, num_frames=4000, esno_db=0.0,
+                          seed=42, edge_width=15):
+        # Encode/decode num_frames random frames over an AWGN channel at the
+        # given Es/No and return the number of bit errors in the first/last
+        # edge_width bits of each frame.
+        enc = fec.cc_encoder_make(FRAME_SIZE, K, RATE, POLYS, mode=fec.CC_STREAMING)
+        dec = fec.cc_decoder.make(FRAME_SIZE, K, RATE, POLYS,
+                                  mode=fec.CC_STREAMING, lookahead=lookahead)
+
+        tb = gr.top_block()
+        rng = np.random.default_rng(1234)
+        bits = rng.integers(0, 2, size=FRAME_SIZE * num_frames, dtype=np.uint8)
+
+        src = blocks.vector_source_b(bits.tolist(), False)
+        encoder = fec.extended_encoder(enc, threading=None, puncpat='11')
+        mapper = digital.map_bb([-1, 1])
+        b2f = blocks.char_to_float(1)
+        noise_amp = (10.0 ** (-esno_db / 10.0) / 2.0) ** 0.5
+        noise = analog.noise_source_f(analog.GR_GAUSSIAN, noise_amp, seed)
+        add = blocks.add_ff(1)
+        decoder = fec.extended_decoder(dec, threading=None, ann=None, puncpat='11',
+                                       integration_period=10000)
+        snk_in = blocks.vector_sink_b()
+        snk_out = blocks.vector_sink_b()
+
+        tb.connect(src, snk_in)
+        tb.connect(src, encoder, mapper, b2f, (add, 0))
+        tb.connect(noise, (add, 1))
+        tb.connect(add, decoder, snk_out)
+        tb.run()
+
+        din = np.array(snk_in.data(), dtype=np.uint8)
+        dout = np.array(snk_out.data(), dtype=np.uint8)
+        n = min(len(din), len(dout))
+        n -= n % FRAME_SIZE
+        din = din[:n].reshape(-1, FRAME_SIZE)
+        dout = dout[:n].reshape(-1, FRAME_SIZE)
+        errs_by_position = (din != dout).sum(axis=0)
+        return int(errs_by_position[:edge_width].sum() + errs_by_position[-edge_width:].sum())
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_cc_decoder_streaming_lookahead)


### PR DESCRIPTION
## Description

`cc_decoder` in `CC_STREAMING` mode has elevated error rates at the beginning and end of each processed frame.

### Root Cause

The block always runs exactly `k - 1` bits of trellis past each frame boundary before committing to a decision. That is the right depth to flush a terminated code, but far short of the `~5 * k` bits a streaming decoder needs for its Viterbi survivor paths to actually converge. The result is an elevated bit error rate in a fixed-width band at each frame boundary. The impact of this on the overall mean error rate depends on the frame size, with shorter frames being more strongly affected since bits at the frame boundaries are a larger fraction of the total.

In this plot of error rate versus bit position the ideal shape is flat near the dotted line.

<img width="1934" height="814" alt="bathtub-before-after" src="https://github.com/user-attachments/assets/bd018a98-290e-4342-9428-38b0d7a45451" />

### Fix

This PR adds an opt-in lookahead parameter to cc_decoder so the lookahead can be increased in `CC_STREAMING` mode, defaulting to `k - 1` so existing usage is unaffected.

If there's tolerance for changing behavior `5 * k` would be a more useful default since it results in performance closer to optimum.

## Declaration of Willingness To Own

- [x] I have tried the code change I'm proposing; it not only builds, but also **verifiably fulfills the purpose**.

## Related Issue

No known existing issues or discussion that I could find.

## Which blocks/areas does this affect?

`gr::fec::code::cc_decoder`

## Testing Done

- Before/after comparison of error rate vs bit position as illustrated in the plot image above
- Measured error rate curves compared to reference "ideal" curves
- Unit tests included

## Checklist

- [x] I am proposing a change I understand and have tested to be effective.
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed-off my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.  **Not done, but happy to do so if this change is accepted**
- [x] I have added tests to cover my changes, and all previous tests pass.
