### PR TITLE
grc: drop sort_objects2, unreachable and not safe to reach

### DIFF
--- a/grc/core/utils/expr_utils.py
+++ b/grc/core/utils/expr_utils.py
@@ -7,7 +7,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 """
 
 
-import ast
 import string
 
 
@@ -63,33 +62,6 @@ def sort_objects(objects, get_id, get_expr) -> list:
     sorted_ids = _sort_variables(id2expr)
     # Return list of sorted objects
     return [id2obj[id] for id in sorted_ids]
-
-
-def dependencies(expr, names=None):
-    node = ast.parse(expr, mode='eval')
-    used_ids = frozenset(
-        [n.id for n in ast.walk(node) if isinstance(n, ast.Name)])
-    return used_ids & names if names else used_ids
-
-
-def sort_objects2(objects, id_getter, expr_getter, check_circular=True):
-    known_ids = {id_getter(obj) for obj in objects}
-
-    def dependent_ids(obj):
-        deps = dependencies(expr_getter(obj))
-        return [id_ if id_ in deps else '' for id_ in known_ids]
-
-    objects = sorted(objects, key=dependent_ids)
-
-    if check_circular:  # walk var defines step by step
-        defined_ids = set()  # variables defined so far
-        for obj in objects:
-            deps = dependencies(expr_getter(obj), known_ids)
-            if not defined_ids.issuperset(deps):  # can't have an undefined dep
-                raise RuntimeError(obj, deps, defined_ids)
-            defined_ids.add(id_getter(obj))  # define this one
-
-    return objects
 
 
 VAR_CHARS = string.ascii_letters + string.digits + '_'

--- a/grc/tests/test_expr_utils.py
+++ b/grc/tests/test_expr_utils.py
@@ -1,4 +1,7 @@
 import operator
+import os
+import subprocess
+import sys
 
 import pytest
 
@@ -6,6 +9,9 @@ from grc.core.utils import expr_utils
 
 id_getter = operator.itemgetter(0)
 expr_getter = operator.itemgetter(1)
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..'))
 
 
 def test_simple():
@@ -38,3 +44,52 @@ def test_circular():
     # Should fail due to circular dependency
     with pytest.raises(Exception):
         expr_utils.sort_objects(test, id_getter, expr_getter)
+
+
+def test_a_variable_never_precedes_what_it_depends_on():
+    objects = [
+        ['d', 'b + c'],
+        ['b', 'a + 1'],
+        ['c', 'a + 2'],
+        ['a', '1'],
+    ]
+
+    order = [o[0] for o in
+             expr_utils.sort_objects(objects, id_getter, expr_getter)]
+
+    assert order.index('a') < order.index('b')
+    assert order.index('a') < order.index('c')
+    assert order.index('b') < order.index('d')
+    assert order.index('c') < order.index('d')
+
+
+CHILD = """\
+import operator, sys
+sys.path.insert(0, %r)
+from grc.core.utils import expr_utils
+objs = [['a', '1'], ['b', 'a + 1'], ['c', 'a + 2'], ['d', 'b + c']]
+out = expr_utils.sort_objects(objs, operator.itemgetter(0), operator.itemgetter(1))
+print('ORDER=' + ','.join(o[0] for o in out))
+"""
+
+
+def test_order_does_not_depend_on_the_hash_seed():
+    """The order has to be a property of the flowgraph, not of the run.
+
+    An ordering keyed on set iteration would vary here: str hashing is salted
+    per interpreter (PEP 456), so the iteration order of a set of variable
+    names moves between processes. Each seed gets its own interpreter, because
+    one process only ever sees one salt.
+    """
+    orders = set()
+    for seed in ('0', '1', '2', '3', 'random', 'random'):
+        env = dict(os.environ, PYTHONHASHSEED=seed)
+        proc = subprocess.run([sys.executable, '-c', CHILD % REPO_ROOT],
+                              capture_output=True, text=True, env=env)
+        assert proc.returncode == 0, proc.stderr
+        tagged = [ln for ln in proc.stdout.splitlines()
+                  if ln.startswith('ORDER=')]
+        assert len(tagged) == 1, proc.stdout
+        orders.add(tagged[0])
+
+    assert len(orders) == 1, 'order changed between interpreters: %s' % orders


### PR DESCRIPTION
`expr_utils.sort_objects2` has had no caller since it arrived in `7f7fa2f91` ("grc: added yaml/mako support", 3 May 2016).

Parsing all 759 Python files in the tree for real references — imports, and `expr_utils.<name>` attribute access — it is the only name in the module nothing reaches. A text search would not do: `dependencies` is an ordinary English word and turns up in `CHANGELOG.md` and half the CMake files. `dependencies()` is called twice, both times from inside `sort_objects2`, so it goes too.

## It is also not a function anyone should start calling

It keys the sort on a set:

```python
known_ids = {id_getter(obj) for obj in objects}

def dependent_ids(obj):
    deps = dependencies(expr_getter(obj))
    return [id_ if id_ in deps else '' for id_ in known_ids]

objects = sorted(objects, key=dependent_ids)
```

The key is a list whose element *positions* come from iterating that set. `str` hashing is salted per interpreter (PEP 456), so the positions — and the comparison between two keys — move between processes.

Four variables, `a=1`, `b=a+1`, `c=a+2`, `d=b+c`, sorted in fresh interpreters:

```
PYTHONHASHSEED=0     a,b,c,d
PYTHONHASHSEED=1     a,d,b,c   <- d before b and c, which it needs
PYTHONHASHSEED=2     a,b,c,d
PYTHONHASHSEED=3     a,b,c,d
```

Ten runs: eight `a,b,c,d` and two `a,d,b,c`.

With its `check_circular` default left on, the bad order is caught and turned into `RuntimeError(obj, deps, defined_ids)` — on a graph with no cycle in it. Same input, same code, eight seeds: two raise, six do not.

`sort_objects`, which the tree does call (`FlowGraph.py`, `FlowGraphProxy.py`, `workflows/common.py`), does not share this. It orders through `_sort_variables`, which sorts each independent set explicitly. Same input, ten interpreters, one order every time.

`import ast` goes with them; nothing else in the module used it. After the removal every remaining name is still reached by something, checked with the same parser.

## Tests

Two are added to `grc/tests/test_expr_utils.py`:

- **the order does not depend on the hash seed** — six subprocesses, because one process only ever sees one salt. Pointed at the removed function it fails, which is how the figures above were measured.
- **a variable never precedes what it depends on** — written as four index comparisons rather than one expected list, so it does not pin an ordering the module is free to change.

`grc/tests`: **40 passed**, Python 3.14, pytest, no build.

## What I did not run

**I have not built GNU Radio.** Saying so plainly, since CONTRIBUTING asks for it: the five suites that need a built `gnuradio` module (`test_compiler`, `test_cpp`, `test_examples`, `test_generator`, `test_qtbot`) were not run here and are untouched. For this change the `grc/` suite is the code under test — both removed functions are pure Python in `grc/core/utils` and have **no callers at all**, which is the point of the change, so no test path reaches them either way.

If you would rather see this from a full build before merging, say so and I will hold it.

---

*Developed with AI assistance; I have reviewed and understand all changes, and personally ran every measurement quoted above.*